### PR TITLE
Implement beforeunload event.

### DIFF
--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -828,6 +828,51 @@ Object.defineProperty(CustomEvent.prototype, Symbol.toStringTag, {
 	configurable: true,
 });
 
+/**
+ * The event fired before a document is unloaded, which a listener cancels to
+ * keep it.
+ *
+ * The interface declares no constructor: every instance is one the engine
+ * fired, so an author's `new` throws as it does in a browser, and
+ * createEvent("BeforeUnloadEvent") throws too -- the name is not in the
+ * legacy interface table.
+ *
+ * Cancellation has two spellings, both of which the teardown honors:
+ * preventDefault(), and a returnValue set to anything but the empty string.
+ */
+export class BeforeUnloadEvent extends Event {
+	#returnValue = "";
+
+	constructor() {
+		super("beforeunload", {cancelable: true});
+		if (!internalConstruction) throw new TypeError("Illegal constructor");
+	}
+
+	/**
+	 * The legacy message a browser would have shown, which shadows Event's
+	 * boolean returnValue with a DOMString. Its type is `any` because a
+	 * narrower one is not assignable over the boolean it shadows -- the same
+	 * resolution the platform's own type definitions reach.
+	 */
+	override get returnValue(): any {
+		return this.#returnValue;
+	}
+
+	override set returnValue(value: any) {
+		this.#returnValue = String(value);
+	}
+}
+
+Object.defineProperty(BeforeUnloadEvent.prototype, Symbol.toStringTag, {
+	value: "BeforeUnloadEvent",
+	configurable: true,
+});
+
+/** A beforeunload event, which only a teardown about to happen fires. */
+export function createBeforeUnloadEvent(): BeforeUnloadEvent {
+	return constructInternal(() => new BeforeUnloadEvent());
+}
+
 /* ------------------------------------------------------------- UI events */
 
 export interface UIEventInit extends EventInit {

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -321,6 +321,7 @@ export interface EngineWindow extends EventTarget {
 	FocusEvent: typeof globalThis.FocusEvent;
 	InputEvent: typeof globalThis.InputEvent;
 	CompositionEvent: typeof globalThis.CompositionEvent;
+	BeforeUnloadEvent: typeof globalThis.BeforeUnloadEvent;
 	DOMException: typeof globalThis.DOMException;
 	Node: typeof globalThis.Node;
 	Element: typeof globalThis.Element;
@@ -954,6 +955,19 @@ export class TermDOM {
 		// browser tab: dispose, then close the transport. Ctrl-C's default
 		// action is this call.
 		window.close = () => {
+			// beforeunload is the door out, and a listener that cancels keeps
+			// the session. A browser answers a canceled beforeunload with a
+			// prompt of its own; a terminal has no UA chrome to prompt with,
+			// so cancellation just stops the teardown, leaving the app to ask
+			// "are you sure?" however it likes and to close again once the
+			// user says yes. Every close asks: the event carries nothing from
+			// the last one.
+			const unloadEvent = DOM.createBeforeUnloadEvent();
+			(window as unknown as DOM.EventTarget).dispatchEvent(unloadEvent);
+			if (unloadEvent.defaultPrevented || unloadEvent.returnValue !== "") {
+				return;
+			}
+
 			const wasAttached = termDOM.#attached;
 			// An immediate close must not tear down mid-establishment: wait
 			// for attach to finish (anchor found, first frame painted) so the

--- a/tests/attach.test.ts
+++ b/tests/attach.test.ts
@@ -212,3 +212,152 @@ test("window.close() before the first frame leaves prior screen content alone", 
 	expect(text).toContain("PROMPT-LINE");
 	expect(text).toContain("closing content");
 });
+
+/**
+ * A transport that counts the closes it is asked for, which is how a teardown
+ * that ran and one a beforeunload listener stopped tell apart.
+ */
+function closeCountingTransport(terminal: MockProcess): {
+	transport: any;
+	closes(): number;
+} {
+	const base = terminal.transport;
+	let closes = 0;
+	return {
+		transport: {
+			...base,
+			cols: base.cols,
+			rows: base.rows,
+			close: () => {
+				closes++;
+			},
+		},
+		closes: () => closes,
+	};
+}
+
+test("window.close() fires beforeunload, then tears down", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 10});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	dom.document.body.innerHTML = `<div>still here</div>`;
+	await nextFrame(dom);
+
+	const events: any[] = [];
+	dom.window.addEventListener("beforeunload", (event) => events.push(event));
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 150));
+
+	expect(events.length).toBe(1);
+	expect(events[0].type).toBe("beforeunload");
+	expect(events[0].cancelable).toBe(true);
+	expect(events[0].returnValue).toBe("");
+	expect(watched.closes()).toBe(1);
+});
+
+test("a beforeunload listener that preventDefaults keeps the session", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 10});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	dom.document.body.innerHTML = `<div>unsaved work</div>`;
+	await nextFrame(dom);
+
+	let asked = 0;
+	const listener = (event: any) => {
+		asked++;
+		event.preventDefault();
+	};
+	dom.window.addEventListener("beforeunload", listener);
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 150));
+
+	expect(asked).toBe(1);
+	expect(watched.closes()).toBe(0);
+	// The session is still live: a mutation after the canceled close paints.
+	dom.document.body.innerHTML = `<div>saved now</div>`;
+	await nextFrame(dom);
+	expect(terminal.getVisibleText()).toContain("saved now");
+
+	// Closing again asks again -- the app's own dialog said yes this time.
+	dom.window.removeEventListener("beforeunload", listener);
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 150));
+	expect(watched.closes()).toBe(1);
+});
+
+test("a beforeunload returnValue keeps the session", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 10});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	dom.document.body.innerHTML = `<div>unsaved work</div>`;
+	await nextFrame(dom);
+
+	dom.window.addEventListener("beforeunload", (event: any) => {
+		event.returnValue = "Are you sure?";
+	});
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 150));
+
+	expect(watched.closes()).toBe(0);
+	await dom.dispose();
+});
+
+test("Ctrl-C fires beforeunload, and a listener can keep the session", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 10});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	dom.document.body.innerHTML = `<div>unsaved work</div>`;
+	await nextFrame(dom);
+
+	let asked = 0;
+	const listener = (event: any) => {
+		asked++;
+		event.preventDefault();
+	};
+	dom.window.addEventListener("beforeunload", listener);
+	(terminal.stdin as any).emit("data", Buffer.from("\x03"));
+	await new Promise((r) => setTimeout(r, 150));
+
+	expect(asked).toBe(1);
+	expect(watched.closes()).toBe(0);
+
+	dom.window.removeEventListener("beforeunload", listener);
+	(terminal.stdin as any).emit("data", Buffer.from("\x03"));
+	await new Promise((r) => setTimeout(r, 150));
+	expect(watched.closes()).toBe(1);
+});
+
+test("BeforeUnloadEvent is the interface a browser exposes", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 10});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	await nextFrame(dom);
+
+	// The interface declares no constructor: only a teardown makes one.
+	expect(() => new (dom.window as any).BeforeUnloadEvent()).toThrow(TypeError);
+
+	let fired: any = null;
+	dom.window.addEventListener("beforeunload", (event: any) => {
+		fired = event;
+		// returnValue is a DOMString, so anything set to it stringifies -- and
+		// anything but the empty string cancels.
+		event.returnValue = 42;
+	});
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 150));
+
+	expect(fired).not.toBe(null);
+	expect(fired instanceof dom.window.Event).toBe(true);
+	expect(Object.prototype.toString.call(fired)).toBe(
+		"[object BeforeUnloadEvent]",
+	);
+	expect(fired.returnValue).toBe("42");
+	expect(fired.defaultPrevented).toBe(false);
+	expect(watched.closes()).toBe(0);
+	await dom.dispose();
+});


### PR DESCRIPTION
Implements the `beforeunload` event. `window.close()` — including the Ctrl-C default, whose default action is that call — dispatches `beforeunload` on `window` before teardown. Canceling the event cancels the close; the app can show its own confirmation and call `window.close()` again. Each close dispatches a fresh event.

`BeforeUnloadEvent`:

- No usable constructor: `new BeforeUnloadEvent()` throws "Illegal constructor", and `createEvent("BeforeUnloadEvent")` is absent from the legacy interface table, both matching browsers.
- `returnValue` is a DOMString shadowing `Event`'s legacy boolean. Initial value `""`; the setter applies IDL `String()` coercion. A non-empty `returnValue` cancels, as does `preventDefault()`.
- Exposed on `window` with the other event interfaces.

Not included: process signals (SIGTERM/SIGHUP must remain kills; Ctrl-C never arrives as a signal in raw mode) and `unload`/`pagehide`.

Tests: five cases in `tests/attach.test.ts` — dispatch then teardown, cancel via `preventDefault` (including that a later close proceeds), cancel via `returnValue`, the Ctrl-C path, and the interface contract. Full suite passes after rebase onto current main: node 1129, bun 1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
