### PR TITLE
Fix preserved-space collapsing at inline boundaries

### DIFF
--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -5374,17 +5374,22 @@ export class LayoutEngine {
 				let processed = rendered.text;
 				let dataOffsets = rendered.offsets;
 
-				// Handle boundary whitespace between adjacent text nodes
-				if (leafIndex > 0 && processed.length > 0) {
+				// Collapse boundary whitespace between adjacent text nodes -- but
+				// only where this leaf's white-space collapses at all. Under the
+				// preserving values every space is content, and a run of
+				// single-space spans is as wide as it has spans.
+				if (
+					leafIndex > 0 &&
+					processed.length > 0 &&
+					!preservesSpaces(leafWhiteSpace)
+				) {
 					const prevItem = items[items.length - 1];
 					if (prevItem && prevItem.leafNode.type === "text") {
-						// Check if we have adjacent spaces at the boundary
 						const prevEndsWithSpace =
 							text.length > 0 && text[text.length - 1] === " ";
 						const thisStartsWithSpace = processed[0] === " ";
 
 						if (prevEndsWithSpace && thisStartsWithSpace) {
-							// Remove the leading space to avoid double spaces at boundaries
 							processed = processed.substring(1);
 							dataOffsets = shiftRenderedOffsets(dataOffsets, 1);
 						}

--- a/tests/whitespace.test.ts
+++ b/tests/whitespace.test.ts
@@ -638,3 +638,22 @@ test("a preserved space is content, and keeps its line", async () => {
 
 	dom.dispose();
 });
+
+test("preserved spaces survive inline element boundaries", async () => {
+	// A bar chart's empty cells are single-space spans: under `pre` each is
+	// one cell, and a run of them is as wide as it has spans.
+	const terminal = new MockProcess({cols: 40, rows: 6});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.attach();
+	dom.document.body.innerHTML =
+		'<div style="white-space: pre">|<span> </span><span> </span><span> </span>X</div>' +
+		'<div style="white-space: pre">|A<span> </span>B</div>' +
+		"<div>|<span> </span><span> </span>collapsed</div>";
+	await nextFrame(dom);
+	const lines = terminal.getVisibleText().split("\n");
+	expect(lines[0]).toContain("|   X");
+	expect(lines[1]).toContain("|A B");
+	// Under collapsing white-space the boundary rule still merges them.
+	expect(lines[2]).toContain("| collapsed");
+	dom.dispose();
+});


### PR DESCRIPTION
Under `white-space: pre`/`pre-wrap`/`break-spaces`, a space that begins a text leaf was still merged with a space ending the previous leaf — the boundary-dedup in run assembly never consulted the white-space value. A run of single-space `<span>`s (a bar chart's empty columns) collapsed pairwise into one cell, compacting chart rows leftward.

Fix: the boundary merge applies only when the leaf's white-space collapses spaces (`preservesSpaces` guard). One condition in `layout.ts`; no behavior change for collapsing values, covered by the existing boundary expectations.

Regression test in `tests/whitespace.test.ts` (three space-spans stay three cells under `pre`, single boundary space still merges under `normal`) — fails on main, passes here. Full suite: node 1125, bun 1150.

Found via the weather example's hourly chart rendering compacted (reported with a screenshot); the same repro distilled to three divs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD