### PR TITLE
Remove Buffer from the engine

### DIFF
--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -50,6 +50,26 @@ import {
 // coalesce the burst of SIGWINCHes a drag fires, short enough to feel immediate.
 const RESIZE_DEBOUNCE_MS = 40;
 
+const BASE64_ALPHABET =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/** UTF-8 base64 of a string, the payload OSC 52 carries to the clipboard. */
+function base64OfText(text: string): string {
+	const bytes = new TextEncoder().encode(text);
+	let out = "";
+	for (let i = 0; i < bytes.length; i += 3) {
+		const a = bytes[i];
+		const b = i + 1 < bytes.length ? bytes[i + 1] : 0;
+		const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
+		out += BASE64_ALPHABET[a >> 2];
+		out += BASE64_ALPHABET[((a & 3) << 4) | (b >> 4)];
+		out +=
+			i + 1 < bytes.length ? BASE64_ALPHABET[((b & 15) << 2) | (c >> 6)] : "=";
+		out += i + 2 < bytes.length ? BASE64_ALPHABET[c & 63] : "=";
+	}
+	return out;
+}
+
 // The built-in tags that upgrade to a UA widget on connect.
 const UPGRADEABLE_CONTROLS = new Set([
 	"INPUT",
@@ -1009,7 +1029,7 @@ export class TermDOM {
 						);
 					}
 					return termDOM.#session.write(
-						`\x1b]52;c;${Buffer.from(String(text), "utf8").toString("base64")}\x07`,
+						`\x1b]52;c;${base64OfText(String(text))}\x07`,
 					);
 				},
 				readText: (): Promise<string> =>
@@ -1665,7 +1685,7 @@ export class TermDOM {
 					if (this.#mouseCaptureYielded) {
 						this.#reclaimMouseCapture();
 					}
-					this.#dispatchGlobalKeyboardEvent(Buffer.from(keyInput));
+					this.#dispatchGlobalKeyboardEvent(keyInput);
 				},
 				onMouse: (button, x, y, release) => {
 					this.#inputGeneration++;
@@ -2731,14 +2751,12 @@ export class TermDOM {
 		);
 	}
 
-	#dispatchGlobalKeyboardEvent(chunk: Buffer): void {
-		const key = chunk.toString("utf8");
-
+	#dispatchGlobalKeyboardEvent(key: string): void {
 		// Tokenize multi-key chunks and dispatch each token on its own.
 		const tokens = Array.from(tokenizeInput(key));
 		if (tokens.length > 1) {
 			for (const token of tokens) {
-				this.#dispatchGlobalKeyboardEvent(Buffer.from(token));
+				this.#dispatchGlobalKeyboardEvent(token);
 			}
 			return;
 		}

--- a/src/internal/terminalsession.ts
+++ b/src/internal/terminalsession.ts
@@ -79,7 +79,7 @@ export interface TerminalTransport {
 export interface TTYWriteStream {
 	write(
 		chunk: any,
-		encoding?: BufferEncoding | ((error?: Error) => void),
+		encoding?: string | ((error?: Error) => void),
 		callback?: (error?: Error) => void,
 	): boolean;
 	columns: number;
@@ -89,10 +89,13 @@ export interface TTYWriteStream {
 
 export interface TTYReadStream {
 	isTTY: boolean;
-	on(event: "data", listener: (chunk: string | Buffer) => void): unknown;
+	on(
+		event: "data",
+		listener: (chunk: string | Uint8Array | ArrayBuffer) => void,
+	): unknown;
 	removeListener?(
 		event: "data",
-		listener: (chunk: string | Buffer) => void,
+		listener: (chunk: string | Uint8Array | ArrayBuffer) => void,
 	): unknown;
 	setRawMode?(mode: boolean): this;
 	resume(): this;
@@ -190,7 +193,9 @@ export function transportFromProcess(
 	});
 
 	let engaged = false;
-	let dataListener: ((chunk: string | Buffer) => void) | null = null;
+	let dataListener:
+		| ((chunk: string | Uint8Array | ArrayBuffer) => void)
+		| null = null;
 	const signalListeners: Array<[ProcessSignal, () => void]> = [];
 
 	const disengage = () => {
@@ -224,9 +229,14 @@ export function transportFromProcess(
 				stdin.setRawMode?.(true);
 				stdin.resume();
 				stdin.setEncoding?.("utf8");
-				dataListener = (chunk: string | Buffer) => {
+				// Hosts without setEncoding deliver bytes; a streaming decoder
+				// keeps a code point split across two chunks whole.
+				const decoder = new TextDecoder();
+				dataListener = (chunk: string | Uint8Array | ArrayBuffer) => {
 					controller.enqueue(
-						typeof chunk === "string" ? chunk : chunk.toString("utf8"),
+						typeof chunk === "string"
+							? chunk
+							: decoder.decode(chunk, {stream: true}),
 					);
 				};
 				stdin.on("data", dataListener);


### PR DESCRIPTION
Removes the three `Buffer` uses in `termdom.ts`, found while building the browser playground (#34): they were the only reason a browser bundle needed a `Buffer` polyfill.

- The keystroke path wrapped a string in `Buffer.from()` only for the dispatcher to call `.toString("utf8")` on it. `onKeys` delivers a string; `#dispatchGlobalKeyboardEvent` now takes one.
- The OSC 52 clipboard payload now encodes through `TextEncoder` and a base64 table instead of `Buffer.from(...).toString("base64")`. The encoder was differential-tested against `Buffer`'s output for empty, ASCII, CJK, emoji, and 1000-character inputs — byte-identical.

Node types remain only in `terminalsession.ts`, which is the transport quarantine.

Full suite passes: node 1124, bun 1149 (includes the existing OSC 52 copy test in `mouse.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD

Follow-up commit: `ProcessLike`'s chunk type widens to `string | Uint8Array | ArrayBuffer` (Buffer already satisfies it) and the write encoding to plain `string`, so no public name resolves through `@types/node`; byte chunks decode through one streaming `TextDecoder`, which also fixes a code point torn across two chunks.
