### PR TITLE
Implement the Popover API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ setInterval(() => {
   prints the selection to stdout.
 - [`weather.ts`](./examples/weather.ts) — an emoji forecast from
   Open-Meteo, with a city search and flexbox day cards.
+- [`popover.ts`](./examples/popover.ts) — a menu bar where every menu is
+  a declarative popover; open, dismiss and stacking are the platform's.
 - [`solitaire.ts`](./examples/solitaire.ts) — the Klondike solitaire above,
   with seeded deals playable by keyboard or mouse.
 

--- a/docs/dom-conformance.md
+++ b/docs/dom-conformance.md
@@ -467,7 +467,7 @@ The event handler IDL attributes -- onclick and its ninety-odd siblings -- are h
 
 ### the focus members, and every subtest that calls focus() or blur()
 
-`focus()`, `blur()` and `document.activeElement` are absent. A focusable area is defined over elements that are being rendered, and nothing is rendered here; a focus() that could never focus anything is not the method the specification defines. The same holds for the popover members, whose showing puts an element in the top layer.
+`focus()`, `blur()` and `document.activeElement` are absent. A focusable area is defined over elements that are being rendered, and nothing is rendered here; a focus() that could never focus anything is not the method the specification defines.
 
 ### SVG and MathML elements
 

--- a/examples/popover.ts
+++ b/examples/popover.ts
@@ -1,0 +1,108 @@
+// A menu bar built on the Popover API
+//
+//   node examples/popover.ts
+//
+//   The menus are declarative popovers: each menu-bar button carries
+//   popovertarget, so opening, toggling, light dismiss and Escape are the
+//   platform's. The only JavaScript here is what the menu items do.
+//
+//   Tab    moves through the menu buttons and the editor
+//   Enter  opens the focused menu, activates the focused item
+//   Escape closes the open menu; clicking anywhere else does too
+//   The saved toast is popover="manual": clicks and Escape cannot
+//   dismiss it, and it hides itself.
+import {TermDOM} from "@b9g/termdom";
+
+const term = new TermDOM();
+term.attach();
+const {document} = term;
+
+const style = document.createElement("style");
+style.textContent = `
+	.menubar { display: flex; flex-direction: row; background-color: #1d3557; }
+	.menubar button { border: none; padding: 0 1ch; background-color: inherit;
+	                  color: #cfe8d8; }
+	.menubar button::before, .menubar button::after,
+	.menu button::before, .menu button::after { content: ""; }
+	.menubar button:focus { background-color: #5fafff; color: black; }
+	.menu { position: fixed; inset: auto; top: 1px; margin: 0; padding: 0;
+	        border: 1px solid #5fafff; background-color: #0b2135; }
+	.menu button { display: block; border: none; background-color: inherit;
+	               color: #cfe8d8; padding: 0 1ch; width: 16ch;
+	               text-align: left; }
+	.menu button:focus { background-color: #5fafff; color: black; }
+	#file-menu { left: 0; }
+	#edit-menu { left: 7ch; }
+	#help-menu { left: 14ch; }
+	#about { padding: 1px 2ch; border-color: #ffd75f; }
+	#about .title { color: #ffd75f; font-weight: bold; }
+	#saved { position: fixed; inset: auto; top: 1px; right: 1ch; margin: 0;
+	         border-color: #87d787; color: #87d787; padding: 0 1ch; }
+	textarea { border: none; padding: 1px 1ch; width: 100%; height: 12px; }
+	.status { color: #666666; }
+`;
+document.head.appendChild(style);
+
+document.body.innerHTML = `
+	<div class="menubar">
+		<button popovertarget="file-menu">File</button>
+		<button popovertarget="edit-menu">Edit</button>
+		<button popovertarget="help-menu">Help</button>
+	</div>
+	<div id="file-menu" class="menu" popover>
+		<button data-action="new">New</button>
+		<button data-action="save">Save</button>
+		<button data-action="quit">Quit</button>
+	</div>
+	<div id="edit-menu" class="menu" popover>
+		<button data-action="upper">Uppercase</button>
+		<button data-action="lower">Lowercase</button>
+		<button data-action="clear">Clear</button>
+	</div>
+	<div id="help-menu" class="menu" popover>
+		<button popovertarget="about">About</button>
+	</div>
+	<div id="about" popover>
+		<div class="title">popover.ts</div>
+		<div>Menus, a toast and this box are popovers.</div>
+		<div>This one stacked on the Help menu.</div>
+	</div>
+	<div id="saved" popover="manual">Saved.</div>
+	<textarea placeholder="type here, then explore the menus…"></textarea>
+	<div class="status"> Tab to the menu bar · Enter opens · Escape or a click closes</div>
+`;
+
+const editor = document.querySelector("textarea") as HTMLTextAreaElement;
+const saved = document.getElementById("saved")!;
+
+// The menus open, close, stack and dismiss on their own. Actions are the
+// one thing left to write.
+document.addEventListener("click", (event) => {
+	const item = (event.target as Element | null)?.closest?.("[data-action]");
+	if (!item) return;
+	(item.closest("[popover]") as HTMLElement).hidePopover();
+	switch (item.getAttribute("data-action")) {
+		case "new":
+			editor.value = "";
+			break;
+		case "save":
+			saved.showPopover();
+			setTimeout(() => saved.hidePopover(), 1500);
+			break;
+		case "quit":
+			term.window.close();
+			break;
+		case "upper":
+			editor.value = editor.value.toUpperCase();
+			break;
+		case "lower":
+			editor.value = editor.value.toLowerCase();
+			break;
+		case "clear":
+			editor.value = "";
+			break;
+	}
+	editor.focus();
+});
+
+editor.focus();

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -60,6 +60,13 @@ export interface UAEngine {
 		lineFragments(text: object): TextareaVisualLine[];
 	};
 	styles: {registerShadowRoot(root: object): void};
+	/**
+	 * Note that a state no attribute records moved -- a popover shown or
+	 * hidden. Nothing about it is a mutation, so the rules that test it and
+	 * the frame that paints what they reveal have nothing else to hear it
+	 * from.
+	 */
+	stateChanged(element: object): void;
 	observer: {observe(target: object, options: object): void};
 	/** Note the unbounded damage attaching a shadow tree is. */
 	invalidateStructure(): void;
@@ -6684,6 +6691,91 @@ export class HTMLElement extends Element {
 			document[kActiveElement] = null;
 		}
 	}
+
+	/**
+	 * Show the element as a popover: it joins the top layer, over everything
+	 * the document paints, and the UA sheet stops hiding it.
+	 */
+	showPopover(options?: {source?: Element | null}): void {
+		const init =
+			options === undefined
+				? {}
+				: toDictionary<{source?: Element | null}>(options, "Show options");
+		showPopover(this, true, init.source ?? null);
+	}
+
+	/** Hide a showing popover, which leaves the top layer as it goes. */
+	hidePopover(): void {
+		hidePopover(this, true, true, true, null);
+	}
+
+	/**
+	 * Show a hidden popover or hide a showing one, and answer with whether it
+	 * is showing afterwards. A force of true only ever shows and one of false
+	 * only ever hides, so a caller that knows the state it wants says it.
+	 */
+	togglePopover(
+		options?: boolean | {force?: boolean; source?: Element | null},
+	): boolean {
+		let force: boolean | null = null;
+		let source: Element | null = null;
+		if (typeof options === "boolean") {
+			force = options;
+		} else if (options !== undefined) {
+			const init = toDictionary<{force?: boolean; source?: Element | null}>(
+				options,
+				"Toggle options",
+			);
+			if (init.force !== undefined) force = Boolean(init.force);
+			source = init.source ?? null;
+		}
+		const showing = isShowingPopover(this);
+		if (showing && force !== true) {
+			hidePopover(this, true, true, true, null);
+		} else if (!showing && force !== false) {
+			showPopover(this, true, source);
+		} else {
+			// Neither half runs, and the state still has to be a legal one:
+			// toggling something that is not a popover throws either way.
+			const validity = popoverValidity(this, showing, null);
+			if (isPopoverException(validity)) throw validity;
+		}
+		return isShowingPopover(this);
+	}
+
+	/**
+	 * A popover whose attribute changes state stops being the popover it was
+	 * showing as, so it closes -- silently, since the author who changed the
+	 * attribute is not asking to be told about the popover it used to be.
+	 */
+	override [kAttributeChanged](
+		localName: string,
+		oldValue: string | null,
+		value: string | null,
+		namespace: string | null,
+	): void {
+		super[kAttributeChanged](localName, oldValue, value, namespace);
+		if (namespace !== null || localName !== "popover") return;
+		if (popoverValueState(oldValue) === popoverValueState(value)) return;
+		if (!isShowingPopover(this)) return;
+		hidePopover(this, true, true, false, null);
+	}
+
+	/**
+	 * A popover taken out of the document is no longer showing: the top layer
+	 * holds nothing off the tree, and there is no page left for it to be over.
+	 */
+	override [kRemovingSteps](oldParent: Node): void {
+		super[kRemovingSteps](oldParent);
+		if (!isShowingPopover(this)) return;
+		const state = popoverStateOf(this);
+		topLayerOf(this[kDocument]).delete(this);
+		state.visibility = "hidden";
+		state.mode = null;
+		state.trigger = null;
+		state.previouslyFocused = null;
+		popoverStateChanged(this);
+	}
 }
 
 /**
@@ -8447,6 +8539,9 @@ function installReflection(prototype: object, spec: ReflectSpec): void {
 			get = function (this: Element): string | null {
 				const value = this.getAttribute(attribute);
 				if (value === null) return spec.nullable ? null : missing;
+				// An attribute whose empty string is one of its own keywords
+				// answers with the state that keyword names.
+				if (value === "" && spec.empty !== undefined) return spec.empty;
 				const lowered = asciiLowercase(value);
 				for (const candidate of keywords) {
 					if (asciiLowercase(candidate) === lowered) return candidate;
@@ -10605,7 +10700,20 @@ export class HTMLInputElement extends HTMLElement {
 		}
 	}
 
-	[kActivationBehavior](): void {
+	/**
+	 * The popover this input invokes when it is one of the types that render
+	 * as a button, which the attribute names by id or an author hands over as
+	 * an element.
+	 */
+	get popoverTargetElement(): Element | null {
+		return popoverTargetAttributeElement(this);
+	}
+
+	set popoverTargetElement(value: Element | null) {
+		setPopoverTargetAttributeElement(this, value);
+	}
+
+	[kActivationBehavior](event: Event): void {
 		if (isActuallyDisabled(this)) return;
 		const type = this.type;
 		if (type === "checkbox" || type === "radio") {
@@ -10614,12 +10722,14 @@ export class HTMLInputElement extends HTMLElement {
 			return;
 		}
 		const form = formOwner(this);
-		if (form === null) return;
-		if (type === "submit" || type === "image") {
-			submitForm(form, this, false);
-		} else if (type === "reset") {
-			form.reset();
+		if (form !== null) {
+			if (type === "submit" || type === "image") {
+				submitForm(form, this, false);
+			} else if (type === "reset") {
+				form.reset();
+			}
 		}
+		popoverTargetActivationBehavior(this, event.target);
 	}
 
 	/** Set checkedness, unchecking the rest of a radio button's group. */
@@ -10965,15 +11075,29 @@ export class HTMLButtonElement extends HTMLElement {
 		return labelsOf(this);
 	}
 
-	[kActivationBehavior](): void {
+	/**
+	 * The popover this button invokes, which the attribute names by id or an
+	 * author hands over as an element.
+	 */
+	get popoverTargetElement(): Element | null {
+		return popoverTargetAttributeElement(this);
+	}
+
+	set popoverTargetElement(value: Element | null) {
+		setPopoverTargetAttributeElement(this, value);
+	}
+
+	[kActivationBehavior](event: Event): void {
 		if (isActuallyDisabled(this)) return;
 		const form = formOwner(this);
-		if (form === null) return;
-		if (this.type === "submit") {
-			submitForm(form, this, false);
-		} else if (this.type === "reset") {
-			form.reset();
+		if (form !== null) {
+			if (this.type === "submit") {
+				submitForm(form, this, false);
+			} else if (this.type === "reset") {
+				form.reset();
+			}
 		}
+		popoverTargetActivationBehavior(this, event.target);
 	}
 }
 /**
@@ -12414,18 +12538,21 @@ export class HTMLFieldSetElement extends HTMLElement {
 export interface ToggleEventInit extends EventInit {
 	oldState?: string;
 	newState?: string;
+	source?: Element | null;
 }
 
 /** The event a details or a popover fires when it opens or closes. */
 export class ToggleEvent extends Event {
 	#oldState: string;
 	#newState: string;
+	#source: Element | null;
 
 	constructor(type: string, eventInitDict: ToggleEventInit = {}) {
 		super(type, eventInitDict);
 		const init = toDictionary<ToggleEventInit>(eventInitDict, "An event init");
 		this.#oldState = String(init.oldState ?? "");
 		this.#newState = String(init.newState ?? "");
+		this.#source = init.source ?? null;
 	}
 
 	get oldState(): string {
@@ -12434,6 +12561,11 @@ export class ToggleEvent extends Event {
 
 	get newState(): string {
 		return this.#newState;
+	}
+
+	/** The element whose activation opened or closed the popover, if any. */
+	get source(): Element | null {
+		return this.#source;
 	}
 }
 
@@ -12578,6 +12710,14 @@ export class HTMLDialogElement extends HTMLElement {
 	}
 
 	/**
+	 * The dialog focusing steps, as the popover focusing steps reach them: a
+	 * dialog shown as a popover focuses like a dialog, not like a popover.
+	 */
+	[kDialogFocusingSteps](): void {
+		this.#focusDialog();
+	}
+
+	/**
 	 * HTML's dialog focusing steps: focus goes to the descendant asking for it
 	 * with `autofocus`, else to the first one that can take focus, else to the
 	 * dialog itself -- which is focusable for exactly as long as it is the
@@ -12649,6 +12789,651 @@ export class HTMLDialogElement extends HTMLElement {
 /** Whether a node's root is a document, which is what connected means. */
 function isConnectedNode(node: Node): boolean {
 	return shadowIncludingRoot(node).nodeType === DOCUMENT_NODE;
+}
+
+/* ------------------------------------------------------------- popovers */
+
+const kDialogFocusingSteps = Symbol("the dialog focusing steps");
+const kPopoverShowing = Symbol("a popover is opening");
+const kPopoverHidingCount = Symbol("how many popovers are closing");
+
+/**
+ * A popover's state, which no attribute records.
+ *
+ * `mode` is the state the popover was OPENED in rather than the one its
+ * attribute names now: the attribute can change under a showing popover, and
+ * the stack it belongs to is the one it entered. `previouslyFocused` is set
+ * only for the popover that opened a stack, so closing the stack gives focus
+ * back once rather than once per popover.
+ */
+interface PopoverState {
+	visibility: "hidden" | "showing";
+	mode: "auto" | null;
+	trigger: Element | null;
+	previouslyFocused: Element | null;
+	hiding: boolean;
+	toggleTask: {oldState: string; canceled: boolean} | null;
+}
+
+/**
+ * The popover state of the elements that have one. HTML gives the slots to
+ * every HTML element; an element that was never a popover has no state to
+ * hold, and the state it would hold is the initial one.
+ */
+const popoverStates = new WeakMap<Element, PopoverState>();
+
+function popoverStateOf(element: Element): PopoverState {
+	let state = popoverStates.get(element);
+	if (state === undefined) {
+		state = {
+			visibility: "hidden",
+			mode: null,
+			trigger: null,
+			previouslyFocused: null,
+			hiding: false,
+			toggleTask: null,
+		};
+		popoverStates.set(element, state);
+	}
+	return state;
+}
+
+/**
+ * The state an element's popover attribute is in: auto for the empty string
+ * and `auto`, manual for `manual` and for every value the attribute does not
+ * know, and null -- not a popover -- when the attribute is absent.
+ *
+ * HTML's third state, Hint, is NOT implemented: a hint popover keeps a second
+ * stack that auto popovers close and that closes with the auto popover it
+ * hangs from, and every algorithm here would carry that second stack through
+ * it. `popover=hint` therefore takes the route the attribute defines for a
+ * value it does not know, the Manual state, and reflects as "manual".
+ */
+function popoverAttributeState(element: Element): "auto" | "manual" | null {
+	if (element[kNamespace] !== HTML_NAMESPACE) return null;
+	return popoverValueState(element.getAttribute("popover"));
+}
+
+/** The state a popover attribute VALUE is in, for comparing two of them. */
+function popoverValueState(value: string | null): "auto" | "manual" | null {
+	if (value === null) return null;
+	const keyword = asciiLowercase(value);
+	return keyword === "" || keyword === "auto" ? "auto" : "manual";
+}
+
+/** Whether an element is a popover in the showing state -- `:popover-open`. */
+export function isShowingPopover(node: object): boolean {
+	return (
+		node instanceof HTMLElement &&
+		popoverStates.get(node)?.visibility === "showing"
+	);
+}
+
+/**
+ * A document's showing auto popover list: the auto popovers in its top layer,
+ * in the order they entered it, which is the order they close in.
+ */
+function showingAutoPopovers(document: Document): Element[] {
+	const popovers: Element[] = [];
+	for (const element of topLayerOf(document)) {
+		const state = popoverStates.get(element);
+		if (state?.mode === "auto" && state.visibility === "showing") {
+			popovers.push(element);
+		}
+	}
+	return popovers;
+}
+
+/** The auto popover on top of a document's stack, or null while none is up. */
+export function topmostAutoPopover(document: object): Element | null {
+	const popovers = showingAutoPopovers(document as Document);
+	return popovers.length === 0 ? null : popovers[popovers.length - 1];
+}
+
+/**
+ * Tell the environment that a popover's state moved. Nothing about showing
+ * one is a mutation -- the attribute stands, the tree stands -- so the rules
+ * that test `:popover-open`, and the frame that would paint what they hide or
+ * reveal, have nothing else to hear it from.
+ */
+function popoverStateChanged(element: Element): void {
+	uaEngineOf(element)?.stateChanged(element);
+}
+
+/**
+ * Check popover validity, as the callers below hold the result: true, false
+ * for a call that is simply not to happen, or the exception the check threw,
+ * which a caller rethrows only where the specification says it does.
+ *
+ * HTML also refuses a popover whose fullscreen flag is set. Fullscreen is the
+ * renderer's, not the tree's -- this file knows nothing of it -- and the
+ * element that is fullscreen paints over the whole screen either way, so the
+ * check is the environment's if it ever wants one.
+ */
+function popoverValidity(
+	element: Element,
+	expectedToBeShowing: boolean,
+	expectedDocument: Document | null,
+): true | false | unknown {
+	if (popoverAttributeState(element) === null) {
+		return domError("NotSupportedError", "That element is not a popover");
+	}
+	const showing = popoverStateOf(element).visibility === "showing";
+	if (expectedToBeShowing !== showing) return false;
+	if (!isConnectedNode(element)) {
+		return domError("InvalidStateError", "That popover is not connected");
+	}
+	if (expectedDocument !== null && element[kDocument] !== expectedDocument) {
+		return domError("InvalidStateError", "That popover changed documents");
+	}
+	if (isModalDialog(element)) {
+		return domError(
+			"InvalidStateError",
+			"A dialog showing modally cannot also show as a popover",
+		);
+	}
+	return true;
+}
+
+/** Whether a validity result is the exception a throwing caller rethrows. */
+function isPopoverException(result: true | false | unknown): boolean {
+	return result !== true && result !== false;
+}
+
+/**
+ * HTML's show popover: the popover joins the top layer, and an auto one first
+ * closes every open auto popover it is not nested inside -- through the node
+ * tree or through the element that invoked it.
+ */
+function showPopover(
+	element: Element,
+	throwExceptions: boolean,
+	source: Element | null,
+): void {
+	const document = element[kDocument];
+	// Showing a popover from inside another popover's show or hide is a
+	// reentrancy the stack algorithms cannot unwind, so it is refused.
+	if (document[kPopoverShowing] || document[kPopoverHidingCount] !== 0) {
+		if (throwExceptions) {
+			throw domError(
+				"InvalidStateError",
+				"A popover cannot be shown while another is opening or closing",
+			);
+		}
+		return;
+	}
+	let validity = popoverValidity(element, false, null);
+	if (validity !== true) {
+		if (throwExceptions && isPopoverException(validity)) throw validity;
+		return;
+	}
+	const state = popoverStateOf(element);
+	document[kPopoverShowing] = true;
+	const cleanup = (): void => {
+		document[kPopoverShowing] = false;
+	};
+	const opening = new ToggleEvent("beforetoggle", {
+		cancelable: true,
+		oldState: "closed",
+		newState: "open",
+		source,
+	});
+	if (!dispatch(element, opening)) {
+		cleanup();
+		return;
+	}
+	// A beforetoggle listener can have disconnected the element or changed
+	// its popover attribute, so what was checked above is checked again.
+	validity = popoverValidity(element, false, document);
+	if (validity !== true) {
+		cleanup();
+		if (throwExceptions && isPopoverException(validity)) throw validity;
+		return;
+	}
+	let shouldRestoreFocus = false;
+	const originalType = popoverAttributeState(element);
+	if (originalType === "auto") {
+		const ancestor = topmostPopoverAncestor(element, source);
+		hidePopoverStackUntil(document, ancestor, false, true);
+		if (originalType !== popoverAttributeState(element)) {
+			cleanup();
+			if (throwExceptions) {
+				throw domError(
+					"InvalidStateError",
+					"That popover changed state while the ones over it closed",
+				);
+			}
+			return;
+		}
+		validity = popoverValidity(element, false, document);
+		if (validity !== true) {
+			cleanup();
+			if (throwExceptions && isPopoverException(validity)) throw validity;
+			return;
+		}
+		// Focus goes back to the page only for the popover that OPENED the
+		// stack, so unwinding one returns it once.
+		if (topmostAutoPopover(document) === null) shouldRestoreFocus = true;
+		state.mode = "auto";
+	}
+	state.previouslyFocused = null;
+	const originallyFocused = document[kActiveElement];
+	topLayerOf(document).add(element);
+	state.visibility = "showing";
+	state.trigger = source;
+	popoverFocusingSteps(element);
+	if (shouldRestoreFocus && popoverAttributeState(element) !== null) {
+		state.previouslyFocused = originallyFocused;
+	}
+	cleanup();
+	queuePopoverToggleEventTask(element, "closed", "open", source);
+	popoverStateChanged(element);
+}
+
+/**
+ * HTML's hide popover: the popover leaves the top layer, and an auto one
+ * takes the popovers stacked above it with it.
+ */
+function hidePopover(
+	element: Element,
+	focusPreviousElement: boolean,
+	fireEvents: boolean,
+	throwExceptions: boolean,
+	source: Element | null,
+): void {
+	let validity = popoverValidity(element, true, null);
+	if (validity !== true) {
+		if (throwExceptions && isPopoverException(validity)) throw validity;
+		return;
+	}
+	const document = element[kDocument];
+	const state = popoverStateOf(element);
+	const nestedHide = state.hiding;
+	state.hiding = true;
+	if (nestedHide) fireEvents = false;
+	document[kPopoverHidingCount]++;
+	const cleanup = (): void => {
+		if (!nestedHide) state.hiding = false;
+		document[kPopoverHidingCount]--;
+	};
+	if (state.mode === "auto") {
+		hidePopoverStackUntil(document, element, focusPreviousElement, fireEvents);
+		// Closing the popovers above this one can have disconnected it or
+		// changed its attribute, so validity is asked again.
+		validity = popoverValidity(element, true, null);
+		if (validity !== true) {
+			cleanup();
+			if (throwExceptions && isPopoverException(validity)) throw validity;
+			return;
+		}
+	}
+	if (fireEvents) {
+		dispatch(
+			element,
+			new ToggleEvent("beforetoggle", {
+				oldState: "open",
+				newState: "closed",
+				source,
+			}),
+		);
+		validity = popoverValidity(element, true, null);
+		if (validity !== true) {
+			cleanup();
+			if (throwExceptions && isPopoverException(validity)) throw validity;
+			return;
+		}
+	}
+	topLayerOf(document).delete(element);
+	state.trigger = null;
+	state.mode = null;
+	state.visibility = "hidden";
+	if (fireEvents) {
+		queuePopoverToggleEventTask(element, "open", "closed", source);
+	}
+	const previouslyFocused = state.previouslyFocused;
+	if (previouslyFocused !== null) {
+		state.previouslyFocused = null;
+		// Focus goes back only if the popover still holds it: an author who
+		// moved focus elsewhere while it was up keeps it there.
+		const active = document[kActiveElement];
+		if (
+			focusPreviousElement &&
+			active !== null &&
+			(active === element || element.contains(active))
+		) {
+			(previouslyFocused as HTMLElement).focus();
+		}
+	}
+	cleanup();
+	popoverStateChanged(element);
+}
+
+/**
+ * Close a popover the way a close request does -- Escape on the topmost auto
+ * popover -- which is a hide that gives focus back and fires its events.
+ */
+export function closePopover(element: object): void {
+	hidePopover(element as Element, true, true, false, null);
+}
+
+/**
+ * HTML's hide popover stack until: close the auto popovers stacked above an
+ * endpoint, topmost first, leaving the endpoint and everything under it. A
+ * null endpoint closes the whole stack.
+ *
+ * The second pass catches the popovers a beforetoggle listener showed while
+ * the stack was unwinding, which would otherwise be left over the endpoint.
+ */
+function hidePopoverStackUntil(
+	document: Document,
+	endpoint: Element | null,
+	focusPreviousElement: boolean,
+	fireEvents: boolean,
+): void {
+	const popovers = showingAutoPopovers(document);
+	const index = endpoint === null ? -1 : popovers.indexOf(endpoint);
+	const lastHideIndex = index === -1 ? 0 : index + 1;
+	const toHide = popovers.slice(lastHideIndex).reverse();
+	const toRemain = popovers.slice(0, lastHideIndex);
+	for (const popover of toHide) {
+		hidePopover(popover, focusPreviousElement, fireEvents, false, null);
+	}
+	for (const popover of showingAutoPopovers(document).reverse()) {
+		if (toRemain.includes(popover)) continue;
+		hidePopover(popover, focusPreviousElement, false, false, null);
+	}
+}
+
+/**
+ * HTML's hide popovers until, which is the stack unwind light dismiss and an
+ * opening popover both run. With no hint stack, it is the auto stack's.
+ */
+export function hidePopoversUntil(
+	document: object,
+	endpoint: object | null,
+	focusPreviousElement: boolean,
+	fireEvents: boolean,
+): void {
+	hidePopoverStackUntil(
+		document as Document,
+		endpoint as Element | null,
+		focusPreviousElement,
+		fireEvents,
+	);
+}
+
+/**
+ * HTML's topmost popover ancestor: the open auto popover a node hangs from,
+ * either by sitting inside it in the flat tree or by being invoked from
+ * inside it. The ancestor is the LAST such popover in the stack, so what
+ * closes above it is exactly what is unrelated to the node.
+ */
+function topmostPopoverAncestor(
+	node: Element,
+	source: Element | null,
+): Element | null {
+	const popovers = showingAutoPopovers(node[kDocument]);
+	const nodeIndex = lastFlatAncestorIndex(popovers, node);
+	const sourceIndex =
+		source === null ? -1 : lastFlatAncestorIndex(popovers, source);
+	const index = Math.max(nodeIndex, sourceIndex);
+	return index === -1 ? null : popovers[index];
+}
+
+/** The index of the last popover in a stack a node sits inside of. */
+function lastFlatAncestorIndex(popovers: Element[], node: Element): number {
+	for (let i = popovers.length - 1; i >= 0; i--) {
+		if (isFlatTreeDescendant(node, popovers[i])) return i;
+	}
+	return -1;
+}
+
+/** Whether a node renders inside an element, shadow trees crossed. */
+function isFlatTreeDescendant(node: Node, ancestor: Element): boolean {
+	for (
+		let current = flatParentElement<Node>(node);
+		current !== null;
+		current = flatParentElement<Node>(current)
+	) {
+		if (current === ancestor) return true;
+	}
+	return false;
+}
+
+/** HTML's nearest inclusive open popover: the auto popover a node is in. */
+function nearestInclusiveOpenPopover(node: Node): Element | null {
+	for (
+		let current: Node | null = node;
+		current !== null;
+		current = flatParentElement<Node>(current)
+	) {
+		const state = popoverStates.get(current as Element);
+		if (state?.mode === "auto" && state.visibility === "showing") {
+			return current as Element;
+		}
+	}
+	return null;
+}
+
+/**
+ * HTML's nearest inclusive target popover: the open auto popover the node, or
+ * an element it sits in, INVOKES. It is what keeps a click on a popover's own
+ * button from light-dismissing the popover it opened.
+ */
+function nearestInclusiveTargetPopover(node: Node): Element | null {
+	for (
+		let current: Node | null = node;
+		current !== null;
+		current = flatParentElement<Node>(current)
+	) {
+		const target = popoverTargetElementOf(current);
+		if (
+			target !== null &&
+			popoverAttributeState(target) === "auto" &&
+			isShowingPopover(target)
+		) {
+			return target;
+		}
+	}
+	return null;
+}
+
+/** Where a popover sits in its document's stack; zero for one not in it. */
+function popoverStackPosition(popover: Element | null): number {
+	if (popover === null) return 0;
+	const index = showingAutoPopovers(popover[kDocument]).indexOf(popover);
+	return index === -1 ? 0 : index + 1;
+}
+
+/**
+ * HTML's topmost clicked popover: the popover a click at a node belongs to,
+ * which is the deeper of the popover the node is in and the popover the node
+ * invokes. Light dismiss closes everything stacked above it.
+ */
+export function topmostClickedPopover(node: object): Element | null {
+	const clicked = nearestInclusiveOpenPopover(node as Node);
+	const target = nearestInclusiveTargetPopover(node as Node);
+	return popoverStackPosition(clicked) > popoverStackPosition(target)
+		? clicked
+		: target;
+}
+
+/**
+ * HTML's popover focusing steps. Unlike a dialog, a popover does not take
+ * focus off the page by opening: focus moves only where the content asks for
+ * it with autofocus.
+ */
+function popoverFocusingSteps(element: Element): void {
+	if (element instanceof HTMLDialogElement) {
+		element[kDialogFocusingSteps]();
+		return;
+	}
+	if (element.hasAttribute("autofocus")) {
+		(element as HTMLElement).focus();
+		return;
+	}
+	for (const node of shadowIncludingInclusiveDescendants(element)) {
+		if (node === element || node.nodeType !== ELEMENT_NODE) continue;
+		const descendant = node as Element;
+		if (!descendant.hasAttribute("autofocus")) continue;
+		if (!isFocusableArea(descendant)) continue;
+		(descendant as HTMLElement).focus();
+		return;
+	}
+}
+
+/**
+ * HTML's queue a popover toggle event task. A popover shown and hidden inside
+ * one turn reports the state it settled on: the pending task is dropped and
+ * its old state carried into the one that replaces it, so an author sees one
+ * toggle describing the whole run rather than a pair that cancel out.
+ */
+function queuePopoverToggleEventTask(
+	element: Element,
+	oldState: string,
+	newState: string,
+	source: Element | null,
+): void {
+	const state = popoverStateOf(element);
+	if (state.toggleTask !== null) {
+		oldState = state.toggleTask.oldState;
+		state.toggleTask.canceled = true;
+	}
+	const task = {oldState, canceled: false};
+	state.toggleTask = task;
+	queueMicrotask(() => {
+		if (task.canceled) return;
+		state.toggleTask = null;
+		dispatch(element, new ToggleEvent("toggle", {oldState, newState, source}));
+	});
+}
+
+/**
+ * The elements a popovertarget was set to as an ELEMENT rather than named by
+ * id. The attribute cannot hold one, so the reference is held beside it, and
+ * the getter answers with it only while the element it names is in a tree the
+ * invoker composes into.
+ */
+const explicitPopoverTargets = new WeakMap<Element, Element>();
+
+/**
+ * HTML's get the popovertarget-associated element: the explicitly set element
+ * if it is still reachable, otherwise the element the attribute names by id
+ * in the invoker's own tree.
+ */
+function popoverTargetAttributeElement(node: Node): Element | null {
+	if (node.nodeType !== ELEMENT_NODE) return null;
+	const element = node as Element;
+	const explicit = explicitPopoverTargets.get(element);
+	if (explicit !== undefined) {
+		// The reference stands while the target is in the invoker's own tree
+		// or in one that tree composes into; it goes stale, rather than
+		// dangling, when the target is moved out from under it.
+		for (let root: Node = getRoot(element); ; ) {
+			if (root.contains(explicit)) return explicit;
+			if (!isShadowRoot(root)) return null;
+			const host = (root as ShadowRoot)[kHost];
+			if (host === null) return null;
+			root = getRoot(host);
+		}
+	}
+	const id = element.getAttribute("popovertarget");
+	if (id === null) return null;
+	const root = getRoot(element);
+	if (root.nodeType !== DOCUMENT_NODE && !isShadowRoot(root)) return null;
+	return (root as Document | ShadowRoot).getElementById(id);
+}
+
+/** Set the element a popovertarget names, per HTML's element reflection. */
+function setPopoverTargetAttributeElement(
+	element: Element,
+	value: Element | null,
+): void {
+	if (value === null || value === undefined) {
+		explicitPopoverTargets.delete(element);
+		element.removeAttribute("popovertarget");
+		return;
+	}
+	explicitPopoverTargets.set(element, value);
+	element.setAttribute("popovertarget", "");
+}
+
+/**
+ * Whether a node is a BUTTON as the popover target attributes mean it: the
+ * button element, and the input types that render as buttons.
+ */
+function isPopoverInvokerButton(node: Node): boolean {
+	if (node instanceof HTMLButtonElement) return true;
+	if (!(node instanceof HTMLInputElement)) return false;
+	const type = node.type;
+	return (
+		type === "submit" ||
+		type === "reset" ||
+		type === "button" ||
+		type === "image"
+	);
+}
+
+/**
+ * HTML's get the popover target element: the popover a node invokes. A button
+ * that submits a form is not an invoker -- its activation is the submission,
+ * and the attribute on it does nothing.
+ */
+function popoverTargetElementOf(node: Node): Element | null {
+	if (!isPopoverInvokerButton(node)) return null;
+	const element = node as Element;
+	if (isActuallyDisabled(element)) return null;
+	if (formOwner(element) !== null && isSubmitButton(element)) return null;
+	const popover = popoverTargetAttributeElement(element);
+	if (popover === null) return null;
+	return popoverAttributeState(popover) === null ? null : popover;
+}
+
+/**
+ * HTML's popover target attribute activation behavior: what a button with
+ * popovertarget does when it is activated. `popovertargetaction` names which
+ * half of the toggle to run, and a button inside the popover it targets does
+ * nothing -- the click that reaches it is the popover's own.
+ */
+function popoverTargetActivationBehavior(node: Element, target: unknown): void {
+	const popover = popoverTargetElementOf(node);
+	if (popover === null) return;
+	if (
+		target instanceof Node &&
+		isShadowIncludingInclusiveDescendant(target, popover) &&
+		isShadowIncludingInclusiveDescendant(popover, node) &&
+		popover !== node
+	) {
+		return;
+	}
+	const action = asciiLowercase(
+		node.getAttribute("popovertargetaction") ?? "toggle",
+	);
+	const showing = isShowingPopover(popover);
+	if (action === "show" && showing) return;
+	if (action === "hide" && !showing) return;
+	if (showing) {
+		hidePopover(popover, true, true, false, node);
+		return;
+	}
+	if (popoverValidity(popover, false, null) === true) {
+		showPopover(popover, false, node);
+	}
+}
+
+/** Whether a node is the element itself or renders anywhere beneath it. */
+function isShadowIncludingInclusiveDescendant(
+	node: Node,
+	ancestor: Node,
+): boolean {
+	for (
+		let current: Node | null = node;
+		current !== null;
+		current = flatParentElement<Node>(current)
+	) {
+		if (current === ancestor) return true;
+	}
+	return false;
 }
 /**
  * A script, which never runs.
@@ -14447,6 +15232,10 @@ export class Document extends Node {
 	[kStyleElements] = 0;
 	[kChildren]: HTMLCollection | null = null;
 	[kTopLayer] = new Set<Element>();
+	// The reentrancy guards the popover algorithms hold on the document: one
+	// popover opening at a time, and a count of the ones closing under it.
+	[kPopoverShowing] = false;
+	[kPopoverHidingCount] = 0;
 
 	/** Parse a document, declarative shadow roots included. */
 	static parseHTMLUnsafe(html: string): Document {
@@ -17792,6 +18581,20 @@ function selectorEngine(document: Document): SelectorEngine {
 			(match: string[], source: string) => ({
 				match,
 				source: `if(s.isModal(e)){${source}}`,
+				status: true,
+				modvar: null,
+			}),
+		);
+		// `:popover-open` is the same kind of state: a popover's showing lives
+		// in the top layer and in nothing the tree records, so the engine asks
+		// rather than derives.
+		engine.Snapshot.isPopoverOpen = isShowingPopover;
+		engine.registerSelector(
+			":popover-open",
+			/^:popover-open(.*)/i,
+			(match: string[], source: string) => ({
+				match,
+				source: `if(s.isPopoverOpen(e)){${source}}`,
 				status: true,
 				modvar: null,
 			}),

--- a/src/internal/domhtml.ts
+++ b/src/internal/domhtml.ts
@@ -39,6 +39,8 @@ export interface ReflectSpec {
 	missing?: string;
 	/** The state an enumerated attribute takes when its value is not known. */
 	invalid?: string;
+	/** The state an enumerated attribute takes when its value is empty. */
+	empty?: string;
 	/** Limited to only non-negative numbers: a negative set throws. */
 	nonNegative?: boolean;
 	/** Limited to only non-negative numbers greater than zero: a zero set throws. */
@@ -155,6 +157,16 @@ const REFERRER_POLICIES = [
 	"unsafe-url",
 ];
 
+/** Which half of the toggle a button with popovertarget runs. */
+const popoverTargetAction = (): ReflectSpec =>
+	keyword(
+		"popoverTargetAction",
+		"popovertargetaction",
+		["toggle", "show", "hide"],
+		"toggle",
+		"toggle",
+	);
+
 const referrerPolicy = (): ReflectSpec =>
 	keyword("referrerPolicy", "referrerpolicy", REFERRER_POLICIES, "", "");
 
@@ -237,13 +249,18 @@ export const HTML_ELEMENT_REFLECTIONS: readonly ReflectSpec[] = [
 		"true",
 		"true",
 	),
+	// The empty string is the popover attribute's own spelling of the auto
+	// state. HTML's third state, hint, is not implemented -- see the note on
+	// the popover algorithms -- so `popover=hint` takes the route the
+	// attribute defines for a value it does not know.
 	{
 		property: "popover",
 		attribute: "popover",
 		kind: "enum",
-		keywords: ["auto", "manual", "hint"],
+		keywords: ["auto", "manual"],
 		nullable: true,
 		missing: "",
+		empty: "auto",
 		invalid: "manual",
 	},
 ];
@@ -794,6 +811,7 @@ export const HTML_INTERFACES: readonly InterfaceSpec[] = [
 			str("align"),
 			ulong("height", "height", 0),
 			ulong("width", "width", 0),
+			popoverTargetAction(),
 		],
 	},
 	{
@@ -811,6 +829,7 @@ export const HTML_INTERFACES: readonly InterfaceSpec[] = [
 				"submit",
 			),
 			str("value"),
+			popoverTargetAction(),
 		],
 	},
 	{

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -7703,6 +7703,22 @@ export class StyleManager {
 		}
 	}
 
+	/**
+	 * A state no attribute records moved: a popover was shown or hidden. The
+	 * rules that test it (`:popover-open`, and the UA sheet's display among
+	 * them) matched before the move, and a popover that stops being displayed
+	 * takes its subtree's styles with it -- so the element and everything
+	 * whose style comes through it re-resolve.
+	 */
+	handleStateChange(element: Element): void {
+		this.#invalidateSubtree(element);
+		// No mutation record describes the move, so the frame that decides
+		// whether anything is worth painting is told here: the cascade moved,
+		// and the rows the element claims are the damage to repaint.
+		this.#pendingStyleDamage?.add(element);
+		this.#layoutEngine?.invalidateFrame();
+	}
+
 	/** Set the `:focus-visible` state; returns whether it changed. */
 	setFocusVisible(active: boolean): boolean {
 		if (this.#focusVisibleActive === active) return false;

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -10,12 +10,17 @@ import {
 	caretRangeOf,
 	fieldValueText,
 	flatIsConnected,
+	closePopover,
+	hidePopoversUntil,
 	installUAEngine,
 	isModalDialog,
+	isShowingPopover,
 	isTextField,
 	pseudoHostOf,
 	setUASelection,
 	topLayerOf,
+	topmostAutoPopover,
+	topmostClickedPopover,
 	upgradeUAWidget,
 } from "./dom.js";
 import {LayoutEngine} from "./layout.js";
@@ -631,6 +636,9 @@ export class TermDOM {
 	// becomes a click. (Browsers dispatch click at the nearest common
 	// ancestor; the same-element case is the one that matters on a cell grid.)
 	#mouseDownTarget: Element | null = null;
+	// The popover the last mousedown belonged to, which light dismiss compares
+	// the release against.
+	#popoverPressTarget: object | null = null;
 	// Where a left-button drag started selecting text, as a caret position --
 	// the selection's anchor. The focus end follows the drag; both feed
 	// Selection.setBaseAndExtent, which handles backward drags itself.
@@ -733,6 +741,14 @@ export class TermDOM {
 			styles: this.#styleManager,
 			observer: this[kObserver],
 			invalidateStructure: () => this[kLayoutEngine].invalidateStructure(),
+			// A popover shows and hides without touching the tree, so the
+			// rules that test `:popover-open` -- the UA sheet's own display
+			// among them -- are told here, and the frame that paints what
+			// they reveal is asked for here.
+			stateChanged: (element: object) => {
+				this.#styleManager.handleStateChange(element as Element);
+				void this.#render();
+			},
 		});
 		this.#painter = new Painter({
 			window: this.window,
@@ -2345,6 +2361,21 @@ export class TermDOM {
 	}
 
 	/**
+	 * What a close request closes: the modal dialog or auto popover last into
+	 * the top layer, which is the one the user sees on top. A manual popover
+	 * is not one -- it responds to neither Escape nor a click outside -- and
+	 * neither is anything else riding the layer.
+	 */
+	#topmostCloseRequestTarget(): Element | null {
+		const popover = topmostAutoPopover(this.document) as Element | null;
+		let target: Element | null = null;
+		for (const element of this.#topLayer) {
+			if (isModalDialog(element) || element === popover) target = element;
+		}
+		return target;
+	}
+
+	/**
 	 * Focus the next or previous focusable element
 	 */
 	#moveFocus(reverse: boolean): void {
@@ -2601,6 +2632,10 @@ export class TermDOM {
 
 		if (!isRelease) {
 			this.#mouseDownTarget = target;
+			// The popover a press belongs to, which the release compares
+			// against: light dismiss is a press and a release in the same
+			// place, so a drag out of a popover does not close it.
+			this.#popoverPressTarget = topmostClickedPopover(target);
 			this.#fieldDragAnchor = null;
 			// A pointer press suppresses the :focus-visible ring.
 			if (this.#styleManager.setFocusVisible(false)) {
@@ -2683,6 +2718,17 @@ export class TermDOM {
 		}
 
 		target.dispatchEvent(new this.window.MouseEvent("mouseup", eventInit));
+		// LIGHT DISMISS: a release closes every auto popover the released
+		// point is not inside of and did not open -- the invoker of a popover
+		// counts as part of it, so the click that follows toggles rather than
+		// reopens what this closed. It runs before the click, where a browser
+		// runs it, and no listener can prevent it.
+		const dismissAncestor = topmostClickedPopover(target);
+		const samePopoverPress = dismissAncestor === this.#popoverPressTarget;
+		this.#popoverPressTarget = null;
+		if (samePopoverPress && topmostAutoPopover(this.document) !== null) {
+			hidePopoversUntil(this.document, dismissAncestor, false, true);
+		}
 		// A selection is only a selection: writing the clipboard is a
 		// deliberate act, through navigator.clipboard. The terminal's own
 		// select-to-copy remains available as Shift+drag, which bypasses
@@ -2870,17 +2916,25 @@ export class TermDOM {
 
 		const notCanceled = targetElement.dispatchEvent(keydownEvent);
 
-		// Escape is a CLOSE REQUEST on the topmost modal dialog: fire cancel,
-		// and close unless a listener took it. The dialog gets Escape only
-		// when nothing is fullscreen -- the branch above already returned --
-		// which is the browser's own precedence: the fullscreen exit is the
-		// user agent's guarantee, and only after it is spent does the key
-		// reach the page's own modality. Unlike Tab below, a preventDefault
-		// on keydown does not suppress it; `cancel` is the hook for that.
+		// Escape is a CLOSE REQUEST on whatever is on top of the top layer and
+		// answers one: a modal dialog fires cancel and closes unless a
+		// listener takes it, an auto popover closes outright (nothing cancels
+		// a popover, which is why a manual one -- answering no close request
+		// -- is the way to keep one up). Whichever entered the layer last is
+		// the one the key reaches, so a popover over a dialog closes first.
+		// Both get Escape only when nothing is fullscreen -- the branch above
+		// already returned -- which is the browser's own precedence: the
+		// fullscreen exit is the user agent's guarantee, and only after it is
+		// spent does the key reach the page's own modality. Unlike Tab below,
+		// a preventDefault on keydown does not suppress it.
 		if (keyName === "Escape") {
-			const modal = this.#topmostModalDialog();
-			if (modal) {
-				modal.requestClose();
+			const target = this.#topmostCloseRequestTarget();
+			if (target !== null) {
+				if (isShowingPopover(target)) {
+					closePopover(target);
+				} else {
+					(target as HTMLDialogElement).requestClose();
+				}
 				void this.#render();
 				return;
 			}

--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -894,6 +894,13 @@ export function getInitialStyle(
  * of "obscure the page" is to clear it. An author who wants a different one
  * writes `dialog::backdrop { background-color: ... }`, and `transparent`
  * removes it entirely.
+ *
+ * The popover rules are the dialog's, over an attribute instead of a method: a
+ * popover is hidden until it is showing, and a showing one is the same fixed,
+ * centered, bordered box on the terminal's own background. Its ::backdrop
+ * paints nothing -- a browser's is transparent too, because a popover is a
+ * thing over the page rather than a thing instead of it -- and the rule saying
+ * so is what keeps a dialog shown as a popover from clearing the viewport.
  */
 export const UA_DOCUMENT_STYLES = `
 	*::selection { background-color: Highlight; color: HighlightText; }
@@ -910,6 +917,17 @@ export const UA_DOCUMENT_STYLES = `
 		margin: auto;
 	}
 	dialog::backdrop { background-color: Canvas; }
+	[popover]:not(:popover-open):not(dialog[open]) { display: none; }
+	dialog:popover-open { display: block; }
+	[popover] {
+		position: fixed;
+		top: 0; right: 0; bottom: 0; left: 0;
+		margin: auto;
+		border: 1px solid;
+		padding: 0 1ch;
+		background-color: Canvas;
+	}
+	:popover-open::backdrop { background-color: transparent; }
 	details:not([open]) > :not(summary) { display: none; }
 	details > summary:first-of-type::before { content: "▸ "; }
 	details[open] > summary:first-of-type::before { content: "▾ "; }

--- a/tests/popover.test.ts
+++ b/tests/popover.test.ts
@@ -1,0 +1,496 @@
+/**
+ * The popover: the top layer as an attribute reaches it. A popover is hidden
+ * until it is shown, paints over the document when it is, closes when the user
+ * clicks past it or presses Escape -- unless it is manual, which does neither
+ * -- and an auto one closes whatever open popover it is not nested inside.
+ */
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+async function open(html: string, cols = 40, rows = 10) {
+	const terminal = new MockProcess({rows, cols});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML = html;
+	dom.attach();
+	await nextFrame(dom);
+	const {document} = dom;
+	const popover = document.querySelector("[popover]") as HTMLElement;
+	return {terminal, dom, document, popover};
+}
+
+function press(terminal: MockProcess, data: string): Promise<void> {
+	(terminal.stdin as any).emit("data", Buffer.from(data));
+	// Input rides the transport's readable: delivery is a microtask away.
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** A press and a release at a screen cell, which is a click. */
+async function click(terminal: MockProcess, col: number, row: number) {
+	await press(terminal, `\x1b[<0;${col};${row}M`);
+	await press(terminal, `\x1b[<0;${col};${row}m`);
+}
+
+/* --------------------------------------------------------- state mapping */
+
+test("the popover attribute's states are auto, manual, and not a popover", async () => {
+	const {document, dom} = await open(
+		`<div id=empty popover></div>` +
+			`<div id=auto popover=auto></div>` +
+			`<div id=manual popover=manual></div>` +
+			`<div id=hint popover=hint></div>` +
+			`<div id=bogus popover=sideways></div>` +
+			`<div id=none></div>`,
+	);
+	const state = (id: string) =>
+		(document.getElementById(id) as HTMLElement).popover;
+	// The empty string is the attribute's own spelling of auto.
+	expect(state("empty")).toBe("auto");
+	expect(state("auto")).toBe("auto");
+	expect(state("manual")).toBe("manual");
+	// A value the attribute does not know is manual, and hint is not
+	// implemented, so it takes that route.
+	expect(state("hint")).toBe("manual");
+	expect(state("bogus")).toBe("manual");
+	// Absent is not a popover at all, and showing one throws.
+	expect(state("none")).toBe(null);
+	expect(() =>
+		(document.getElementById("none") as HTMLElement).showPopover(),
+	).toThrow(/not a popover/);
+	dom.dispose();
+});
+
+test("the popover attribute reflects both ways", async () => {
+	const {document, dom} = await open(`<div id=box></div>`);
+	const box = document.getElementById("box") as HTMLElement;
+	box.popover = "auto";
+	expect(box.getAttribute("popover")).toBe("auto");
+	box.popover = null as unknown as string;
+	expect(box.hasAttribute("popover")).toBe(false);
+	dom.dispose();
+});
+
+/* ------------------------------------------------------------- rendering */
+
+test("a popover is hidden until it is shown, and paints over the page", async () => {
+	const {terminal, dom, popover} = await open(
+		`<p>page one</p><p>page two</p><div popover><p>the popover</p></div>`,
+	);
+	// Hidden until shown: the UA sheet's display: none, not a special case in
+	// the painter -- the content is not on screen at all.
+	expect(terminal.getPlainText()).not.toContain("the popover");
+	expect(terminal.getPlainText()).toContain("page one");
+
+	popover.showPopover();
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toContain("the popover");
+	// Over the page rather than instead of it: a popover has no scrim.
+	expect(terminal.getPlainText()).toContain("page one");
+
+	popover.hidePopover();
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).not.toContain("the popover");
+	dom.dispose();
+});
+
+test("an author's ::backdrop rule paints behind a showing popover", async () => {
+	const {terminal, dom, popover} = await open(
+		`<style>[popover]::backdrop { background-color: Canvas; }</style>` +
+			`<p>page one</p><p>page two</p><div popover><p>hello</p></div>`,
+	);
+	popover.showPopover();
+	await nextFrame(dom);
+	// The backdrop clears the viewport the way a modal dialog's does, so the
+	// page it covers is gone while the popover is up.
+	const output = terminal.getPlainText();
+	expect(output).toContain("hello");
+	expect(output).not.toContain("page one");
+	dom.dispose();
+});
+
+/* ------------------------------------------------------- show, hide, toggle */
+
+test(":popover-open matches a popover while it is showing", async () => {
+	const {document, dom, popover} = await open(`<div popover>hi</div>`);
+	expect(popover.matches(":popover-open")).toBe(false);
+
+	popover.showPopover();
+	expect(popover.matches(":popover-open")).toBe(true);
+	expect(document.querySelectorAll("[popover]:popover-open").length).toBe(1);
+
+	popover.hidePopover();
+	expect(popover.matches(":popover-open")).toBe(false);
+	expect(document.querySelectorAll(":popover-open").length).toBe(0);
+	dom.dispose();
+});
+
+test("showing a shown popover and hiding a hidden one do nothing", async () => {
+	const {dom, popover} = await open(`<div popover>hi</div>`);
+	popover.hidePopover();
+	expect(popover.matches(":popover-open")).toBe(false);
+
+	popover.showPopover();
+	popover.showPopover();
+	expect(popover.matches(":popover-open")).toBe(true);
+	dom.dispose();
+});
+
+test("a popover out of the document cannot be shown", async () => {
+	const {document, dom} = await open(`<p>page</p>`);
+	const detached = document.createElement("div") as HTMLElement;
+	detached.setAttribute("popover", "");
+	expect(() => detached.showPopover()).toThrow(/connected/);
+	dom.dispose();
+});
+
+test("a dialog showing modally cannot also show as a popover", async () => {
+	const {document, dom} = await open(`<dialog popover>hi</dialog>`);
+	const dialog = document.querySelector("dialog") as HTMLDialogElement;
+	dialog.showModal();
+	expect(() => (dialog as HTMLElement).showPopover()).toThrow(/modally/);
+	dialog.close();
+	dom.dispose();
+});
+
+test("togglePopover flips the state, and force names the half to run", async () => {
+	const {dom, popover} = await open(`<div popover>hi</div>`);
+	expect(popover.togglePopover()).toBe(true);
+	expect(popover.togglePopover()).toBe(false);
+
+	expect(popover.togglePopover(true)).toBe(true);
+	expect(popover.togglePopover(true)).toBe(true);
+	// The dictionary form of force, which the ambient DOM types predate.
+	expect((popover as any).togglePopover({force: false})).toBe(false);
+	expect((popover as any).togglePopover({force: false})).toBe(false);
+	dom.dispose();
+});
+
+test("removing a showing popover takes it out of the top layer", async () => {
+	const {terminal, dom, popover} = await open(
+		`<p>page one</p><div popover>the popover</div>`,
+	);
+	popover.showPopover();
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toContain("the popover");
+
+	popover.remove();
+	await nextFrame(dom);
+	expect(popover.matches(":popover-open")).toBe(false);
+	expect(terminal.getPlainText()).not.toContain("the popover");
+	dom.dispose();
+});
+
+test("changing the attribute's state closes a showing popover", async () => {
+	const {dom, popover} = await open(`<div popover=auto>hi</div>`);
+	popover.showPopover();
+	popover.setAttribute("popover", "manual");
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+/* ---------------------------------------------------------------- events */
+
+test("beforetoggle and toggle report the states either side of the move", async () => {
+	const {dom, popover} = await open(`<div popover>hi</div>`);
+	const seen: string[] = [];
+	for (const type of ["beforetoggle", "toggle"]) {
+		popover.addEventListener(type, (event: any) => {
+			seen.push(`${type} ${event.oldState}->${event.newState}`);
+		});
+	}
+
+	popover.showPopover();
+	await nextFrame(dom);
+	popover.hidePopover();
+	await nextFrame(dom);
+
+	expect(seen).toEqual([
+		"beforetoggle closed->open",
+		"toggle closed->open",
+		"beforetoggle open->closed",
+		"toggle open->closed",
+	]);
+	dom.dispose();
+});
+
+test("a canceled beforetoggle keeps the popover closed", async () => {
+	const {dom, popover} = await open(`<div popover>hi</div>`);
+	const seen: string[] = [];
+	popover.addEventListener("beforetoggle", (event: Event) => {
+		seen.push("beforetoggle");
+		event.preventDefault();
+	});
+	popover.addEventListener("toggle", () => seen.push("toggle"));
+
+	popover.showPopover();
+	await nextFrame(dom);
+	expect(popover.matches(":popover-open")).toBe(false);
+	expect(seen).toEqual(["beforetoggle"]);
+
+	// Closing is not cancelable: a popover that will not close is a trap.
+	popover.togglePopover(true);
+	dom.dispose();
+});
+
+test("a show and a hide in one turn report one toggle, of the state it settled on", async () => {
+	const {dom, popover} = await open(`<div popover>hi</div>`);
+	const seen: string[] = [];
+	popover.addEventListener("toggle", (event: any) => {
+		seen.push(`${event.oldState}->${event.newState}`);
+	});
+
+	popover.showPopover();
+	popover.hidePopover();
+	await nextFrame(dom);
+	expect(seen).toEqual(["closed->closed"]);
+	dom.dispose();
+});
+
+/* -------------------------------------------------------------- invokers */
+
+test("a button with popovertarget toggles the popover it names", async () => {
+	const {document, dom, popover} = await open(
+		`<button popovertarget=pop>Open</button><div id=pop popover>hi</div>`,
+	);
+	const button = document.querySelector("button") as HTMLButtonElement;
+	expect(button.popoverTargetElement).toBe(popover);
+	expect(button.popoverTargetAction).toBe("toggle");
+
+	button.click();
+	expect(popover.matches(":popover-open")).toBe(true);
+	button.click();
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("popovertargetaction names which half of the toggle runs", async () => {
+	const {document, dom, popover} = await open(
+		`<button id=show popovertarget=pop popovertargetaction=show>Show</button>` +
+			`<button id=hide popovertarget=pop popovertargetaction=hide>Hide</button>` +
+			`<div id=pop popover>hi</div>`,
+	);
+	const show = document.getElementById("show") as HTMLButtonElement;
+	const hide = document.getElementById("hide") as HTMLButtonElement;
+
+	hide.click();
+	expect(popover.matches(":popover-open")).toBe(false);
+	show.click();
+	show.click();
+	expect(popover.matches(":popover-open")).toBe(true);
+	hide.click();
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("an input that is a button invokes; one that is not does nothing", async () => {
+	const {document, dom, popover} = await open(
+		`<input id=button type=button popovertarget=pop value=Open>` +
+			`<input id=text type=text popovertarget=pop>` +
+			`<div id=pop popover>hi</div>`,
+	);
+	const text = document.getElementById("text") as HTMLInputElement;
+	text.click();
+	expect(popover.matches(":popover-open")).toBe(false);
+
+	(document.getElementById("button") as HTMLInputElement).click();
+	expect(popover.matches(":popover-open")).toBe(true);
+	dom.dispose();
+});
+
+test("a submit button is not an invoker, and a disabled one is not either", async () => {
+	const {document, dom, popover} = await open(
+		`<form><button id=submit popovertarget=pop>Send</button></form>` +
+			`<button id=off popovertarget=pop disabled>Open</button>` +
+			`<div id=pop popover>hi</div>`,
+	);
+	const submit = document.getElementById("submit") as HTMLButtonElement;
+	// The attribute is on it, but its activation is the submission.
+	expect(submit.popoverTargetElement).toBe(popover);
+	submit.click();
+	expect(popover.matches(":popover-open")).toBe(false);
+
+	(document.getElementById("off") as HTMLButtonElement).click();
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("popoverTargetElement takes an element, not only an id", async () => {
+	const {document, dom, popover} = await open(
+		`<button>Open</button><div popover>hi</div>`,
+	);
+	const button = document.querySelector("button") as HTMLButtonElement;
+	expect(button.popoverTargetElement).toBe(null);
+
+	button.popoverTargetElement = popover;
+	expect(button.popoverTargetElement).toBe(popover);
+	button.click();
+	expect(popover.matches(":popover-open")).toBe(true);
+
+	button.popoverTargetElement = null;
+	expect(button.hasAttribute("popovertarget")).toBe(false);
+	expect(button.popoverTargetElement).toBe(null);
+	dom.dispose();
+});
+
+/* ---------------------------------------------------------- light dismiss */
+
+test("a click outside an auto popover closes it, and one inside does not", async () => {
+	const {terminal, dom, popover} = await open(
+		`<p>page one</p><div popover><p>the popover</p></div>`,
+	);
+	popover.showPopover();
+	await nextFrame(dom);
+	const rect = popover.getBoundingClientRect();
+
+	// Inside the popover: it stays.
+	await click(
+		terminal,
+		Math.round(rect.left + rect.width / 2) + 1,
+		Math.round(rect.top) + 2,
+	);
+	expect(popover.matches(":popover-open")).toBe(true);
+
+	// The corner of the screen is past it, and past it is dismissal.
+	await click(terminal, 1, 1);
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("a click on a popover's own invoker toggles rather than reopens", async () => {
+	const {terminal, dom, popover} = await open(
+		`<button popovertarget=pop>Open</button><div id=pop popover>hi</div>`,
+	);
+	// The button is the first thing on the first row.
+	await click(terminal, 3, 1);
+	expect(popover.matches(":popover-open")).toBe(true);
+
+	// Light dismiss treats the invoker as part of the popover it opened, so
+	// the click that follows closes it once rather than closing and reopening.
+	await click(terminal, 3, 1);
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("Escape closes the topmost auto popover", async () => {
+	const {terminal, dom, popover} = await open(
+		`<p>page</p><div popover>the popover</div>`,
+	);
+	popover.showPopover();
+	await nextFrame(dom);
+
+	await press(terminal, "\x1b");
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("a manual popover ignores both the click outside and Escape", async () => {
+	const {terminal, dom, popover} = await open(
+		`<p>page one</p><div popover=manual><p>the popover</p></div>`,
+	);
+	popover.showPopover();
+	await nextFrame(dom);
+
+	await click(terminal, 1, 1);
+	expect(popover.matches(":popover-open")).toBe(true);
+	await press(terminal, "\x1b");
+	expect(popover.matches(":popover-open")).toBe(true);
+
+	popover.hidePopover();
+	expect(popover.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+/* -------------------------------------------------------------- stacking */
+
+test("showing an auto popover closes the open ones it is unrelated to", async () => {
+	const {document, dom} = await open(
+		`<div id=one popover>one</div><div id=two popover>two</div>` +
+			`<div id=manual popover=manual>manual</div>`,
+	);
+	const one = document.getElementById("one") as HTMLElement;
+	const two = document.getElementById("two") as HTMLElement;
+	const manual = document.getElementById("manual") as HTMLElement;
+
+	manual.showPopover();
+	one.showPopover();
+	two.showPopover();
+	expect(one.matches(":popover-open")).toBe(false);
+	expect(two.matches(":popover-open")).toBe(true);
+	// A manual popover is in nobody's stack: an auto one opening leaves it.
+	expect(manual.matches(":popover-open")).toBe(true);
+	dom.dispose();
+});
+
+test("a nested popover joins the stack rather than closing it", async () => {
+	const {document, dom} = await open(
+		`<div id=outer popover>outer<div id=inner popover>inner</div></div>` +
+			`<div id=other popover>other</div>`,
+	);
+	const outer = document.getElementById("outer") as HTMLElement;
+	const inner = document.getElementById("inner") as HTMLElement;
+	const other = document.getElementById("other") as HTMLElement;
+
+	outer.showPopover();
+	inner.showPopover();
+	expect(outer.matches(":popover-open")).toBe(true);
+	expect(inner.matches(":popover-open")).toBe(true);
+
+	// Closing the one underneath closes what is stacked on it.
+	inner.showPopover();
+	outer.hidePopover();
+	expect(inner.matches(":popover-open")).toBe(false);
+
+	// And an unrelated popover closes the whole stack.
+	outer.showPopover();
+	inner.showPopover();
+	other.showPopover();
+	expect(outer.matches(":popover-open")).toBe(false);
+	expect(inner.matches(":popover-open")).toBe(false);
+	dom.dispose();
+});
+
+test("a popover invoked from inside another is the inner one of a stack", async () => {
+	const {document, dom} = await open(
+		`<div id=outer popover>` +
+			`<button popovertarget=inner>More</button></div>` +
+			`<div id=inner popover>inner</div>`,
+	);
+	const outer = document.getElementById("outer") as HTMLElement;
+	const inner = document.getElementById("inner") as HTMLElement;
+
+	outer.showPopover();
+	(document.querySelector("button") as HTMLButtonElement).click();
+	// The invoker's popover is the parent, so the outer one survives its
+	// child opening -- the node trees are siblings, the invocation is not.
+	expect(outer.matches(":popover-open")).toBe(true);
+	expect(inner.matches(":popover-open")).toBe(true);
+	dom.dispose();
+});
+
+/* ----------------------------------------------------------------- focus */
+
+test("focus moves into a popover only where the content asks for it", async () => {
+	const {document, dom} = await open(
+		`<button id=page>page</button>` +
+			`<div id=plain popover><button id=first>first</button></div>` +
+			`<div id=asking popover><button id=second autofocus>second</button></div>`,
+	);
+	const plain = document.getElementById("plain") as HTMLElement;
+	const asking = document.getElementById("asking") as HTMLElement;
+	(document.getElementById("page") as HTMLElement).focus();
+
+	// Unlike a dialog, a popover does not take focus off the page by opening.
+	plain.showPopover();
+	await nextFrame(dom);
+	expect(document.activeElement?.id).toBe("page");
+	plain.hidePopover();
+
+	asking.showPopover();
+	await nextFrame(dom);
+	expect(document.activeElement?.id).toBe("second");
+
+	// Closing gives focus back to what had it when the stack opened.
+	asking.hidePopover();
+	expect(document.activeElement?.id).toBe("page");
+	dom.dispose();
+});


### PR DESCRIPTION
Implements the HTML Popover API on the top-layer foundation from #32. The `popover` attribute previously reflected but did nothing.

Behavior:

- Attribute states: absent → not a popover (methods throw `NotSupportedError`); `""`/`auto` → auto; `manual` and unknown values → manual (the spec's invalid-value default). `popover=""` reflects as `"auto"`.
- `showPopover()`/`hidePopover()`/`togglePopover(force)` with the spec's error and no-op conditions; hidden-until-shown via the UA sheet; popovers paint in the top layer with `::backdrop` (transparent by default per spec, author-stylable).
- `beforetoggle` (cancelable on opening) and `toggle` with `oldState`/`newState`, reusing the ToggleEvent interface; toggle events coalesce per spec.
- Invokers: `popovertarget`/`popovertargetaction` on buttons and button-like inputs, including `popoverTargetElement` as a reflected element reference; disabled and form-submit buttons are not invokers.
- Light dismiss for auto popovers: mousedown/mouseup agreement on a point outside closes up to the clicked popover (invoker exempt via nearest-target rules); Escape closes the topmost top-layer entrant that answers a close request, so a popover over a modal dialog closes first, and fullscreen still consumes the key ahead of both.
- Auto stacking: derived from the document top layer (no parallel list); showing an auto popover closes unrelated ones; nested and invoked-from-inside popovers form a stack.
- `:popover-open` registered in the selector engine like `:modal`.

Excluded, documented in code: the `hint` state (takes the unknown-value route to manual; its second showing list and effective-type downgrade are disproportionate for now), `commandfor`/`command` (separate feature), and the fullscreen-flag validity check (fullscreen lives in the renderer).

One engine seam added: popover state changes are not DOM mutations, so the frame gate skipped the repaint; `UAEngine.stateChanged(element)` now routes state flips through style damage and a render request.

Tests: 27 cases in `tests/popover.test.ts` covering states, reflection, methods and errors, events, invokers, light dismiss, Escape ordering, manual immunity, stacking, focus. Full suite passes: node 1208, bun 1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
