### PR TITLE
Implement dialog showModal(), the top layer, and ::backdrop

### DIFF
--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -12459,15 +12459,39 @@ Object.defineProperty(HTMLElement.prototype, kActivationBehavior, {
 	configurable: true,
 });
 /**
+ * A document's TOP LAYER: the elements that render above every stacking
+ * context of the document, in the order they entered it. Membership is what
+ * `showModal` grants and `close` revokes, and what the renderer paints last.
+ */
+export function topLayerOf(document: object): Set<Element> {
+	return (document as Document)[kTopLayer];
+}
+
+/**
+ * Whether an element is showing modally -- the state `:modal` matches. A
+ * dialog is modal exactly while it is in its document's top layer: `show()`
+ * never puts one there and `close()` takes it out, so there is no second
+ * flag to keep in step with the first.
+ */
+export function isModalDialog(node: object): boolean {
+	return (
+		node instanceof HTMLDialogElement &&
+		topLayerOf(node[kDocument]).has(node as Element)
+	);
+}
+
+/**
  * A dialog.
  *
- * Showing one modally puts it in the top layer, which is a rendering concept
- * this DOM does not have; what is here is the state a caller can see -- the
- * open attribute, the return value, and the events closing one fires.
+ * Showing one modally puts it in the document's top layer, above every
+ * stacking context and outside the flow it was written in, and makes the rest
+ * of the document unreachable until it closes; showing one with `show()`
+ * leaves it exactly where it is, an ordinary box that happens to be visible.
  */
 export class HTMLDialogElement extends HTMLElement {
 	#returnValue = "";
-	#modal = false;
+	// Where focus was when the dialog took it, so closing can give it back.
+	#previouslyFocused: Element | null = null;
 
 	get returnValue(): string {
 		return this.#returnValue;
@@ -12479,7 +12503,7 @@ export class HTMLDialogElement extends HTMLElement {
 
 	show(): void {
 		if (this.hasAttribute("open")) {
-			if (this.#modal) {
+			if (isModalDialog(this)) {
 				throw domError(
 					"InvalidStateError",
 					"That dialog is already showing modally",
@@ -12500,8 +12524,49 @@ export class HTMLDialogElement extends HTMLElement {
 				"A dialog must be connected to show modally",
 			);
 		}
+		// The top layer is the modality: everything else -- `:modal`, the
+		// backdrop, the hit-testing that stops clicks reaching the page --
+		// reads membership rather than a flag of its own.
+		topLayerOf(this[kDocument]).add(this);
 		this.setAttribute("open", "");
-		this.#modal = true;
+		this.#focusDialog();
+	}
+
+	/**
+	 * HTML's dialog focusing steps: focus goes to the descendant asking for it
+	 * with `autofocus`, else to the first one that can take focus, else to the
+	 * dialog itself -- which is focusable for exactly as long as it is the
+	 * modal one, so a dialog of plain text still takes keys off the page.
+	 */
+	#focusDialog(): void {
+		this.#previouslyFocused = this[kDocument][kActiveElement];
+		const walker = shadowIncludingInclusiveDescendants(this);
+		let fallback: Element | null = null;
+		for (const node of walker) {
+			if (node === this || node.nodeType !== ELEMENT_NODE) continue;
+			const element = node as Element;
+			if (!isFocusableArea(element)) continue;
+			if (element.hasAttribute("autofocus")) {
+				(element as HTMLElement).focus();
+				return;
+			}
+			if (fallback === null) fallback = element;
+		}
+		if (fallback !== null) {
+			(fallback as HTMLElement).focus();
+			return;
+		}
+		this[kDocument][kActiveElement] = this;
+	}
+
+	/**
+	 * A modal dialog taken out of the document leaves the top layer with it:
+	 * nothing off the tree can render above it, and a detached dialog is no
+	 * longer modal.
+	 */
+	override [kRemovingSteps](oldParent: Node): void {
+		super[kRemovingSteps](oldParent);
+		topLayerOf(this[kDocument]).delete(this);
 	}
 
 	close(returnValue?: string): void {
@@ -12518,7 +12583,19 @@ export class HTMLDialogElement extends HTMLElement {
 	#close(returnValue: string | undefined, _fromRequest: boolean): void {
 		if (!this.hasAttribute("open")) return;
 		this.removeAttribute("open");
-		this.#modal = false;
+		topLayerOf(this[kDocument]).delete(this);
+		// The page gets its focus back where the dialog took it from, so the
+		// keyboard returns to what the user was doing before it opened.
+		if (this.#previouslyFocused !== null) {
+			const previous = this.#previouslyFocused;
+			this.#previouslyFocused = null;
+			if (
+				this[kDocument][kActiveElement] === this ||
+				this.contains(this[kDocument][kActiveElement])
+			) {
+				(previous as HTMLElement).focus();
+			}
+		}
 		if (returnValue !== undefined) this.#returnValue = String(returnValue);
 		dispatch(this, new Event("close"));
 	}
@@ -14277,6 +14354,7 @@ const kNwsapi = Symbol("selector engine");
 const kActiveElement = Symbol("focused area");
 const kDefaultView = Symbol("the window this document is displayed in");
 const kStyleElements = Symbol("how many style elements the tree holds");
+const kTopLayer = Symbol("the document's top layer");
 
 let currentDocumentForConstruction: Document | null = null;
 let ambientDocument: Document | null = null;
@@ -14323,6 +14401,7 @@ export class Document extends Node {
 	[kDefaultView]: object | null = null;
 	[kStyleElements] = 0;
 	[kChildren]: HTMLCollection | null = null;
+	[kTopLayer] = new Set<Element>();
 
 	/** Parse a document, declarative shadow roots included. */
 	static parseHTMLUnsafe(html: string): Document {
@@ -17658,6 +17737,20 @@ function selectorEngine(document: Document): SelectorEngine {
 			IDS_DUPES: true,
 			MIXEDCASE: true,
 		});
+		// `:modal` is a state no attribute records, so the engine cannot
+		// derive it from the tree: it asks the document's top layer, through
+		// the resolver object the compiled matchers already close over.
+		engine.Snapshot.isModal = isModalDialog;
+		engine.registerSelector(
+			":modal",
+			/^:modal(.*)/i,
+			(match: string[], source: string) => ({
+				match,
+				source: `if(s.isModal(e)){${source}}`,
+				status: true,
+				modvar: null,
+			}),
+		);
 		if (document.documentElement !== null) {
 			document[kNwsapi] = engine;
 		}

--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -404,16 +404,16 @@ export const FOCUSABLE_SELECTOR =
 	'a[href], input:not([disabled]), button:not([disabled]), textarea:not([disabled]), select:not([disabled]), details > summary:first-of-type, [tabindex]:not([tabindex="-1"])';
 
 /**
- * Get all focusable elements in tab order
+ * Get all focusable elements in tab order, within a root: the document, or
+ * the modal dialog whose subtree is the only reachable part of it.
  */
 export function getFocusableElements(
-	document: Document,
+	root: Document | Element,
 	window: EngineWindow,
 	layoutEngine: LayoutEngine,
 ): Element[] {
-	const elements = Array.from(
-		document.querySelectorAll(FOCUSABLE_SELECTOR),
-	).filter((element) => {
+	const candidates = root.querySelectorAll(FOCUSABLE_SELECTOR);
+	const elements = Array.from(candidates).filter((element) => {
 		// Browsers keep unrendered elements out of tab order: a hidden
 		// edit-row checkbox must not swallow a Tab press invisibly. An
 		// element is rendered when nothing on its flat-tree chain is

--- a/src/internal/externals.d.ts
+++ b/src/internal/externals.d.ts
@@ -121,6 +121,32 @@ declare module "nwsapi" {
 		select(selector: string, context?: unknown, callback?: unknown): unknown[];
 		ancestor(selector: string, context?: unknown, callback?: unknown): unknown;
 		configure(options: Record<string, boolean>): void;
+		/**
+		 * The resolver object every compiled matcher is handed as `s`: the
+		 * engine's own helpers, and the ones a registered selector adds.
+		 */
+		Snapshot: Record<string, unknown>;
+		/**
+		 * Teach the engine a pseudo-class it does not know. The expression
+		 * matches the selector with the rest of it captured last (the parser
+		 * pops that remainder); the callback wraps the source compiled so far
+		 * in the test, and reports whether it recognized the selector.
+		 */
+		registerSelector(
+			name: string,
+			expression: RegExp,
+			callback: (
+				match: string[],
+				source: string,
+				mode: boolean,
+				callback: unknown,
+			) => {
+				match?: string[];
+				source: string;
+				status: boolean;
+				modvar: string | null;
+			},
+		): void;
 	}
 
 	export default function nwsapi(global: {

--- a/src/internal/flex.ts
+++ b/src/internal/flex.ts
@@ -2573,6 +2573,19 @@ function layoutAbsoluteChild(
 		parentWidth,
 	);
 
+	// An auto margin between an inset and the box is the box asking to be
+	// placed in the space the insets leave rather than stretched across it --
+	// the same reading the in-flow block path gives `margin: auto`, and what
+	// centers a modal dialog in the viewport.
+	const autoLeft = child.style.margin[EDGE_LEFT].unit === UNIT_AUTO;
+	const autoRight = child.style.margin[EDGE_RIGHT].unit === UNIT_AUTO;
+	const autoTop = child.style.margin[EDGE_TOP].unit === UNIT_AUTO;
+	const autoBottom = child.style.margin[EDGE_BOTTOM].unit === UNIT_AUTO;
+	const shrinkAcross =
+		isDefined(left) && isDefined(right) && autoLeft && autoRight;
+	const shrinkDown =
+		isDefined(top) && isDefined(bottom) && autoTop && autoBottom;
+
 	const childWidth = {value: NaN, mode: MEASURE_MODE_UNDEFINED};
 	const childHeight = {value: NaN, mode: MEASURE_MODE_UNDEFINED};
 
@@ -2580,6 +2593,11 @@ function layoutAbsoluteChild(
 		childWidth.value =
 			resolveValue(child.style.width, parentWidth) + marginLeft + marginRight;
 		childWidth.mode = MEASURE_MODE_EXACTLY;
+	} else if (shrinkAcross) {
+		// Auto margins on both sides: the insets bound the box, they do not
+		// size it, so it shrinks to its content within them.
+		childWidth.value = parentWidth - borderLeft - borderRight - left - right;
+		childWidth.mode = MEASURE_MODE_AT_MOST;
 	} else if (isDefined(left) && isDefined(right)) {
 		// Both insets pin the box, so its width is implied.
 		childWidth.value =
@@ -2600,6 +2618,9 @@ function layoutAbsoluteChild(
 		childHeight.value =
 			resolveValue(child.style.height, parentHeight) + marginTop + marginBottom;
 		childHeight.mode = MEASURE_MODE_EXACTLY;
+	} else if (shrinkDown) {
+		childHeight.value = parentHeight - borderTop - borderBottom - top - bottom;
+		childHeight.mode = MEASURE_MODE_AT_MOST;
 	} else if (isDefined(top) && isDefined(bottom)) {
 		childHeight.value =
 			parentHeight -
@@ -2635,7 +2656,18 @@ function layoutAbsoluteChild(
 			: null;
 
 	// Horizontal placement.
-	if (isDefined(left)) {
+	if (shrinkAcross) {
+		// The space the insets left, minus the box, goes to the auto margins:
+		// half each, which is centering.
+		const free =
+			parentWidth -
+			borderLeft -
+			borderRight -
+			left -
+			right -
+			child.layout.width;
+		child.layout.left = borderLeft + left + Math.max(free, 0) / 2;
+	} else if (isDefined(left)) {
 		child.layout.left = borderLeft + left + marginLeft;
 	} else if (isDefined(right)) {
 		child.layout.left =
@@ -2656,7 +2688,16 @@ function layoutAbsoluteChild(
 	}
 
 	// Vertical placement.
-	if (isDefined(top)) {
+	if (shrinkDown) {
+		const free =
+			parentHeight -
+			borderTop -
+			borderBottom -
+			top -
+			bottom -
+			child.layout.height;
+		child.layout.top = borderTop + top + Math.max(free, 0) / 2;
+	} else if (isDefined(top)) {
 		child.layout.top = borderTop + top + marginTop;
 	} else if (isDefined(bottom)) {
 		child.layout.top =

--- a/src/internal/painter.ts
+++ b/src/internal/painter.ts
@@ -107,6 +107,19 @@ function isSystemHighlightColor(value: string): boolean {
 }
 
 /**
+ * A background-color as `fillRect` takes it: the two system colors keep their
+ * terminal meanings (Canvas the terminal's own background, Highlight a swap of
+ * each cell's colors), every other color is its cells' background, and a
+ * background that paints nothing answers null.
+ */
+function backgroundFill(value: string): number | "default" | "inverse" | null {
+	if (!value || value === "initial" || isTransparentColor(value)) return null;
+	if (/^canvas$/i.test(value.trim())) return "default";
+	if (isSystemHighlightColor(value)) return "inverse";
+	return cssColorToNumber(value);
+}
+
+/**
  * A computed style reduced to terminal cell attributes -- one mapping,
  * shared by text nodes and the input painter's shadow parts.
  */
@@ -267,11 +280,33 @@ export class Painter {
 			const previousClip = ctx.clipRect;
 			ctx.clipRect = null;
 			try {
+				this.#renderBackdrop(element, ctx);
 				this.#renderStackingContext(element, ctx, layers);
 			} finally {
 				ctx.clipRect = previousClip;
 			}
 		}
+	}
+
+	/**
+	 * The ::backdrop of a top-layer element: the box between it and everything
+	 * the document already painted, covering the viewport. Like ::selection,
+	 * it has no node of its own -- what it paints comes entirely from the
+	 * ::backdrop rules the cascade resolves, the UA sheet's included, so an
+	 * author writing `dialog::backdrop { background-color: ... }` replaces the
+	 * scrim and one writing `transparent` removes it.
+	 */
+	#renderBackdrop(
+		element: Element,
+		ctx: import("./ansi.js").DrawingContext,
+	): void {
+		const fill = backgroundFill(
+			pseudoStyleOf(element, "::backdrop").computedValueOf("background-color"),
+		);
+		if (fill === null) return;
+		// The viewport, in the document coordinates every draw call takes: the
+		// band the buffer holds, which is where a fixed box paints too.
+		ctx.fillRect(0, -ctx.viewportOffset, ctx.cols, ctx.rows, fill);
 	}
 
 	#renderElement(

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -11,9 +11,11 @@ import {
 	fieldValueText,
 	flatIsConnected,
 	installUAEngine,
+	isModalDialog,
 	isTextField,
 	pseudoHostOf,
 	setUASelection,
+	topLayerOf,
 	upgradeUAWidget,
 } from "./dom.js";
 import {LayoutEngine} from "./layout.js";
@@ -513,9 +515,11 @@ export class TermDOM {
 	/**
 	 * The TOP LAYER: elements painted above every stacking context, in
 	 * insertion order, unclipped -- the foundation dialog/popover/::picker
-	 * share. Members are excluded from normal stacking collection.
+	 * share. Members are excluded from normal stacking collection. The set is
+	 * the DOCUMENT's, by reference: `showModal` puts a dialog in it with no
+	 * route through the renderer, and the renderer paints whatever is there.
 	 */
-	#topLayer = new Set<Element>();
+	#topLayer: Set<Element>;
 
 	// Timers that must be torn down in dispose(), or they keep the process
 	// alive after the app is done -- which, across a test suite, piles up
@@ -659,6 +663,7 @@ export class TermDOM {
 		);
 		const document = this.window.document as unknown as DOM.Document;
 		this.document = this.window.document;
+		this.#topLayer = topLayerOf(this.document) as unknown as Set<Element>;
 
 		// Setup DOM inspector
 		setupInspectMethods(this.window);
@@ -2284,11 +2289,28 @@ export class TermDOM {
 	}
 
 	/**
+	 * The modal dialog on top of the document, or null while none is showing.
+	 * Last in the top layer is topmost, and only a modal dialog is ever in it
+	 * by way of `showModal`.
+	 */
+	#topmostModalDialog(): HTMLDialogElement | null {
+		let modal: HTMLDialogElement | null = null;
+		for (const element of this.#topLayer) {
+			if (isModalDialog(element)) modal = element as HTMLDialogElement;
+		}
+		return modal;
+	}
+
+	/**
 	 * Focus the next or previous focusable element
 	 */
 	#moveFocus(reverse: boolean): void {
+		// A modal dialog makes the rest of the document inert, and the visible
+		// half of inertness is that Tab cannot leave the dialog: the sequential
+		// order is the dialog's own, and it wraps within it.
+		const scope = this.#topmostModalDialog() ?? this.document;
 		const focusable = getFocusableElements(
-			this.document,
+			scope,
 			this.window,
 			this[kLayoutEngine],
 		);
@@ -2356,6 +2378,15 @@ export class TermDOM {
 			} else {
 				break;
 			}
+		}
+		// A modal dialog makes the rest of the document inert: a point outside
+		// it lands on its backdrop, and a backdrop's hits are the DIALOG's --
+		// the target a browser reports for a click on the dim area, and the
+		// reason nothing behind a modal can be clicked or focused while it is
+		// up.
+		const modal = this.#topmostModalDialog();
+		if (modal !== null && (element === null || !modal.contains(element))) {
+			return modal as unknown as Element;
 		}
 		return element;
 	}
@@ -2797,6 +2828,22 @@ export class TermDOM {
 		});
 
 		const notCanceled = targetElement.dispatchEvent(keydownEvent);
+
+		// Escape is a CLOSE REQUEST on the topmost modal dialog: fire cancel,
+		// and close unless a listener took it. The dialog gets Escape only
+		// when nothing is fullscreen -- the branch above already returned --
+		// which is the browser's own precedence: the fullscreen exit is the
+		// user agent's guarantee, and only after it is spent does the key
+		// reach the page's own modality. Unlike Tab below, a preventDefault
+		// on keydown does not suppress it; `cancel` is the hook for that.
+		if (keyName === "Escape") {
+			const modal = this.#topmostModalDialog();
+			if (modal) {
+				modal.requestClose();
+				void this.#render();
+				return;
+			}
+		}
 
 		// Handle default actions if keydown wasn't canceled
 		if (notCanceled) {

--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -505,6 +505,17 @@ export const TERMINAL_ELEMENT_DEFAULTS: Record<
 		// real content, and the painter's scroll-window handles overflow.
 		"white-space": "pre",
 	},
+	// A dialog is a box drawn over the page, so it is bordered and opaque:
+	// the border is what says where the dialog ends and the document it sits
+	// on begins, and Canvas -- the terminal's own background -- is what makes
+	// a non-modal one, which has no backdrop clearing the viewport for it,
+	// still hide the content it covers rather than tangle with it.
+	dialog: {
+		display: "block",
+		border: "1px solid",
+		padding: "0 1ch",
+		"background-color": "Canvas",
+	},
 	// A textarea preserves newlines and soft-wraps at its edge, exactly the
 	// browser default. Its UA shadow tree's value text lays out through the
 	// normal pipeline, so this is what makes multiline values multiline --
@@ -761,6 +772,16 @@ export function getInitialStyle(
  * browser's UA sheet styles shadow trees. The `::selection` rule is the
  * load-bearing one the header warns about: it is CSS's spelling of "swap the
  * cell's colors", which the selection painters translate to SGR 7.
+ *
+ * The two dialog rules are the same kind of load-bearing. A modal dialog is
+ * a fixed box with `inset: 0` and auto margins on all four sides, which is
+ * how a browser's own sheet centers one in the viewport -- the centering is
+ * CSS, not a constant in the painter. Its `::backdrop` fills the viewport
+ * with Canvas, the terminal's own background: a cell holds one color and
+ * cannot blend a browser's translucent scrim, so the terminal-native reading
+ * of "obscure the page" is to clear it. An author who wants a different one
+ * writes `dialog::backdrop { background-color: ... }`, and `transparent`
+ * removes it entirely.
  */
 export const UA_DOCUMENT_STYLES = `
 	*::selection { background-color: Highlight; color: HighlightText; }
@@ -769,6 +790,12 @@ export const UA_DOCUMENT_STYLES = `
 	a[href] { text-decoration: underline; }
 	datalist { display: none; }
 	dialog:not([open]) { display: none; }
+	dialog:modal {
+		position: fixed;
+		top: 0; right: 0; bottom: 0; left: 0;
+		margin: auto;
+	}
+	dialog::backdrop { background-color: Canvas; }
 	details:not([open]) > :not(summary) { display: none; }
 	details > summary:first-of-type::before { content: "▸ "; }
 	details[open] > summary:first-of-type::before { content: "▾ "; }

--- a/tests/dialog.test.ts
+++ b/tests/dialog.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The modal dialog: the top layer as an author reaches it. Showing one
+ * modally lifts it out of the flow it was written in and over everything the
+ * document paints, dims the page behind it into its ::backdrop, takes the
+ * clicks and the keys the page would have had, and gives all of it back on
+ * close.
+ */
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+async function open(html: string, cols = 30, rows = 8) {
+	const terminal = new MockProcess({rows, cols});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = html;
+	await nextFrame(dom);
+	const dialog = dom.document.querySelector("dialog") as HTMLDialogElement;
+	return {terminal, dom, dialog};
+}
+
+function press(terminal: MockProcess, data: string): Promise<void> {
+	(terminal.stdin as any).emit("data", Buffer.from(data));
+	// Input rides the transport's readable: delivery is a microtask away.
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/* ------------------------------------------------------------- rendering */
+
+test("a modal dialog paints over the page, centered in the viewport", async () => {
+	const {terminal, dom, dialog} = await open(
+		`<p>page one</p><p>page two</p><p>page three</p>` +
+			`<dialog><p>Save?</p></dialog>`,
+	);
+	dialog.showModal();
+	await nextFrame(dom);
+
+	const output = terminal.getPlainText();
+	// The dialog's box is the only thing on screen, and it sits in the middle
+	// of the viewport rather than where it was written.
+	expect(output).not.toContain("page one");
+	expect(output).toContain("Save?");
+	// Centered to the cell: the gaps on either side differ by at most the one
+	// cell an odd remainder cannot split.
+	const rect = dialog.getBoundingClientRect();
+	expect(Math.abs(rect.left - (30 - rect.right))).toBeLessThanOrEqual(1);
+	expect(Math.abs(rect.top - (8 - rect.bottom))).toBeLessThanOrEqual(1);
+	dom.dispose();
+});
+
+test("the backdrop covers the viewport, and an author's rules restyle it", async () => {
+	const {terminal, dom, dialog} = await open(
+		`<style>dialog::backdrop { background-color: transparent; }</style>` +
+			`<p>page one</p><p>page two</p><dialog><p>Save?</p></dialog>`,
+	);
+	dialog.showModal();
+	await nextFrame(dom);
+
+	// A transparent backdrop paints nothing, so the page it would have
+	// cleared is still there under the dialog.
+	const output = terminal.getPlainText();
+	expect(output).toContain("page one");
+	expect(output).toContain("Save?");
+	dom.dispose();
+});
+
+test("show() leaves the dialog in the flow, with no backdrop", async () => {
+	const {terminal, dom, dialog} = await open(
+		`<p>page one</p><dialog><p>Save?</p></dialog>`,
+	);
+	dialog.show();
+	await nextFrame(dom);
+
+	const output = terminal.getPlainText();
+	expect(output).toContain("page one");
+	expect(output).toContain("Save?");
+	expect(dialog.matches(":modal")).toBe(false);
+	// In flow means below the paragraph it follows, not centered over it.
+	expect(dialog.getBoundingClientRect().top).toBeGreaterThan(0);
+	dom.dispose();
+});
+
+test("closing gives the page back", async () => {
+	const {terminal, dom, dialog} = await open(
+		`<p>page one</p><dialog><p>Save?</p></dialog>`,
+	);
+	dialog.showModal();
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).not.toContain("page one");
+
+	dialog.close("ok");
+	await nextFrame(dom);
+	const output = terminal.getPlainText();
+	expect(output).toContain("page one");
+	expect(output).not.toContain("Save?");
+	expect(dialog.returnValue).toBe("ok");
+	expect(dialog.open).toBe(false);
+	dom.dispose();
+});
+
+/* ----------------------------------------------------------------- state */
+
+test(":modal matches a dialog shown modally, and only while it is showing", async () => {
+	const {dom, dialog} = await open(`<dialog><p>Save?</p></dialog>`);
+	expect(dialog.matches(":modal")).toBe(false);
+
+	dialog.showModal();
+	expect(dialog.matches(":modal")).toBe(true);
+	expect(dom.document.querySelectorAll("dialog:modal").length).toBe(1);
+
+	dialog.close();
+	expect(dialog.matches(":modal")).toBe(false);
+	expect(dom.document.querySelectorAll(":modal").length).toBe(0);
+	dom.dispose();
+});
+
+test("showModal refuses a dialog that is already showing, or is not connected", async () => {
+	const {dom, dialog} = await open(`<dialog><p>Save?</p></dialog>`);
+	dialog.show();
+	expect(() => dialog.showModal()).toThrow(/already showing/);
+	dialog.close();
+
+	dialog.showModal();
+	expect(() => dialog.showModal()).toThrow(/already showing/);
+	// And a modal one refuses to be shown non-modally on top of itself.
+	expect(() => dialog.show()).toThrow(/already showing modally/);
+	dialog.close();
+
+	const detached = dom.document.createElement("dialog") as HTMLDialogElement;
+	expect(() => detached.showModal()).toThrow(/connected/);
+	expect(detached.open).toBe(false);
+	dom.dispose();
+});
+
+test("taking a modal dialog out of the document takes it out of the top layer", async () => {
+	const {dom, dialog} = await open(`<dialog><p>Save?</p></dialog>`);
+	dialog.showModal();
+	dialog.remove();
+	expect(dialog.matches(":modal")).toBe(false);
+	dom.dispose();
+});
+
+/* ------------------------------------------------------------ modality */
+
+test("a click outside a modal dialog lands on the dialog, not the page", async () => {
+	const {dom, dialog} = await open(
+		`<p id="page">page one</p><dialog><p id="inside">Save?</p></dialog>`,
+	);
+	const {document} = dom;
+	expect(document.elementFromPoint(0, 0)?.id).toBe("page");
+
+	dialog.showModal();
+	await nextFrame(dom);
+	// The corner of the screen is the backdrop, whose hits are the dialog's.
+	expect(document.elementFromPoint(0, 0)).toBe(dialog);
+	// Inside it, the ordinary hit-test answers.
+	const rect = dialog.getBoundingClientRect();
+	expect(
+		document.elementFromPoint(
+			Math.round(rect.left + rect.width / 2),
+			Math.round(rect.top + 1),
+		)?.id,
+	).toBe("inside");
+	dom.dispose();
+});
+
+test("focus enters the dialog and Tab cannot leave it", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML =
+		`<button id="page">page</button>` +
+		`<dialog><button id="ok">OK</button><button id="cancel">Cancel</button></dialog>`;
+	dom.attach();
+	await nextFrame(dom);
+	const {document} = dom;
+	const dialog = document.querySelector("dialog") as HTMLDialogElement;
+	(document.getElementById("page") as HTMLElement).focus();
+
+	dialog.showModal();
+	await nextFrame(dom);
+	// The dialog focusing steps put focus on the first control inside it.
+	expect(document.activeElement?.id).toBe("ok");
+
+	await press(terminal, "\t");
+	expect(document.activeElement?.id).toBe("cancel");
+	// Tab wraps within the dialog rather than reaching the page behind it.
+	await press(terminal, "\t");
+	expect(document.activeElement?.id).toBe("ok");
+
+	dialog.close();
+	// Closing hands focus back to whatever had it when the dialog took it.
+	expect(document.activeElement?.id).toBe("page");
+	dom.dispose();
+});
+
+test("autofocus wins the dialog focusing steps", async () => {
+	const {dom, dialog} = await open(
+		`<dialog><button id="ok">OK</button><button id="cancel" autofocus>Cancel</button></dialog>`,
+	);
+	dialog.showModal();
+	expect(dom.document.activeElement?.id).toBe("cancel");
+	dom.dispose();
+});
+
+test("a dialog with nothing focusable takes focus itself", async () => {
+	const {dom, dialog} = await open(`<dialog><p>Saving...</p></dialog>`);
+	dialog.showModal();
+	expect(dom.document.activeElement).toBe(dialog);
+	dom.dispose();
+});
+
+/* ----------------------------------------------------------------- keys */
+
+test("Escape fires cancel and closes the topmost modal dialog", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = `<p>page</p><dialog><p>Save?</p></dialog>`;
+	dom.attach();
+	await nextFrame(dom);
+	const dialog = dom.document.querySelector("dialog") as HTMLDialogElement;
+	const seen: string[] = [];
+	dialog.addEventListener("cancel", () => seen.push("cancel"));
+	dialog.addEventListener("close", () => seen.push("close"));
+
+	dialog.showModal();
+	await nextFrame(dom);
+	await press(terminal, "\x1b");
+
+	expect(seen).toEqual(["cancel", "close"]);
+	expect(dialog.open).toBe(false);
+	dom.dispose();
+});
+
+test("a canceled cancel event keeps the dialog open", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = `<p>page</p><dialog><p>Save?</p></dialog>`;
+	dom.attach();
+	await nextFrame(dom);
+	const dialog = dom.document.querySelector("dialog") as HTMLDialogElement;
+	dialog.addEventListener("cancel", (event: Event) => event.preventDefault());
+
+	dialog.showModal();
+	await nextFrame(dom);
+	await press(terminal, "\x1b");
+
+	expect(dialog.open).toBe(true);
+	expect(dialog.matches(":modal")).toBe(true);
+	dom.dispose();
+});
+
+test("Escape reaches no dialog while nothing is showing modally", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = `<p>page</p><dialog open><p>Save?</p></dialog>`;
+	dom.attach();
+	await nextFrame(dom);
+	const dialog = dom.document.querySelector("dialog") as HTMLDialogElement;
+
+	await press(terminal, "\x1b");
+	// A non-modal dialog is not a close request's target: it stays open.
+	expect(dialog.open).toBe(true);
+	dom.dispose();
+});


### PR DESCRIPTION
Wires `dialog.showModal()` to the top layer. A modal dialog paints over the current document, centered, with a `::backdrop` behind it; the rest of the page stops receiving input while it shows.

Behavior:

- `showModal()` adds the dialog to the document's top layer (the same layer the select picker uses) and throws `InvalidStateError` when already open or disconnected. `show()` stays in-flow with no backdrop. `close()` removes it from the layer and restores focus to the previously focused element. Removal from the document also removes it from the layer.
- The top layer now lives on the `Document` (where the spec puts it); the renderer holds the same Set by reference. Modality is top-layer membership — the separate `#modal` flag is gone.
- `:modal` matches while modal. The selector engine had no such pseudo-class (`matches(":modal")` threw, a recorded WPT failure); it is now registered with nwsapi and works in `matches`, `querySelectorAll`, and the cascade.
- `::backdrop` resolves like `::selection`/`::placeholder` for any top-layer element. UA default: `dialog::backdrop { background-color: Canvas }` (a cell holds one color; there is no translucent scrim). Authors restyle or remove it in CSS. Limitation: the backdrop has no layout box, so only paint properties apply.
- Clicks outside the topmost modal retarget to the dialog (a browser's backdrop-click target), Tab wraps inside it, focus enters on open (autofocus, else first focusable, else the dialog).
- Escape fires cancelable `cancel`, then closes. Fullscreen still consumes Escape first, matching browser order; documented at the site.
- `<dialog>` gains UA defaults (block, border, padding, Canvas background); it previously fell through to `display: inline`.

Layout change: an absolutely positioned box with both insets and `margin: auto` on an axis now shrinks to its content within the insets and centers in the leftover space, per CSS 2.1's absolute positioning rules. Previously it stretched across the insets. This is what makes the dialog centering plain UA CSS (`position: fixed; inset: 0; margin: auto`) instead of painter logic.

Tests: 14 cases in `tests/dialog.test.ts` covering paint-over, backdrop and author restyling, `show()` vs `showModal()`, `:modal`, error cases, top-layer removal, outside-click retargeting, focus containment and restoration, autofocus, cancel/close. Full suite passes: node 1138, bun 1163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
