### PR TITLE
Implement <kbd> widget

### DIFF
--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -445,7 +445,13 @@ export const TERMINAL_ELEMENT_DEFAULTS: Record<
 	em: {display: "inline", "font-style": "italic"},
 	strong: {display: "inline", "font-weight": "bold"},
 	code: {display: "inline", "background-color": "rgba(0, 0, 0, 0.1)"},
-	kbd: {display: "inline"},
+	// A key is a keycap: bold text inside brackets, "[q]", the form every
+	// terminal help screen and man page uses for a key to press. A browser
+	// draws the cap with a border and a monospace face; a terminal is already
+	// monospace and cannot afford a box around one glyph, so the brackets are
+	// the cap. They are UA ::before/::after rules in the UA document
+	// stylesheet, so author content rules replace them.
+	kbd: {display: "inline", "font-weight": "bold"},
 	samp: {display: "inline"},
 	var: {display: "inline", "font-style": "italic"},
 	b: {display: "inline", "font-weight": "bold"},
@@ -766,6 +772,8 @@ export const UA_DOCUMENT_STYLES = `
 	*::selection { background-color: Highlight; color: HighlightText; }
 	button::before { content: "[ "; }
 	button::after { content: " ]"; }
+	kbd::before { content: "["; }
+	kbd::after { content: "]"; }
 	a[href] { text-decoration: underline; }
 	datalist { display: none; }
 	dialog:not([open]) { display: none; }

--- a/tests/widgets.test.ts
+++ b/tests/widgets.test.ts
@@ -135,6 +135,46 @@ test("Enter on a focused summary toggles the disclosure", async () => {
 	dom.dispose();
 });
 
+/* ------------------------------------------------------------ the keycap */
+
+/** The cell at a screen position, for reading its attributes. */
+function cellAt(terminal: MockProcess, row: number, col: number): any {
+	return (terminal as any).terminal.buffer.active.getLine(row).getCell(col);
+}
+
+test("a kbd wears brackets and bold", async () => {
+	const terminal = new MockProcess({rows: 4, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = `<kbd>x</kbd>`;
+	await nextFrame(dom);
+
+	expect(terminal.getPlainText()).toContain("[x]");
+	// The brackets are generated content of the kbd, so they carry its weight.
+	expect(cellAt(terminal, 0, 0).isBold()).toBeTruthy();
+	expect(cellAt(terminal, 0, 1).isBold()).toBeTruthy();
+	expect(cellAt(terminal, 0, 2).isBold()).toBeTruthy();
+
+	dom.dispose();
+});
+
+test("author rules replace the keycap's brackets and weight", async () => {
+	const terminal = new MockProcess({rows: 4, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML =
+		`<style>` +
+		`kbd { font-weight: normal; }` +
+		`kbd::before { content: "<"; }` +
+		`kbd::after { content: ">"; }` +
+		`</style>` +
+		`<kbd>x</kbd>`;
+	await nextFrame(dom);
+
+	expect(terminal.getPlainText()).toContain("<x>");
+	expect(cellAt(terminal, 0, 1).isBold()).toBeFalsy();
+
+	dom.dispose();
+});
+
 /* ---------------------------------------------------------- the gauges */
 
 /** The row a gauge drew, trimmed of the screen's padding. */


### PR DESCRIPTION
Adds UA default styling for `<kbd>`: bold text wrapped in square brackets, so `<kbd>q</kbd>` renders as `[q]`.

Implementation:

- `font-weight: bold` in the element defaults (`useragent.ts`, next to `strong`/`b`).
- `kbd::before { content: "[" }` and `kbd::after { content: "]" }` in the UA document stylesheet, the same mechanism as `button`'s brackets.

The generated bracket cells inherit the element's font-weight. Author rules override both the weight and the bracket content through normal specificity.

Tests: two cases in `tests/widgets.test.ts` — default rendering (`[x]`, bold cells), and author overrides (custom `::before`/`::after` content plus `font-weight: normal`). Full suite passes: node 1126, bun 1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
