### PR TITLE
Implement CSS logical properties

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,7 +7,7 @@ properties. Every row is a probe -- the feature applied to a real
 document and rendered, with the row recording whether the output
 changed.
 
-109 features supported, 109 probed and unsupported,
+157 features supported, 61 probed and unsupported,
 156 CSS properties not applicable to a character grid,
 129 applicable and not implemented,
 9 not yet probed.
@@ -68,30 +68,30 @@ changed.
 | `border-left-width` | yes |
 | `border-left-style` | yes |
 | `border-left-color` | yes |
-| `border-block-start-width` | no (no effect) |
-| `border-block-end-width` | no (no effect) |
-| `border-inline-start-width` | no (no effect) |
-| `border-inline-end-width` | no (no effect) |
-| `border-block-width` | no (no effect) |
-| `border-block-style` | no (no effect) |
-| `border-block-color` | no (no effect) |
-| `border-block` | no (no effect) |
-| `border-block-start` | no (no effect) |
-| `border-block-start-style` | no (no effect) |
-| `border-block-start-color` | no (no effect) |
-| `border-block-end` | no (no effect) |
-| `border-block-end-style` | no (no effect) |
-| `border-block-end-color` | no (no effect) |
-| `border-inline-width` | no (no effect) |
-| `border-inline-style` | no (no effect) |
-| `border-inline-color` | no (no effect) |
-| `border-inline` | no (no effect) |
-| `border-inline-start` | no (no effect) |
-| `border-inline-start-style` | no (no effect) |
-| `border-inline-start-color` | no (no effect) |
-| `border-inline-end` | no (no effect) |
-| `border-inline-end-style` | no (no effect) |
-| `border-inline-end-color` | no (no effect) |
+| `border-block-start-width` | yes |
+| `border-block-end-width` | yes |
+| `border-inline-start-width` | yes |
+| `border-inline-end-width` | yes |
+| `border-block-width` | yes |
+| `border-block-style` | yes |
+| `border-block-color` | yes |
+| `border-block` | yes |
+| `border-block-start` | yes |
+| `border-block-start-style` | yes |
+| `border-block-start-color` | yes |
+| `border-block-end` | yes |
+| `border-block-end-style` | yes |
+| `border-block-end-color` | yes |
+| `border-inline-width` | yes |
+| `border-inline-style` | yes |
+| `border-inline-color` | yes |
+| `border-inline` | yes |
+| `border-inline-start` | yes |
+| `border-inline-start-style` | yes |
+| `border-inline-start-color` | yes |
+| `border-inline-end` | yes |
+| `border-inline-end-style` | yes |
+| `border-inline-end-color` | yes |
 | `border-spacing` | no (no effect) |
 | `width` | yes |
 | `height` | yes |
@@ -228,31 +228,31 @@ changed.
 
 | feature | supported |
 | --- | --- |
-| `margin-block-start` | no (no effect) |
-| `padding-block-start` | no (no effect) |
-| `inset-block-start` | no (no effect) |
-| `margin-block-end` | no (no effect) |
-| `padding-block-end` | no (no effect) |
-| `inset-block-end` | no (no effect) |
-| `margin-inline-start` | no (no effect) |
-| `padding-inline-start` | no (no effect) |
-| `inset-inline-start` | no (no effect) |
-| `margin-inline-end` | no (no effect) |
-| `padding-inline-end` | no (no effect) |
-| `inset-inline-end` | no (no effect) |
-| `margin-block` | no (no effect) |
-| `padding-block` | no (no effect) |
-| `inset-block` | no (no effect) |
-| `margin-inline` | no (no effect) |
-| `padding-inline` | no (no effect) |
-| `inset-inline` | no (no effect) |
+| `margin-block-start` | yes |
+| `padding-block-start` | yes |
+| `inset-block-start` | yes |
+| `margin-block-end` | yes |
+| `padding-block-end` | yes |
+| `inset-block-end` | yes |
+| `margin-inline-start` | yes |
+| `padding-inline-start` | yes |
+| `inset-inline-start` | yes |
+| `margin-inline-end` | yes |
+| `padding-inline-end` | yes |
+| `inset-inline-end` | yes |
+| `margin-block` | yes |
+| `padding-block` | yes |
+| `inset-block` | yes |
+| `margin-inline` | yes |
+| `padding-inline` | yes |
+| `inset-inline` | yes |
 | `inset` | yes |
-| `inline-size` | no (no effect) |
-| `block-size` | no (no effect) |
-| `min-inline-size` | no (no effect) |
-| `max-inline-size` | no (no effect) |
-| `min-block-size` | no (no effect) |
-| `max-block-size` | no (no effect) |
+| `inline-size` | yes |
+| `block-size` | yes |
+| `min-inline-size` | yes |
+| `max-inline-size` | yes |
+| `min-block-size` | yes |
+| `max-block-size` | yes |
 | `flex-flow` | no (no effect) |
 | `place-content` | no (no effect) |
 | `place-items` | no (no effect) |

--- a/scripts/support-matrix.ts
+++ b/scripts/support-matrix.ts
@@ -337,6 +337,9 @@ function generatedFeatures(): Record<string, Feature> {
 		};
 		out[`padding-${group}`] = {
 			value: physical === "left" || physical === "right" ? "3ch" : "2px",
+			// Padding on the END edge only moves cells inside a box whose
+			// width is stated, exactly as `padding-right` needs it to.
+			setup: physical === "right" ? NARROW : undefined,
 		};
 		out[`border-${group}-width`] = {
 			value: "1px",
@@ -349,7 +352,10 @@ function generatedFeatures(): Record<string, Feature> {
 	}
 	for (const axis of ["block", "inline"]) {
 		out[`margin-${axis}`] = {value: axis === "inline" ? "0 3ch" : "2px 0"};
-		out[`padding-${axis}`] = {value: axis === "inline" ? "0 3ch" : "2px 0"};
+		out[`padding-${axis}`] = {
+			value: axis === "inline" ? "0 3ch" : "2px 0",
+			setup: axis === "inline" ? NARROW : undefined,
+		};
 		out[`inset-${axis}`] = {
 			value: "2px",
 			setup: "#probe { position: absolute; }",

--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -82,18 +82,14 @@ function lineAlignOffset(
 	if (!container || containerWidth === undefined) return 0;
 	const align = getPropertyValue(container, "text-align");
 	if (align === "center") return Math.max(0, (containerWidth - lineWidth) / 2);
-	if (align === "right" || align === "end") {
-		return Math.max(0, containerWidth - lineWidth);
-	}
-	// `start` is the start of the READING direction, so an RTL paragraph with no
-	// text-align of its own begins at the right edge. Unset behaves as start.
-	if (
-		(align === "" || align === "start") &&
-		getPropertyValue(container, "direction") === "rtl"
-	) {
-		return Math.max(0, containerWidth - lineWidth);
-	}
-	return 0;
+	if (align === "right") return Math.max(0, containerWidth - lineWidth);
+	if (align === "left") return 0;
+	// `start` and `end` name the READING direction's ends, so they trade sides
+	// in an RTL paragraph: an undeclared alignment is `start`, which puts an
+	// RTL line at the right edge, and `end` puts it at the left.
+	const rtl = getPropertyValue(container, "direction") === "rtl";
+	const atRightEdge = align === "end" ? !rtl : rtl;
+	return atRightEdge ? Math.max(0, containerWidth - lineWidth) : 0;
 }
 
 /**

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -931,9 +931,45 @@ function evaluateCalc(body: string, context: LengthContext): CalcTerms | null {
 interface DeclarationBlock {
 	declarations: Record<string, string>;
 	important: Record<string, boolean>;
+	/**
+	 * Each declaration's position in the block, counting from the first. A
+	 * logical property and the physical property it maps to are two names for
+	 * one cascade slot, so which of them a block declares LAST decides the
+	 * value -- and only this says which that is.
+	 */
+	order: Record<string, number>;
 }
 
-const EMPTY_DECLARATIONS: DeclarationBlock = {declarations: {}, important: {}};
+const EMPTY_DECLARATIONS: DeclarationBlock = {
+	declarations: {},
+	important: {},
+	order: {},
+};
+
+/**
+ * Which of a cascade slot's names a block declares LAST at the given
+ * importance -- the declaration whose value the slot takes -- or null when it
+ * declares none of them. `accepts` rejects a flow-relative name that maps to
+ * the opposite physical edge under the element's direction.
+ */
+function declaredName(
+	block: DeclarationBlock,
+	names: readonly string[],
+	important: boolean,
+	accepts: (name: string) => boolean,
+): string | null {
+	let winner: string | null = null;
+	let winningOrder = -1;
+	for (const name of names) {
+		if (block.declarations[name] === undefined) continue;
+		if (Boolean(block.important[name]) !== important) continue;
+		const order = block.order[name] ?? 0;
+		if (order < winningOrder || !accepts(name)) continue;
+		winner = name;
+		winningOrder = order;
+	}
+	return winner;
+}
 
 /** The CSSOM shape a declaration block is read through: a rule's, or an element's. */
 interface DeclarationSource {
@@ -957,6 +993,94 @@ const EDGE_NAMES = ["top", "right", "bottom", "left"] as const;
 
 /** The components of a line shorthand, in the order its grammar writes them. */
 const LINE_COMPONENTS = ["width", "style", "color"] as const;
+
+/**
+ * Every flow-relative longhand and the physical longhand it maps to, one table
+ * per inline direction (css-logical-1 §2).
+ *
+ * This engine renders one writing mode -- `horizontal-tb`, the only one a
+ * terminal's row-major grid has -- so the block axis is always vertical and
+ * the inline axis always horizontal: block-start is the top edge, block-end
+ * the bottom, and `direction` alone decides which side the inline edges name.
+ * A `writing-mode` implementation would replace these two tables with four
+ * more; nothing else here would move.
+ */
+const LOGICAL_TO_PHYSICAL: Readonly<
+	Record<"ltr" | "rtl", Map<string, string>>
+> = {ltr: new Map(), rtl: new Map()};
+
+/**
+ * Each physical longhand and the flow-relative longhands that can name it --
+ * its block counterpart, or both inline ones, since which of those maps here
+ * is not known until an element states its direction.
+ */
+const PHYSICAL_TO_LOGICAL = new Map<string, readonly string[]>();
+
+{
+	const map = (logical: string, ltr: string, rtl = ltr) => {
+		LOGICAL_TO_PHYSICAL.ltr.set(logical, ltr);
+		LOGICAL_TO_PHYSICAL.rtl.set(logical, rtl);
+		for (const physical of ltr === rtl ? [ltr] : [ltr, rtl]) {
+			PHYSICAL_TO_LOGICAL.set(physical, [
+				...(PHYSICAL_TO_LOGICAL.get(physical) ?? []),
+				logical,
+			]);
+		}
+	};
+	for (const kind of ["margin", "padding"]) {
+		map(`${kind}-block-start`, `${kind}-top`);
+		map(`${kind}-block-end`, `${kind}-bottom`);
+		map(`${kind}-inline-start`, `${kind}-left`, `${kind}-right`);
+		map(`${kind}-inline-end`, `${kind}-right`, `${kind}-left`);
+	}
+	map("inset-block-start", "top");
+	map("inset-block-end", "bottom");
+	map("inset-inline-start", "left", "right");
+	map("inset-inline-end", "right", "left");
+	for (const component of LINE_COMPONENTS) {
+		map(`border-block-start-${component}`, `border-top-${component}`);
+		map(`border-block-end-${component}`, `border-bottom-${component}`);
+		map(
+			`border-inline-start-${component}`,
+			`border-left-${component}`,
+			`border-right-${component}`,
+		);
+		map(
+			`border-inline-end-${component}`,
+			`border-right-${component}`,
+			`border-left-${component}`,
+		);
+	}
+	// The flow-relative sizes name an axis and no edge, so `direction` does
+	// not reach them: only a vertical writing mode could.
+	for (const prefix of ["", "min-", "max-"]) {
+		map(`${prefix}block-size`, `${prefix}height`);
+		map(`${prefix}inline-size`, `${prefix}width`);
+	}
+}
+
+/** The physical longhand a flow-relative one names under `direction`, if it is one. */
+function physicalProperty(
+	property: string,
+	direction: string,
+): string | undefined {
+	return LOGICAL_TO_PHYSICAL[direction === "rtl" ? "rtl" : "ltr"].get(property);
+}
+
+/**
+ * The OTHER names of the cascade slot a longhand belongs to under `direction`:
+ * a flow-relative longhand's physical counterpart, or a physical longhand's
+ * flow-relative ones. Empty for a longhand that stands alone.
+ */
+function slotNames(property: string, direction: string): readonly string[] {
+	const physical = physicalProperty(property, direction);
+	if (physical) return [physical];
+	const logical = PHYSICAL_TO_LOGICAL.get(property);
+	if (!logical) return [];
+	return logical.filter(
+		(name) => physicalProperty(name, direction) === property,
+	);
+}
 
 /** The keywords every property accepts, whatever its own grammar. */
 const CSS_WIDE_KEYWORDS = new Set([
@@ -1019,11 +1143,15 @@ for (const [shorthand, all] of Object.entries(CSS_SHORTHANDS)) {
 		shorthand,
 		box
 			? "box"
-			: indexed.length === 12 &&
+			: // A width, a style and a color stated once for several sides:
+				// four for `border`, the axis's two for `border-block` and
+				// `border-inline`.
+				indexed.length >= 2 * LINE_COMPONENTS.length &&
 				  LINE_COMPONENTS.every(
 						(kind) =>
 							indexed.filter((longhand) => longhand.endsWith(`-${kind}`))
-								.length === 4,
+								.length ===
+							indexed.length / LINE_COMPONENTS.length,
 				  )
 				? "border"
 				: indexed.length === LINE_COMPONENTS.length &&
@@ -1040,7 +1168,9 @@ for (const [shorthand, all] of Object.entries(CSS_SHORTHANDS)) {
 /**
  * The shorthands a longhand belongs to, widest first: block serialization
  * prefers the shorthand covering the most declarations, and `all` -- covering
- * every longhand there is -- comes first of all.
+ * every longhand there is -- comes first of all. A vendor-prefixed shorthand
+ * comes last however wide it is: `-webkit-border-start` covers exactly the
+ * longhands `border-inline-start` does, and is not the name to write them as.
  */
 const LONGHAND_SHORTHANDS = new Map<string, readonly string[]>();
 {
@@ -1055,8 +1185,10 @@ const LONGHAND_SHORTHANDS = new Map<string, readonly string[]>();
 	for (const [longhand, shorthands] of byLonghand) {
 		shorthands.sort(
 			(a, b) =>
+				Number(a.startsWith("-")) - Number(b.startsWith("-")) ||
 				SHORTHAND_LONGHANDS.get(b)!.length -
-					SHORTHAND_LONGHANDS.get(a)!.length || (a < b ? -1 : 1),
+					SHORTHAND_LONGHANDS.get(a)!.length ||
+				(a < b ? -1 : 1),
 		);
 		LONGHAND_SHORTHANDS.set(longhand, shorthands);
 	}
@@ -1850,34 +1982,42 @@ export class CSSStyleDeclaration implements DeclarationSource {
 
 		const declarations: Record<string, string> = {};
 		const important: Record<string, boolean> = {};
+		const order: Record<string, number> = {};
 		const importantValues: Record<string, string> = {};
 		let undecomposed = false;
-		for (const entry of this.#declarations) {
+		this.#declarations.forEach((entry, index) => {
 			// An invalid declaration never enters the cascade: dropping it is
 			// what lets a lower-priority rule keep winning, as a browser does.
-			if (!isValidDeclaration(entry.name, entry.value)) continue;
+			if (!isValidDeclaration(entry.name, entry.value)) return;
 			declarations[entry.name] = entry.value;
+			order[entry.name] = index;
 			if (entry.important) {
 				important[entry.name] = true;
 				importantValues[entry.name] = entry.value;
 			}
 			if (SHORTHAND_LONGHANDS.has(entry.name)) undecomposed = true;
-		}
+		});
 
 		// The block holds longhands, which is what the cascade consults --
 		// except for a shorthand whose grammar this engine does not decompose,
 		// which reaches the cascade as whatever longhands it can name, its
-		// importance covering each of them.
+		// importance covering each of them. A longhand a shorthand states
+		// stands where the shorthand does.
 		if (undecomposed) {
 			for (const property of Object.keys(expandShorthands(importantValues))) {
 				important[property] = true;
 			}
+			this.#declarations.forEach((entry, index) => {
+				const expanded = expandShorthands({[entry.name]: entry.value});
+				for (const property in expanded) order[property] = index;
+			});
 			return (this.#block = {
 				declarations: expandShorthands(declarations),
 				important,
+				order,
 			});
 		}
-		return (this.#block = {declarations, important});
+		return (this.#block = {declarations, important, order});
 	}
 
 	get parentRule(): CSSRule | null {
@@ -5499,10 +5639,23 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 				? this.#shorthand(property, longhands, (longhand) =>
 						this.computedValueOf(longhand),
 					)
-				: this.#computed(property);
+				: // A flow-relative longhand shares its computed value with the
+					// physical longhand it maps to, so it is answered as that one.
+					this.#computed(this.#physicalOf(property));
 			this.#resolved.set(property, value);
 		}
 		return value;
+	}
+
+	/**
+	 * The name a longhand computes under: itself, or -- for a flow-relative
+	 * longhand -- the physical longhand this element's `direction` maps it to.
+	 */
+	#physicalOf(property: string): string {
+		if (!LOGICAL_TO_PHYSICAL.ltr.has(property)) return property;
+		return (
+			physicalProperty(property, this.computedValueOf("direction")) ?? property
+		);
 	}
 
 	/**
@@ -5924,14 +6077,42 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 	}
 
 	#resolvePropertyValueRaw(property: string): string {
+		// A physical property and the flow-relative properties that map to it
+		// are ONE cascade slot (css-logical-1 §2.1): every name in the slot
+		// computes to the value of the declaration that comes last in the
+		// cascade, whichever name that declaration used. Which flow-relative
+		// name maps here depends on the element's `direction`, so the slot's
+		// names are widened to both inline edges and narrowed by direction
+		// only once a block actually declares one of them.
+		const logical = PHYSICAL_TO_LOGICAL.get(property);
+		const names = logical ? [property, ...logical] : [property];
+		let direction: string | null = null;
+		const mapsHere = (name: string): boolean =>
+			name === property ||
+			physicalProperty(
+				name,
+				(direction ??= this.computedValueOf("direction")),
+			) === property;
+
 		const inline = this.#inlineDeclarations();
-		const inlineValue = inline.declarations[property]?.trim();
+		const inlineName = declaredName(inline, names, false, mapsHere);
+		const inlineValue = inlineName
+			? inline.declarations[inlineName].trim()
+			: undefined;
 		const inlineUsable = !!inlineValue && !INITIAL_KEYWORDS.has(inlineValue);
-		const inlineImportant = inlineUsable && !!inline.important[property];
+		const inlineImportantName = declaredName(inline, names, true, mapsHere);
+		const inlineImportantValue = inlineImportantName
+			? inline.declarations[inlineImportantName].trim()
+			: undefined;
+		const inlineImportant =
+			!!inlineImportantValue && !INITIAL_KEYWORDS.has(inlineImportantValue);
 
 		// `inherit` skips the rest of the cascade and goes straight to the parent's
 		// resolved value, regardless of whether this property normally inherits.
-		if (inlineUsable && inlineValue === "inherit") {
+		if (inlineImportant && inlineImportantValue === "inherit") {
+			return this.#resolveFromParent(property) ?? "";
+		}
+		if (!inlineImportant && inlineUsable && inlineValue === "inherit") {
 			return this.#resolveFromParent(property) ?? "";
 		}
 
@@ -5941,12 +6122,11 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 		let ruleValue: string | null = null;
 		let importantRuleValue: string | null = null;
 		for (const rule of this.#cssRules) {
-			const value = rule.declarations[property];
-			if (value === undefined) continue;
-			if (rule.important[property]) {
-				importantRuleValue = value;
-			} else {
-				ruleValue = value;
+			const name = declaredName(rule, names, false, mapsHere);
+			if (name !== null) ruleValue = rule.declarations[name];
+			const importantName = declaredName(rule, names, true, mapsHere);
+			if (importantName !== null) {
+				importantRuleValue = rule.declarations[importantName];
 			}
 		}
 
@@ -5958,12 +6138,12 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 			return INITIAL_KEYWORDS.has(value) ? null : value;
 		};
 
-		if (inlineImportant) return inlineValue;
+		if (inlineImportant) return inlineImportantValue!;
 		if (importantRuleValue) {
 			const resolved = declaredByRule(importantRuleValue);
 			if (resolved !== null) return resolved;
 		} else if (inlineUsable) {
-			return inlineValue;
+			return inlineValue!;
 		} else if (ruleValue) {
 			const resolved = declaredByRule(ruleValue);
 			if (resolved !== null) return resolved;
@@ -6040,6 +6220,9 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 		// is resolved from inside layout, which this would re-enter.
 		this.#manager?.flushStyle();
 		if (this.#stale || this.#epoch.value !== this.#seenEpoch) this.#refresh();
+		// A flow-relative longhand resolves as the physical longhand it maps
+		// to: same slot, same measurement, same answer.
+		property = this.#physicalOf(property);
 		if (this.#manager && USED_VALUE_PROPERTIES.has(property)) {
 			return this.#usedValue(property);
 		}
@@ -6925,6 +7108,8 @@ interface ParsedCSSRule {
 	declarations: Record<string, string>;
 	/** Properties declared `!important` in this rule. */
 	important: Record<string, boolean>;
+	/** Each declaration's position in the rule's block. See DeclarationBlock. */
+	order: Record<string, number>;
 	specificity: string; // Zero-padded string for lexicographic comparison
 	pseudoElement?: string;
 	/**
@@ -7812,17 +7997,10 @@ export class StyleManager {
 		// A rule's selector list is a set of selectors that share a block, and
 		// each is matched -- and weighed -- on its own. `#a::before, #b` is one
 		// pseudo-element rule and one ordinary rule, not one of either.
-		const {declarations, important} = styleRule.style.declarationBlock();
+		const block = styleRule.style.declarationBlock();
 		const namespaces = sheetNamespaces(styleRule.parentStyleSheet);
 		for (const selector of splitSelectorList(styleRule.selectorText)) {
-			this.#parseSelector(
-				selector,
-				declarations,
-				important,
-				scope,
-				uaOriginSheet,
-				namespaces,
-			);
+			this.#parseSelector(selector, block, scope, uaOriginSheet, namespaces);
 		}
 	}
 
@@ -7929,12 +8107,12 @@ export class StyleManager {
 
 	#parseSelector(
 		selector: string,
-		declarations: Record<string, string>,
-		important: Record<string, boolean>,
+		block: DeclarationBlock,
 		scope?: Node,
 		uaOriginSheet?: boolean,
 		sheetNamespaces: SelectorNamespaces = NO_NAMESPACES,
 	): void {
+		const {declarations, important, order} = block;
 		let namespace: string | null | undefined;
 		if (sheetNamespaces !== NO_NAMESPACES || selector.includes("|")) {
 			const resolved = selectorNamespace(selector, sheetNamespaces);
@@ -7990,6 +8168,7 @@ export class StyleManager {
 					selector,
 					declarations,
 					important,
+					order,
 					specificity,
 					scope,
 					host: {predicate, rest, child: Boolean(child)},
@@ -8019,6 +8198,7 @@ export class StyleManager {
 				subjectTag: selectorSubjectTag(baseSelector.trim()),
 				declarations,
 				important,
+				order,
 				specificity,
 				pseudoElement,
 				scope,
@@ -8035,6 +8215,7 @@ export class StyleManager {
 				subjectTag,
 				declarations,
 				important,
+				order,
 				specificity,
 				scope,
 				uaOrigin,
@@ -8226,10 +8407,31 @@ export class StyleManager {
 			return this.#ruleMatches(element, rule);
 		});
 
-		// Apply rules in cascade order
+		// Apply rules in cascade order. A pseudo-element's declarations are a
+		// flat record rather than a per-property cascade, so a flow-relative
+		// declaration fills BOTH names of its slot as it lands: the physical
+		// one everything downstream reads, and its own, which a later rule
+		// declaring either name overwrites in turn.
 		const computedStyle: Record<string, string> = {};
+		let direction: string | null = null;
 		for (const rule of matchingRules) {
-			Object.assign(computedStyle, rule.declarations);
+			const names = Object.keys(rule.declarations).sort(
+				(a, b) => (rule.order[a] ?? 0) - (rule.order[b] ?? 0),
+			);
+			for (const name of names) {
+				const value = rule.declarations[name];
+				computedStyle[name] = value;
+				if (
+					!LOGICAL_TO_PHYSICAL.ltr.has(name) &&
+					!PHYSICAL_TO_LOGICAL.has(name)
+				) {
+					continue;
+				}
+				direction ??= this.declarationFor(element).computedValueOf("direction");
+				for (const other of slotNames(name, direction)) {
+					computedStyle[other] = value;
+				}
+			}
 		}
 
 		return computedStyle;

--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -26,12 +26,20 @@ const BORDER_STYLE_KEYWORDS = new Set([
 ]);
 const LINE_WIDTH_KEYWORDS = new Set(["thin", "medium", "thick"]);
 const EDGES = ["top", "right", "bottom", "left"] as const;
+/** The two ends of a flow-relative axis, in the order a pair shorthand states them. */
+const AXIS_ENDS = ["start", "end"] as const;
 const LIST_STYLE_POSITIONS = new Set(["inside", "outside"]);
 
 /** CSS 1-4 value expansion: [all], [v h], [t h b], [t r b l]. */
 function perEdge(values: string[]): [string, string, string, string] {
 	const [a, b = a, c = a, d = b] = values;
 	return [a, b, c, d];
+}
+
+/** A flow-relative pair's two values: [both] or [start end]. */
+function perEnd(values: string[]): [string, string] {
+	const [a, b = a] = values;
+	return [a, b];
 }
 
 /**
@@ -254,6 +262,62 @@ export function expandShorthands(
 				out["outline-width"] = width ?? "medium";
 				out["outline-style"] = lineStyle ?? "none";
 				if (color) out["outline-color"] = color;
+				break;
+			}
+			// The flow-relative pairs (css-logical-1 §4): one value for both
+			// ends of the axis, or one for each. They state their longhands
+			// and, like `margin` and `padding`, are serialized back from them.
+			case "margin-block":
+			case "margin-inline":
+			case "padding-block":
+			case "padding-inline":
+			case "inset-block":
+			case "inset-inline": {
+				const axis = property.slice(property.lastIndexOf("-") + 1);
+				const kind = property.slice(0, property.lastIndexOf("-"));
+				const ends = perEnd(values);
+				AXIS_ENDS.forEach((end, i) => {
+					out[`${kind}-${axis}-${end}`] = ends[i];
+				});
+				continue;
+			}
+			// `border-block` / `border-inline`: one line drawn on both ends of
+			// the axis.
+			case "border-block":
+			case "border-inline": {
+				const axis = property.slice("border-".length);
+				const {width, lineStyle, color} = splitLineValue(value);
+				for (const end of AXIS_ENDS) {
+					out[`border-${axis}-${end}-width`] = width ?? "medium";
+					out[`border-${axis}-${end}-style`] = lineStyle ?? "none";
+					if (color) out[`border-${axis}-${end}-color`] = color;
+				}
+				break;
+			}
+			// One flow-relative edge's line: `border-inline-start: 1px solid`.
+			case "border-block-start":
+			case "border-block-end":
+			case "border-inline-start":
+			case "border-inline-end": {
+				const edge = property.slice("border-".length);
+				const {width, lineStyle, color} = splitLineValue(value);
+				out[`border-${edge}-width`] = width ?? "medium";
+				out[`border-${edge}-style`] = lineStyle ?? "none";
+				if (color) out[`border-${edge}-color`] = color;
+				break;
+			}
+			// One line component across an axis: `border-inline-width: 1px 2px`.
+			case "border-block-width":
+			case "border-block-style":
+			case "border-block-color":
+			case "border-inline-width":
+			case "border-inline-style":
+			case "border-inline-color": {
+				const [, axis, kind] = property.split("-");
+				const ends = perEnd(values);
+				AXIS_ENDS.forEach((end, i) => {
+					out[`border-${axis}-${end}-${kind}`] = ends[i];
+				});
 				break;
 			}
 			case "padding":

--- a/tests/logical-properties.test.ts
+++ b/tests/logical-properties.test.ts
@@ -1,0 +1,338 @@
+/**
+ * CSS logical properties (css-logical-1): the flow-relative spelling of the
+ * box model.
+ *
+ * Two things are load-bearing here. A logical property and the physical
+ * property it maps to are ONE cascade slot -- `margin-left` then
+ * `margin-inline-start` is 2px in LTR, the same pair reversed is 1px -- and
+ * the mapping is read off the element's `direction`, so the same declaration
+ * paints the left edge of an LTR box and the right edge of an RTL one.
+ */
+
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+function makeDOM(html = "", cols = 40, rows = 10) {
+	const terminal = new MockProcess({cols, rows});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = html;
+	return {terminal, dom};
+}
+
+/** One element's computed values, after a frame. */
+async function computed(html: string, selector = "#t") {
+	const {terminal, dom} = makeDOM(html);
+	await nextFrame(dom);
+	const element = dom.document.querySelector(selector)!;
+	const style = dom.window.getComputedStyle(element);
+	return {
+		style,
+		of: (property: string) => style.getPropertyValue(property),
+		rect: element.getBoundingClientRect(),
+		text: terminal.getVisibleText(),
+		dom,
+	};
+}
+
+/** A detached declaration block, for the CSSOM half. */
+function block() {
+	const {dom} = makeDOM();
+	return dom.document.createElement("div").style;
+}
+
+// --- CSSOM: shorthands, longhands and serialization ------------------------
+
+test("margin-inline expands to its longhands and serializes back", () => {
+	const style = block();
+	style.cssText = "margin-inline: 1px 2px";
+	expect([...style]).toEqual(["margin-inline-start", "margin-inline-end"]);
+	expect(style.getPropertyValue("margin-inline-start")).toBe("1px");
+	expect(style.getPropertyValue("margin-inline-end")).toBe("2px");
+	expect(style.getPropertyValue("margin-inline")).toBe("1px 2px");
+	expect(style.cssText).toBe("margin-inline: 1px 2px;");
+});
+
+test("a flow-relative pair collapses when both ends agree", () => {
+	const style = block();
+	style.cssText = "padding-block: 3px";
+	expect(style.getPropertyValue("padding-block-start")).toBe("3px");
+	expect(style.getPropertyValue("padding-block-end")).toBe("3px");
+	expect(style.cssText).toBe("padding-block: 3px;");
+});
+
+test("inset-inline and inset-block round-trip through their longhands", () => {
+	const style = block();
+	style.cssText = "inset-inline: 1px 2px; inset-block: 3px";
+	expect(style.getPropertyValue("inset-inline-start")).toBe("1px");
+	expect(style.getPropertyValue("inset-inline-end")).toBe("2px");
+	expect(style.getPropertyValue("inset-block-start")).toBe("3px");
+	expect(style.getPropertyValue("inset-block-end")).toBe("3px");
+	expect(style.cssText).toBe("inset-inline: 1px 2px; inset-block: 3px;");
+});
+
+test("inset states all four physical offsets", () => {
+	const style = block();
+	style.cssText = "inset: 1px 2px";
+	expect(style.getPropertyValue("top")).toBe("1px");
+	expect(style.getPropertyValue("right")).toBe("2px");
+	expect(style.getPropertyValue("bottom")).toBe("1px");
+	expect(style.getPropertyValue("left")).toBe("2px");
+	expect(style.cssText).toBe("inset: 1px 2px;");
+});
+
+test("border-inline-start expands to width, style and color", () => {
+	const style = block();
+	style.cssText = "border-inline-start: 1px solid red";
+	expect(style.getPropertyValue("border-inline-start-width")).toBe("1px");
+	expect(style.getPropertyValue("border-inline-start-style")).toBe("solid");
+	expect(style.getPropertyValue("border-inline-start-color")).toBe("red");
+	expect(style.cssText).toBe("border-inline-start: 1px solid red;");
+});
+
+test("border-inline draws both edges of the axis", () => {
+	const style = block();
+	style.cssText = "border-inline: 2px dashed";
+	expect(style.getPropertyValue("border-inline-start-style")).toBe("dashed");
+	expect(style.getPropertyValue("border-inline-end-width")).toBe("2px");
+	expect(style.getPropertyValue("border-inline")).toBe("2px dashed");
+	expect(style.cssText).toBe("border-inline: 2px dashed;");
+});
+
+test("border-block-width states one component across the axis", () => {
+	const style = block();
+	style.cssText = "border-block-width: 1px 2px";
+	expect(style.getPropertyValue("border-block-start-width")).toBe("1px");
+	expect(style.getPropertyValue("border-block-end-width")).toBe("2px");
+	expect(style.cssText).toBe("border-block-width: 1px 2px;");
+});
+
+test("the flow-relative sizes are longhands of their own", () => {
+	const style = block();
+	style.cssText =
+		"inline-size: 10px; block-size: 4px; min-inline-size: 2px; max-block-size: 8px";
+	expect(style.getPropertyValue("inline-size")).toBe("10px");
+	expect(style.getPropertyValue("block-size")).toBe("4px");
+	expect(style.getPropertyValue("min-inline-size")).toBe("2px");
+	expect(style.getPropertyValue("max-block-size")).toBe("8px");
+	expect(style.cssText).toBe(
+		"inline-size: 10px; block-size: 4px; min-inline-size: 2px; max-block-size: 8px;",
+	);
+});
+
+test("the IDL attribute reflects a flow-relative longhand", () => {
+	const style = block();
+	style.marginInlineStart = "4px";
+	expect(style.getPropertyValue("margin-inline-start")).toBe("4px");
+	expect(style.cssText).toBe("margin-inline-start: 4px;");
+	style.setProperty("inline-size", "6px");
+	expect(style.inlineSize).toBe("6px");
+});
+
+// --- Computed values: one slot, two names ---------------------------------
+
+test("a logical property computes to the same value as its physical name", async () => {
+	const {of} = await computed(
+		`<div id="t" style="margin-inline-start: 2px; margin-block-end: 3px; padding-inline-end: 1px; inline-size: 9px; block-size: 4px"></div>`,
+	);
+	expect(of("margin-left")).toBe("2px");
+	expect(of("margin-inline-start")).toBe("2px");
+	expect(of("margin-bottom")).toBe("3px");
+	expect(of("margin-block-end")).toBe("3px");
+	expect(of("padding-right")).toBe("1px");
+	expect(of("padding-inline-end")).toBe("1px");
+	expect(of("width")).toBe("9px");
+	expect(of("inline-size")).toBe("9px");
+	expect(of("height")).toBe("4px");
+	expect(of("block-size")).toBe("4px");
+});
+
+test("a physical declaration answers under the logical name too", async () => {
+	const {of} = await computed(
+		`<div id="t" style="margin-left: 5px; border-top: 1px solid red"></div>`,
+	);
+	expect(of("margin-inline-start")).toBe("5px");
+	expect(of("border-block-start-width")).toBe("1px");
+	expect(of("border-block-start-style")).toBe("solid");
+	expect(of("border-block-start-color")).toBe("rgb(255, 0, 0)");
+});
+
+test("the later declaration wins the slot: physical then logical", async () => {
+	const {of} = await computed(
+		`<style>#t { margin-left: 1px; margin-inline-start: 2px }</style><div id="t"></div>`,
+	);
+	expect(of("margin-left")).toBe("2px");
+	expect(of("margin-inline-start")).toBe("2px");
+});
+
+test("the later declaration wins the slot: logical then physical", async () => {
+	const {of} = await computed(
+		`<style>#t { margin-inline-start: 2px; margin-left: 1px }</style><div id="t"></div>`,
+	);
+	expect(of("margin-left")).toBe("1px");
+	expect(of("margin-inline-start")).toBe("1px");
+});
+
+test("a property written through the IDL takes the slot from an earlier one", async () => {
+	const {dom} = makeDOM(`<div id="t"></div>`);
+	await nextFrame(dom);
+	const element = dom.document.getElementById("t")!;
+	element.style.marginInlineStart = "2px";
+	element.style.marginLeft = "1px";
+	expect(dom.window.getComputedStyle(element).marginInlineStart).toBe("1px");
+	element.style.marginInlineStart = "3px";
+	expect(dom.window.getComputedStyle(element).marginLeft).toBe("3px");
+	dom.dispose();
+});
+
+test("a computed style reports both names of the slot", async () => {
+	const {style} = await computed(
+		`<div id="t" style="margin-inline-start: 2px"></div>`,
+	);
+	const names = [...style];
+	expect(names).toContain("margin-inline-start");
+	expect(names).toContain("margin-left");
+	expect(style.marginInlineStart).toBe(style.marginLeft);
+});
+
+test("cascade order decides the slot across rules, not property kind", async () => {
+	const {of} = await computed(
+		`<style>.a { margin-inline-start: 2px } .a { margin-left: 1px }</style><div id="t" class="a"></div>`,
+	);
+	expect(of("margin-left")).toBe("1px");
+});
+
+test("an !important physical declaration beats a later logical one", async () => {
+	const {of} = await computed(
+		`<style>#t { margin-left: 1px !important; margin-inline-start: 2px }</style><div id="t"></div>`,
+	);
+	expect(of("margin-left")).toBe("1px");
+	expect(of("margin-inline-start")).toBe("1px");
+});
+
+test("specificity outranks source order for the shared slot", async () => {
+	const {of} = await computed(
+		`<style>#t { margin-inline-start: 2px } div { margin-left: 1px }</style><div id="t"></div>`,
+	);
+	expect(of("margin-left")).toBe("2px");
+});
+
+test("under direction:rtl the inline slot is the right edge", async () => {
+	const {of} = await computed(
+		`<style>#t { direction: rtl; margin-left: 1px; margin-inline-start: 2px }</style><div id="t"></div>`,
+	);
+	// margin-inline-start names margin-right here, so the two declarations are
+	// different slots and neither overrides the other.
+	expect(of("margin-right")).toBe("2px");
+	expect(of("margin-left")).toBe("1px");
+	expect(of("margin-inline-start")).toBe("2px");
+	expect(of("margin-inline-end")).toBe("1px");
+});
+
+test("direction:rtl leaves the block axis where it was", async () => {
+	const {of} = await computed(
+		`<style>#t { direction: rtl; margin-block-start: 2px }</style><div id="t"></div>`,
+	);
+	expect(of("margin-top")).toBe("2px");
+	expect(of("margin-bottom")).toBe("0px");
+});
+
+test("the flow-relative sizes ignore direction", async () => {
+	const {of} = await computed(
+		`<div id="t" style="direction: rtl; inline-size: 9px; block-size: 4px"></div>`,
+	);
+	expect(of("width")).toBe("9px");
+	expect(of("height")).toBe("4px");
+});
+
+// --- Layout: the edge a flow-relative declaration actually moves -----------
+
+test("margin-inline-start indents from the left in ltr", async () => {
+	const {rect, text} = await computed(
+		`<div id="t" style="margin-inline-start: 4px; width: 10px">hi</div>`,
+	);
+	expect(rect.left).toBe(4);
+	expect(text.split("\n")[0]).toBe("    hi");
+});
+
+test("margin-inline-end indents from the left in rtl", async () => {
+	const start = await computed(
+		`<div style="direction: rtl; width: 20px"><div id="t" style="margin-inline-start: 4px; width: 10px">hi</div></div>`,
+	);
+	// The start edge is the right one here, so the margin holds the box off
+	// the far side of the containing block and its left edge does not move.
+	expect(start.of("margin-right")).toBe("4px");
+	expect(start.rect.left).toBe(0);
+	// The end edge is the left one, and a box indented from it does move.
+	const end = await computed(
+		`<div style="direction: rtl; width: 20px"><div id="t" style="margin-inline-end: 4px; width: 10px">hi</div></div>`,
+	);
+	expect(end.of("margin-left")).toBe("4px");
+	expect(end.rect.left).toBe(4);
+});
+
+test("padding-inline-start pushes content off the correct edge", async () => {
+	const ltr = await computed(
+		`<div id="t" style="padding-inline-start: 3px; width: 12px">hi</div>`,
+	);
+	expect(ltr.text.split("\n")[0]).toBe("   hi");
+	const rtl = await computed(
+		`<div id="t" style="direction: rtl; padding-inline-start: 3px; width: 12px">hi</div>`,
+	);
+	// RTL puts the start edge on the right, and the line reads from it.
+	expect(rtl.text.split("\n")[0]).toBe("       hi");
+});
+
+test("border-inline-start draws the left edge in ltr and the right in rtl", async () => {
+	const ltr = await computed(
+		`<div id="t" style="border-inline-start: 1px solid; width: 6px">x</div>`,
+	);
+	expect(ltr.text.split("\n")[0]).toBe("│x");
+	const rtl = await computed(
+		`<div id="t" style="direction: rtl; border-inline-start: 1px solid; width: 6px">x</div>`,
+	);
+	expect(rtl.text.split("\n")[0]).toBe("    x│");
+});
+
+test("inset-inline-start offsets a positioned box off the correct edge", async () => {
+	const ltr = await computed(
+		`<div style="position: relative; width: 20px; height: 3px"><div id="t" style="position: absolute; inset-inline-start: 5px; width: 4px">x</div></div>`,
+	);
+	expect(ltr.rect.left).toBe(5);
+	const rtl = await computed(
+		`<div style="direction: rtl; position: relative; width: 20px; height: 3px"><div id="t" style="position: absolute; inset-inline-start: 5px; width: 4px">x</div></div>`,
+	);
+	expect(rtl.rect.right).toBe(15);
+});
+
+test("inline-size and block-size size the box", async () => {
+	const {rect} = await computed(
+		`<div id="t" style="inline-size: 7px; block-size: 3px"></div>`,
+	);
+	expect(rect.width).toBe(7);
+	expect(rect.height).toBe(3);
+});
+
+// --- text-align: start and end --------------------------------------------
+
+test("text-align:start is the left edge in ltr and the right in rtl", async () => {
+	const ltr = await computed(
+		`<div id="t" style="text-align: start; width: 10px">ab</div>`,
+	);
+	expect(ltr.text.split("\n")[0]).toBe("ab");
+	const rtl = await computed(
+		`<div id="t" style="direction: rtl; text-align: start; width: 10px">ab</div>`,
+	);
+	expect(rtl.text.split("\n")[0]).toBe("        ab");
+});
+
+test("text-align:end is the right edge in ltr and the left in rtl", async () => {
+	const ltr = await computed(
+		`<div id="t" style="text-align: end; width: 10px">ab</div>`,
+	);
+	expect(ltr.text.split("\n")[0]).toBe("        ab");
+	const rtl = await computed(
+		`<div id="t" style="direction: rtl; text-align: end; width: 10px">ab</div>`,
+	);
+	expect(rtl.text.split("\n")[0]).toBe("ab");
+});


### PR DESCRIPTION
Implements the css-logical-1 flow-relative properties: `margin-block-*`/`margin-inline-*` and `padding-*` equivalents with their pair shorthands, `inset-block-*`/`inset-inline-*` and shorthands, `border-block-*`/`border-inline-*` (width/style/color longhands, per-edge line shorthands, per-component pair shorthands), `block-size`/`inline-size` with `min-`/`max-` variants, and `text-align: start`/`end`.

Mechanism: logical properties are not parse-time aliases. A physical longhand and the logical names that map to it form one cascade slot resolved by declaration position — `margin-left: 1px; margin-inline-start: 2px` computes to 2px in LTR and the reversed order computes to 1px. Importance tiers stay separate (`margin-left: 1px !important` beats a later non-important `margin-inline-start`). Reads of a logical name delegate to the physical name, so `getComputedStyle` reports both forms and layout continues to read physical names only.

Mapping assumes horizontal-tb (`writing-mode` is unimplemented): block = vertical, inline = horizontal, `direction` flips the inline edges. Stated at the mapping tables; a `writing-mode` implementation replaces the two tables with four.

Also fixed: `text-align: end` previously always meant the right edge; it now maps to the left edge under `direction: rtl`.

Excluded, with reasons in the diff: logical corner radii (no per-corner physical longhands exist to map onto until border-radius merges), `-webkit-border-start/-end` aliases (non-standard, left inert), and logical values for `float`/`clear`/`caption-side`/`resize` (their physical bases are unimplemented). Not implemented: CSSOM's logical-property-group ordering rule for `cssText` serialization (a pre-existing failing WPT subtest; no regression).

Tests: 29 cases in `tests/logical-properties.test.ts` — serialization round-trips per family, computed-value equality in both directions, cascade interleaving in both orders (across rules, with `!important`, with specificity, under RTL), and layout assertions for each family in LTR and RTL. `COMPATIBILITY.md` (generated by probing) goes from 109 to 157 supported properties, all 48 new rows the logical family, no regressions. WPT css/cssom results unchanged from main. Full suite passes: node 1153, bun 1178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
