### PR TITLE
Implement border-radius

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,10 +7,10 @@ properties. Every row is a probe -- the feature applied to a real
 document and rendered, with the row recording whether the output
 changed.
 
-157 features supported, 61 probed and unsupported,
+162 features supported, 61 probed and unsupported,
 156 CSS properties not applicable to a character grid,
 129 applicable and not implemented,
-9 not yet probed.
+4 not yet probed.
 
 ## DOM APIs
 
@@ -117,6 +117,11 @@ changed.
 | `border-right` | yes |
 | `border-bottom` | yes |
 | `border-left` | yes |
+| `border-radius` | yes |
+| `border-top-left-radius` | yes |
+| `border-top-right-radius` | yes |
+| `border-bottom-right-radius` | yes |
+| `border-bottom-left-radius` | yes |
 | `box-sizing` | no (no effect) |
 | `outline` | yes |
 | `outline-style` | yes |
@@ -314,4 +319,4 @@ not act on them.
 
 No probe covers these and they are unclassified.
 
-`border-bottom-left-radius`, `border-bottom-right-radius`, `border-end-end-radius`, `border-end-start-radius`, `border-radius`, `border-start-end-radius`, `border-start-start-radius`, `border-top-left-radius`, `border-top-right-radius`
+`border-end-end-radius`, `border-end-start-radius`, `border-start-end-radius`, `border-start-start-radius`

--- a/scripts/support-matrix.ts
+++ b/scripts/support-matrix.ts
@@ -92,6 +92,23 @@ const FEATURES: Record<string, Feature> = {
 	"border-right": {value: "1px solid red"},
 	"border-bottom": {value: "1px solid red"},
 	"border-left": {value: "1px solid red"},
+	"border-radius": {value: "1ch", setup: "#probe { border: 1px solid; }"},
+	"border-top-left-radius": {
+		value: "1ch",
+		setup: "#probe { border: 1px solid; }",
+	},
+	"border-top-right-radius": {
+		value: "1ch",
+		setup: "#probe { border: 1px solid; }",
+	},
+	"border-bottom-right-radius": {
+		value: "1ch",
+		setup: "#probe { border: 1px solid; }",
+	},
+	"border-bottom-left-radius": {
+		value: "1ch",
+		setup: "#probe { border: 1px solid; }",
+	},
 	"box-sizing": {
 		value: "border-box",
 		setup: "#probe { width: 12ch; padding: 0 2ch; border: 1px solid; }",
@@ -984,6 +1001,11 @@ const CATEGORIES: Array<[string, string[]]> = [
 			"border-right",
 			"border-bottom",
 			"border-left",
+			"border-radius",
+			"border-top-left-radius",
+			"border-top-right-radius",
+			"border-bottom-right-radius",
+			"border-bottom-left-radius",
 			"box-sizing",
 			"outline",
 			"outline-style",

--- a/src/internal/ansi.ts
+++ b/src/internal/ansi.ts
@@ -2,7 +2,12 @@
  * The screen: the cells the terminal is showing, the cells the next frame
  * wants, and the shortest escape sequence between them.
  */
-import {BOX_DRAWING, BorderEdgeStyle} from "./styles.js";
+import {
+	BOX_DRAWING,
+	BorderEdgeStyle,
+	ROUNDED_CORNERS,
+	type BorderStyles,
+} from "./styles.js";
 import {stringWidth} from "./text.js";
 
 /** One shared grapheme segmenter -- construction is expensive. */
@@ -426,6 +431,8 @@ export function getBorderChar(borderEncoding: number): string {
 	].filter((s) => s > 0);
 
 	const dominantStyle = Math.max(...styles);
+	// The radius rides the edges meeting in this cell, so a cell is a rounded
+	// corner exactly when the edges that made it one carry the flag.
 	const hasRounded =
 		(hasTop && getEdgeRounded(topEdge)) ||
 		(hasRight && getEdgeRounded(rightEdge)) ||
@@ -435,7 +442,7 @@ export function getBorderChar(borderEncoding: number): string {
 	let charSet;
 	switch (dominantStyle) {
 		case BorderEdgeStyle.Solid:
-			charSet = hasRounded ? BOX_DRAWING.lightRounded : BOX_DRAWING.light;
+			charSet = BOX_DRAWING.light;
 			break;
 		case BorderEdgeStyle.Double:
 			charSet = BOX_DRAWING.double;
@@ -454,7 +461,7 @@ export function getBorderChar(borderEncoding: number): string {
 			break;
 		case BorderEdgeStyle.Inset:
 		case BorderEdgeStyle.Outset:
-			charSet = hasRounded ? BOX_DRAWING.lightRounded : BOX_DRAWING.light;
+			charSet = BOX_DRAWING.light;
 			break;
 		case BorderEdgeStyle.Hidden:
 		case BorderEdgeStyle.None:
@@ -481,10 +488,23 @@ export function getBorderChar(borderEncoding: number): string {
 		return charSet.leftTee; // ┤
 	}
 
-	if (hasRight && hasBottom) return charSet.topLeft; // ┌
-	if (hasLeft && hasBottom) return charSet.topRight; // ┐
-	if (hasRight && hasTop) return charSet.bottomLeft; // └
-	if (hasLeft && hasTop) return charSet.bottomRight; // ┘
+	// A corner takes its rounded form where one exists. The character set is
+	// still the border style's -- a rounded dashed box keeps its dashes and
+	// bends only the four cells where the strokes turn -- and a style whose
+	// corner has no rounded glyph stays square; see ROUNDED_CORNERS.
+	const corner =
+		hasRight && hasBottom
+			? charSet.topLeft // ┌
+			: hasLeft && hasBottom
+				? charSet.topRight // ┐
+				: hasRight && hasTop
+					? charSet.bottomLeft // └
+					: hasLeft && hasTop
+						? charSet.bottomRight // ┘
+						: null;
+	if (corner !== null) {
+		return hasRounded ? (ROUNDED_CORNERS[corner] ?? corner) : corner;
+	}
 
 	if (hasLeft || hasRight) return charSet.horizontal; // ─
 	if (hasTop || hasBottom) return charSet.vertical; // │
@@ -963,13 +983,7 @@ export class DrawingContext {
 		y: number,
 		width: number,
 		height: number,
-		borderStyles: {
-			topEdge: number;
-			rightEdge: number;
-			bottomEdge: number;
-			leftEdge: number;
-			hasAnyBorder: boolean;
-		},
+		borderStyles: BorderStyles,
 		style?: CellStyle,
 		// Per-edge overrides for differently-colored sides. A corner cell's
 		// glyph spans two edges but holds one color; it takes the horizontal
@@ -988,7 +1002,8 @@ export class DrawingContext {
 		const right = x + width - 1;
 		const bottom = y + height - 1;
 
-		const {topEdge, rightEdge, bottomEdge, leftEdge} = borderStyles;
+		const {topEdge, rightEdge, bottomEdge, leftEdge, roundedCorners} =
+			borderStyles;
 		const hasTop = topEdge > 0;
 		const hasRight = rightEdge > 0;
 		const hasBottom = bottomEdge > 0;
@@ -1024,16 +1039,31 @@ export class DrawingContext {
 			this.#setBorderCell(col, row, encoding, edgeStyle ?? style);
 		};
 
+		// A radius bends one cell -- the corner where two edges turn -- so the
+		// flag rides only the edges written into that cell, and the runs between
+		// corners carry none of it.
+		const round = (edge: number, rounded: boolean) =>
+			edge > 0 && rounded ? edge | BorderEdgeStyle.Rounded : edge;
+
 		// Top edge: a horizontal run that turns down at whichever corners exist.
 		if (hasTop) {
 			for (let col = x; col <= right; col++) {
 				const atLeft = col === x && hasLeft;
 				const atRight = col === right && hasRight;
-				const down = atLeft ? leftEdge : atRight ? rightEdge : 0;
+				const rounded = atLeft
+					? Boolean(roundedCorners?.topLeft)
+					: atRight
+						? Boolean(roundedCorners?.topRight)
+						: false;
+				const across = round(topEdge, rounded);
+				const down = round(
+					atLeft ? leftEdge : atRight ? rightEdge : 0,
+					rounded,
+				);
 				put(
 					col,
 					y,
-					encode(0, atRight ? 0 : topEdge, down, atLeft ? 0 : topEdge),
+					encode(0, atRight ? 0 : across, down, atLeft ? 0 : across),
 					edgeStyles?.top,
 				);
 			}
@@ -1045,11 +1075,17 @@ export class DrawingContext {
 			for (let col = x; col <= right; col++) {
 				const atLeft = col === x && hasLeft;
 				const atRight = col === right && hasRight;
-				const up = atLeft ? leftEdge : atRight ? rightEdge : 0;
+				const rounded = atLeft
+					? Boolean(roundedCorners?.bottomLeft)
+					: atRight
+						? Boolean(roundedCorners?.bottomRight)
+						: false;
+				const across = round(bottomEdge, rounded);
+				const up = round(atLeft ? leftEdge : atRight ? rightEdge : 0, rounded);
 				put(
 					col,
 					bottom,
-					encode(up, atRight ? 0 : bottomEdge, 0, atLeft ? 0 : bottomEdge),
+					encode(up, atRight ? 0 : across, 0, atLeft ? 0 : across),
 					edgeStyles?.bottom,
 				);
 			}

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -280,6 +280,11 @@ const LENGTH_PROPERTIES = new Set([
 	"border-right-width",
 	"border-bottom-width",
 	"border-left-width",
+	"border-radius",
+	"border-top-left-radius",
+	"border-top-right-radius",
+	"border-bottom-right-radius",
+	"border-bottom-left-radius",
 	"font-size",
 	"text-indent",
 	"letter-spacing",
@@ -582,6 +587,23 @@ function computedNumber(token: string): string {
 	return `${number}${unit}`;
 }
 
+/** The corner radii, whose value is a horizontal radius and a vertical one. */
+const RADIUS_LONGHANDS = new Set([
+	"border-top-left-radius",
+	"border-top-right-radius",
+	"border-bottom-right-radius",
+	"border-bottom-left-radius",
+]);
+
+/**
+ * A corner radius with its second component dropped where the two agree: a
+ * circular corner states one radius, an elliptical one states both.
+ */
+function collapseRadius(value: string): string {
+	const parts = value.split(/\s+/).filter(Boolean);
+	return parts.length === 2 && parts[0] === parts[1] ? parts[0] : value;
+}
+
 /**
  * The computed spelling of a declared value: the one place a struct becomes
  * a string, at the getPropertyValue boundary.
@@ -599,7 +621,8 @@ function normalizeValue(property: string, declared: string): string {
 		return serializeColor(value) ?? value;
 	}
 	if (LENGTH_PROPERTIES.has(property)) {
-		return value.split(/\s+/).map(computedNumber).join(" ");
+		const lengths = value.split(/\s+/).map(computedNumber).join(" ");
+		return RADIUS_LONGHANDS.has(property) ? collapseRadius(lengths) : lengths;
 	}
 	return IDENTIFIER_VALUE.test(value) ? value.toLowerCase() : value;
 }
@@ -1100,11 +1123,18 @@ const CORNER_NAMES = [
 
 /**
  * The shape of a shorthand's grammar, and so how its value serializes: a box
- * of four sides or corners collapsed to one to four values, a pair collapsed
- * when both agree, a line's width/style/color, `border`'s three uniform boxes,
- * or a plain sequence of components.
+ * of four sides or corners collapsed to one to four values, a radius box
+ * whose corners each carry two values, a pair collapsed when both agree, a
+ * line's width/style/color, `border`'s three uniform boxes, or a plain
+ * sequence of components.
  */
-type ShorthandShape = "box" | "pair" | "line" | "border" | "sequence";
+type ShorthandShape =
+	| "box"
+	| "radius"
+	| "pair"
+	| "line"
+	| "border"
+	| "sequence";
 
 /**
  * Each shorthand's longhands, in the order its grammar names them: the
@@ -1139,10 +1169,16 @@ for (const [shorthand, all] of Object.entries(CSS_SHORTHANDS)) {
 		boxOrder(shorthand, indexed, CORNER_NAMES);
 	const longhands = box ? [...box, ...(reset ?? [])] : all;
 	SHORTHAND_LONGHANDS.set(shorthand, longhands);
+	// A corner box whose longhands are radii writes its two axes around a
+	// slash rather than one value per corner.
+	const radius =
+		box !== null && indexed.every((longhand) => longhand.endsWith("-radius"));
 	SHORTHAND_SHAPES.set(
 		shorthand,
 		box
-			? "box"
+			? radius
+				? "radius"
+				: "box"
 			: // A width, a style and a color stated once for several sides:
 				// four for `border`, the axis's two for `border-block` and
 				// `border-inline`.
@@ -1586,6 +1622,17 @@ function expandShorthandValue(
 	return ordered;
 }
 
+/**
+ * A corner radius as its two axes, the vertical one taken from the horizontal
+ * where the value states a single radius.
+ */
+function radiusAxes(value: string): [string, string] {
+	const [horizontal, vertical = horizontal] = value
+		.split(/\s+/)
+		.filter(Boolean);
+	return [horizontal ?? "0px", vertical ?? "0px"];
+}
+
 /** The four values of a box shorthand, collapsed to the shortest equivalent. */
 function collapseSides(values: string[]): string {
 	const [top, right, bottom, left] = values;
@@ -1663,6 +1710,15 @@ function serializeShorthandValue(
 	switch (SHORTHAND_SHAPES.get(shorthand)) {
 		case "box":
 			return collapseSides(values);
+		// `border-radius` writes the four horizontal radii, then the four
+		// vertical ones after a slash -- and drops the slash entirely where
+		// the two axes agree, which is every circular corner.
+		case "radius": {
+			const axes = values.map(radiusAxes);
+			const across = collapseSides(axes.map(([horizontal]) => horizontal));
+			const down = collapseSides(axes.map(([, vertical]) => vertical));
+			return across === down ? across : `${across} / ${down}`;
+		}
 		// `border` and its logical twins are three uniform boxes -- widths,
 		// styles and colors -- and serialize only when every side agrees.
 		case "border": {
@@ -5578,7 +5634,13 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 	#computed(property: string): string {
 		const entry = computedEntry(property, this.#resolvePropertyValue(property));
 		if (!entry.contextual) return entry.value;
-		return absolutizeLengths(entry.value, this.#lengthContext(property));
+		const absolute = absolutizeLengths(
+			entry.value,
+			this.#lengthContext(property),
+		);
+		// Two radii that differ as written -- `1ch 1px` -- can measure the same
+		// cell, and a corner whose radii agree states one of them.
+		return RADIUS_LONGHANDS.has(property) ? collapseRadius(absolute) : absolute;
 	}
 
 	/**
@@ -6731,6 +6793,8 @@ export enum BorderEdgeStyle {
 	Hidden = 0b1111,
 
 	// Flags (bit 4+)
+	// Set on the edges that meet in a corner cell whose radius rounds it, and
+	// on nothing else: the runs between corners are the same line either way.
 	Rounded = 0b00010000,
 }
 
@@ -6814,39 +6878,53 @@ export const BOX_DRAWING: Record<string, BoxCharSet> = {
 		rightTee: "├",
 		cross: "┼",
 	},
-	lightRounded: {
-		horizontal: "─",
-		vertical: "│",
-		topLeft: "╭",
-		topRight: "╮",
-		bottomLeft: "╰",
-		bottomRight: "╯",
-		topTee: "┬",
-		bottomTee: "┴",
-		leftTee: "┤",
-		rightTee: "├",
-		cross: "┼",
-	},
 };
 
 /**
- * Resolve border styles for an element, returning per-edge encoded data
+ * The rounded form of a corner glyph.
+ *
+ * Unicode draws rounded corners for the light single stroke alone, so this is
+ * the whole of what a terminal can bend: the light-cornered character sets --
+ * solid, dashed, dotted, ridge, inset, outset -- round, and double and heavy
+ * corners stay square because no glyph exists that bends those strokes. That
+ * is the deliberate adaptation: a radius on a double border is honored as far
+ * as the terminal's characters allow, which is not at all.
  */
-export function resolveBorderStyles(element: Element): {
+export const ROUNDED_CORNERS: Readonly<Record<string, string>> = {
+	"┌": "╭",
+	"┐": "╮",
+	"└": "╰",
+	"┘": "╯",
+};
+
+/** Which of a box's four corners a nonzero radius rounds. */
+export interface RoundedCorners {
+	topLeft: boolean;
+	topRight: boolean;
+	bottomRight: boolean;
+	bottomLeft: boolean;
+}
+
+/** An element's border as the painter draws it: per-edge encodings and corners. */
+export interface BorderStyles {
 	topEdge: number;
 	rightEdge: number;
 	bottomEdge: number;
 	leftEdge: number;
 	hasAnyBorder: boolean;
-} {
+	/** Absent where no radius was resolved, which squares every corner. */
+	roundedCorners?: RoundedCorners;
+}
+
+/**
+ * Resolve border styles for an element: per-edge encoded data, and which
+ * corners its radii round.
+ */
+export function resolveBorderStyles(element: Element): BorderStyles {
 	const computedStyle = computedStyleOf(element);
 
 	// Helper to encode individual edge
-	const encodeEdge = (
-		width: string,
-		style: string,
-		isRounded: boolean,
-	): number => {
+	const encodeEdge = (width: string, style: string): number => {
 		const parsed = parseBorderWidthValue(width);
 		const widthValue = typeof parsed === "number" ? parsed : NaN;
 		if (isNaN(widthValue) || widthValue <= 0 || !style || style === "none") {
@@ -6886,18 +6964,20 @@ export function resolveBorderStyles(element: Element): {
 				edgeValue = BorderEdgeStyle.Solid;
 		}
 
-		if (isRounded) {
-			edgeValue |= BorderEdgeStyle.Rounded;
-		}
-
 		return edgeValue;
 	};
 
-	// Check for border-radius (applies to all corners)
-	const borderRadius = parseFloat(
-		computedStyle.computedValueOf("border-radius"),
-	);
-	const hasRadius = !isNaN(borderRadius) && borderRadius > 0;
+	// A corner is rounded when its radius is nonzero on BOTH axes, exactly as
+	// a browser squares off a corner whose ellipse has collapsed. A cell grid
+	// has one size of curve, so how large the radius is says nothing further.
+	const isRounded = (corner: string): boolean => {
+		const radii = computedStyle
+			.computedValueOf(`border-${corner}-radius`)
+			.split(/\s+/)
+			.filter(Boolean);
+		if (radii.length === 0) return false;
+		return radii.every((radius) => parseFloat(radius) > 0);
+	};
 
 	// Resolve individual edges
 	const topWidth =
@@ -6929,10 +7009,10 @@ export function resolveBorderStyles(element: Element): {
 		computedStyle.computedValueOf("border-style");
 
 	// Encode each edge
-	const topEdge = encodeEdge(topWidth, topStyle, hasRadius);
-	const rightEdge = encodeEdge(rightWidth, rightStyle, hasRadius);
-	const bottomEdge = encodeEdge(bottomWidth, bottomStyle, hasRadius);
-	const leftEdge = encodeEdge(leftWidth, leftStyle, hasRadius);
+	const topEdge = encodeEdge(topWidth, topStyle);
+	const rightEdge = encodeEdge(rightWidth, rightStyle);
+	const bottomEdge = encodeEdge(bottomWidth, bottomStyle);
+	const leftEdge = encodeEdge(leftWidth, leftStyle);
 
 	return {
 		topEdge,
@@ -6941,6 +7021,12 @@ export function resolveBorderStyles(element: Element): {
 		leftEdge,
 		hasAnyBorder:
 			topEdge > 0 || rightEdge > 0 || bottomEdge > 0 || leftEdge > 0,
+		roundedCorners: {
+			topLeft: isRounded("top-left"),
+			topRight: isRounded("top-right"),
+			bottomRight: isRounded("bottom-right"),
+			bottomLeft: isRounded("bottom-left"),
+		},
 	};
 }
 

--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -28,9 +28,20 @@ const LINE_WIDTH_KEYWORDS = new Set(["thin", "medium", "thick"]);
 const EDGES = ["top", "right", "bottom", "left"] as const;
 /** The two ends of a flow-relative axis, in the order a pair shorthand states them. */
 const AXIS_ENDS = ["start", "end"] as const;
+
+const CORNERS = [
+	"top-left",
+	"top-right",
+	"bottom-right",
+	"bottom-left",
+] as const;
 const LIST_STYLE_POSITIONS = new Set(["inside", "outside"]);
 
-/** CSS 1-4 value expansion: [all], [v h], [t h b], [t r b l]. */
+/**
+ * CSS 1-4 value expansion: [all], [v h], [t h b], [t r b l]. The four corners
+ * fill by the same rule, running top-left, top-right, bottom-right,
+ * bottom-left.
+ */
 function perEdge(values: string[]): [string, string, string, string] {
 	const [a, b = a, c = a, d = b] = values;
 	return [a, b, c, d];
@@ -202,6 +213,30 @@ function expandBorderImage(value: string): Record<string, string> {
 }
 
 /**
+ * Expand the `border-radius` shorthand: up to four horizontal radii and,
+ * after a slash, up to four vertical ones, each list filled out by the CSS
+ * 1-4 rule. A corner is elliptical, so its longhand holds both radii -- and
+ * states one value where the two agree, which is how a radius serializes.
+ */
+function expandBorderRadius(value: string): Record<string, string> {
+	const [across, down] = value.split("/");
+	const horizontal = splitComponents(across ?? "");
+	if (horizontal.length === 0) return {};
+	const vertical = down === undefined ? horizontal : splitComponents(down);
+	const horizontalCorners = perEdge(horizontal);
+	const verticalCorners = perEdge(
+		vertical.length === 0 ? horizontal : vertical,
+	);
+	const out: Record<string, string> = {};
+	CORNERS.forEach((corner, i) => {
+		const h = horizontalCorners[i];
+		const v = verticalCorners[i];
+		out[`border-${corner}-radius`] = h === v ? h : `${h} ${v}`;
+	});
+	return out;
+}
+
+/**
  * Expand CSS SHORTHANDS into the longhands everything downstream reads.
  * Declarations are consulted per-property, so a `border: 1px solid` that
  * never becomes border-top-width etc. simply doesn't exist to the box model
@@ -209,9 +244,10 @@ function expandBorderImage(value: string): Record<string, string> {
  * longhand after a shorthand still overrides it.
  *
  * A shorthand keeps its own entry alongside the longhands it declares, so
- * `getPropertyValue("border")` still answers what was authored. `margin` and
- * `padding` are the exception: their computed answers are serialized from the
- * four longhands, so keeping the shorthand would shadow that.
+ * `getPropertyValue("border")` still answers what was authored. `margin`,
+ * `padding` and `border-radius` are the exception: their computed answers are
+ * serialized from the four longhands, so keeping the shorthand would shadow
+ * that.
  */
 export function expandShorthands(
 	declarations: Record<string, string>,
@@ -246,6 +282,13 @@ export function expandShorthands(
 			case "border-color":
 				setEdges("color", values);
 				break;
+			case "border-radius": {
+				const corners = expandBorderRadius(value);
+				if (Object.keys(corners).length === 0) break;
+				Object.assign(out, corners);
+				// The shorthand itself is serialized from these on read.
+				continue;
+			}
 			case "border-top":
 			case "border-right":
 			case "border-bottom":
@@ -402,7 +445,6 @@ const CSS_SPEC_DEFAULTS: Record<string, string> = {
 	"border-right-color": "currentColor",
 	"border-bottom-color": "currentColor",
 	"border-left-color": "currentColor",
-	"border-radius": "0",
 	"background-color": "transparent",
 	color: "#000000",
 	// One cell tall: the terminal's font is the grid, and a length written in

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -426,6 +426,18 @@ describe("Border Functions", () => {
 			// ╭ is the rounded ┌: rightward and downward.
 			const roundedTopLeft = (rounded << 8) | (rounded << 16);
 			expect(getBorderChar(roundedTopLeft)).toBe("╭");
+
+			// The dashes are the border style's; only the turn bends.
+			const dashed = BorderEdgeStyle.Dashed | BorderEdgeStyle.Rounded;
+			expect(getBorderChar((dashed << 16) | (dashed << 24))).toBe("╮");
+
+			// Unicode draws no rounded double corner, so the radius cannot
+			// reach this one.
+			const double = BorderEdgeStyle.Double | BorderEdgeStyle.Rounded;
+			expect(getBorderChar((double << 0) | (double << 8))).toBe("╚");
+
+			// A radius bends the corner, not the run leaving it.
+			expect(getBorderChar((rounded << 8) | (rounded << 24))).toBe("─");
 		});
 	});
 

--- a/tests/css-conformance.test.ts
+++ b/tests/css-conformance.test.ts
@@ -175,6 +175,50 @@ for (const fx of FIXTURES) {
 	});
 }
 
+// A radius bends the corner GLYPH and nothing else: a cell grid has one
+// size of curve, so how large the radius is says nothing, and no cell is
+// clipped or moved by it.
+test("css: border-radius draws the rounded corner glyphs", async () => {
+	const {text} = await renderFixture({
+		name: "border-radius",
+		cols: 12,
+		rows: 5,
+		html: `<div style="border:1px solid; border-radius:1ch; width:4px; height:3px">ab</div>`,
+	});
+	expect(text.split("\n").filter(Boolean)).toEqual(["╭──╮", "│ab│", "╰──╯"]);
+});
+
+test("css: a corner longhand rounds its own corner alone", async () => {
+	const {text} = await renderFixture({
+		name: "border-radius-longhand",
+		cols: 12,
+		rows: 5,
+		html: `<div style="border:1px solid; border-bottom-right-radius:2px; width:4px; height:3px">ab</div>`,
+	});
+	expect(text.split("\n").filter(Boolean)).toEqual(["┌──┐", "│ab│", "└──╯"]);
+});
+
+test("css: border-radius leaves a double border's corners square", async () => {
+	const {text} = await renderFixture({
+		name: "border-radius-double",
+		cols: 12,
+		rows: 5,
+		html: `<div style="border:1px double; border-radius:1ch; width:4px; height:3px">ab</div>`,
+	});
+	// Unicode draws no rounded double corner, so the box keeps ╔╗╚╝.
+	expect(text.split("\n").filter(Boolean)).toEqual(["╔══╗", "║ab║", "╚══╝"]);
+});
+
+test("css: a zero radius leaves every corner square", async () => {
+	const {text} = await renderFixture({
+		name: "border-radius-zero",
+		cols: 12,
+		rows: 5,
+		html: `<div style="border:1px solid; border-radius:0; width:4px; height:3px">ab</div>`,
+	});
+	expect(text.split("\n").filter(Boolean)).toEqual(["┌──┐", "│ab│", "└──┘"]);
+});
+
 test("css: visibility:hidden paints nothing, but reserves its box", async () => {
 	const {text} = await renderFixture({
 		name: "visibility",

--- a/tests/cssom.test.ts
+++ b/tests/cssom.test.ts
@@ -273,6 +273,66 @@ test("a declaration block stores longhands and serializes shorthands", () => {
 	dom.dispose();
 });
 
+test("border-radius stores its corners and serializes both axes", () => {
+	const {dom} = makeDOM(`<div id="box"></div>`);
+	const style = dom.document.getElementById("box")!.style;
+
+	style.borderRadius = "1px";
+	expect(style.length).toBe(4);
+	expect(style.item(0)).toBe("border-top-left-radius");
+	expect(style.borderTopLeftRadius).toBe("1px");
+	expect(style.cssText).toBe("border-radius: 1px;");
+
+	// Four corners, running top-left, top-right, bottom-right, bottom-left.
+	style.borderRadius = "1px 2px 3px 4px";
+	expect(style.borderTopRightRadius).toBe("2px");
+	expect(style.borderBottomRightRadius).toBe("3px");
+	expect(style.borderBottomLeftRadius).toBe("4px");
+
+	// Two corners named, the other two filled by the CSS 1-4 rule.
+	style.borderRadius = "1px 2px";
+	expect(style.borderBottomRightRadius).toBe("1px");
+	expect(style.borderBottomLeftRadius).toBe("2px");
+	expect(style.cssText).toBe("border-radius: 1px 2px;");
+
+	// The slash separates the horizontal radii from the vertical ones, and a
+	// corner holds the pair its two lists give it.
+	style.borderRadius = "1px 2px / 3px";
+	expect(style.borderTopLeftRadius).toBe("1px 3px");
+	expect(style.borderTopRightRadius).toBe("2px 3px");
+	expect(style.borderRadius).toBe("1px 2px / 3px");
+	expect(style.cssText).toBe("border-radius: 1px 2px / 3px;");
+
+	// A corner whose two radii agree writes one of them, and a box whose two
+	// axes agree writes no slash.
+	style.borderRadius = "2px / 2px";
+	expect(style.borderTopLeftRadius).toBe("2px");
+	expect(style.borderRadius).toBe("2px");
+
+	// Percentages are radii like any other length.
+	style.borderRadius = "50% 25%";
+	expect(style.borderTopLeftRadius).toBe("50%");
+	expect(style.borderRadius).toBe("50% 25%");
+
+	// A longhand overriding one corner reconstructs the shorthand around it.
+	style.borderRadius = "1px";
+	style.borderBottomLeftRadius = "5px";
+	expect(style.borderRadius).toBe("1px 1px 1px 5px");
+
+	// `border-radius: 0` resets every corner it had set.
+	style.borderRadius = "0";
+	expect(style.borderBottomLeftRadius).toBe("0");
+	expect(style.cssText).toBe("border-radius: 0;");
+
+	// One corner alone cannot serialize as the shorthand.
+	style.removeProperty("border-radius");
+	style.borderTopLeftRadius = "1px";
+	expect(style.borderRadius).toBe("");
+	expect(style.cssText).toBe("border-top-left-radius: 1px;");
+
+	dom.dispose();
+});
+
 test("the accessor surface follows the CSSOM attribute-mapping rules", () => {
 	const {dom} = makeDOM(`<div id="box"></div>`);
 	const style = dom.document.getElementById("box")!.style;

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -626,6 +626,47 @@ test("a nonzero length without a unit is invalid and never enters the cascade", 
 	dom.dispose();
 });
 
+test("a corner radius computes to a length pair and does not inherit", async () => {
+	const terminal = new MockProcess({rows: 6, cols: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.head.innerHTML = `<style>
+		.cells { border-radius: 2ch; }
+		.ellipse { border-radius: 1px 2px / 3px 4px; }
+		.percent { border-radius: 50%; }
+		.reset { border-radius: 4px; border-radius: 0; }
+	</style>`;
+	dom.document.body.innerHTML = `<div class="cells">C<span class="child">K</span></div>
+		<div class="ellipse">E</div><div class="percent">P</div><div class="reset">R</div>`;
+	await nextFrame(dom);
+	const value = (sel: string, prop: string) =>
+		dom.window
+			.getComputedStyle(dom.document.querySelector(sel)!)
+			.getPropertyValue(prop);
+
+	// A cell is the terminal's unit of width, so a radius in ch computes to
+	// that many px like any other length.
+	expect(value(".cells", "border-top-left-radius")).toBe("2px");
+	expect(value(".cells", "border-radius")).toBe("2px");
+	// Radii are not inherited properties.
+	expect(value(".child", "border-top-left-radius")).toBe("0px");
+
+	// An elliptical corner keeps both radii, horizontal first.
+	expect(value(".ellipse", "border-top-left-radius")).toBe("1px 3px");
+	expect(value(".ellipse", "border-top-right-radius")).toBe("2px 4px");
+	// Two values name one diagonal each: bottom-right repeats top-left.
+	expect(value(".ellipse", "border-bottom-right-radius")).toBe("1px 3px");
+	expect(value(".ellipse", "border-bottom-left-radius")).toBe("2px 4px");
+	expect(value(".ellipse", "border-radius")).toBe("1px 2px / 3px 4px");
+
+	// A percentage resolves against the box when something uses it, so it
+	// computes as written.
+	expect(value(".percent", "border-top-right-radius")).toBe("50%");
+	expect(value(".percent", "border-radius")).toBe("50%");
+
+	expect(value(".reset", "border-radius")).toBe("0px");
+	dom.dispose();
+});
+
 test("bare numbers stay valid where CSS says they are", async () => {
 	// Zero needs no unit on any length, and the number-typed properties
 	// take bare numbers by spec -- the check is per-property, not a


### PR DESCRIPTION
Implements `border-radius`. A corner with a nonzero computed radius renders with the rounded box-drawing glyph (`╭ ╮ ╰ ╯`); the radius has no effect on layout or clipping. Corners are controlled individually by the four longhands. Dashed and dotted borders round their corners; `double` corners stay square (Unicode has no rounded double-stroke glyphs; noted at the glyph table).

CSSOM:

- The shorthand expands to the four longhands on write and is reconstructed on read, the same mechanism as `margin`/`padding`.
- Slash syntax parses to elliptical pairs; `1px 2px / 3px 4px` round-trips. The serializer collapses each axis and emits ` / ` only when the axes differ.
- A corner squares when either of its radii is zero.
- `getComputedStyle` reports computed lengths; percentages compute as written; the properties do not inherit; `border-radius: 0` resets all corners; a lone longhand does not serialize as the shorthand.

Rendering extends the existing corner-glyph selection in `resolveBorderStyles`/`drawBorder` with a `ROUNDED_CORNERS` mapping table.

`COMPATIBILITY.md` now probes all five properties (previously in the "not yet probed" list).

Tests: CSSOM storage/serialization (`cssom.test.ts`), computed values and inheritance (`styles.test.ts`), rendered glyphs including per-corner and double-border cases (`css-conformance.test.ts`), ANSI-level corner assertions (`ansi.test.ts`). WPT cssom shorthand-serialization results are identical to the recorded baseline. Full suite passes: node 1130, bun 1155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
