### PR TITLE
Fix mode-probe echo on terminals without DECRQM

### DIFF
--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -1839,6 +1839,10 @@ export class TermDOM {
 			this.#session.initializeCursorDetection();
 			void this.#session.negotiateBidi();
 			void this.#session.negotiateGraphemeClusters();
+			// A terminal that does not implement a mode report may echo the
+			// request's final byte as text. Homing and erasing the line
+			// disposes of any echo before the first frame claims the row.
+			void this.#session.write("\r\x1b[K");
 			this.#attachBeginning = false;
 			begun();
 

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -1839,10 +1839,7 @@ export class TermDOM {
 			this.#session.initializeCursorDetection();
 			void this.#session.negotiateBidi();
 			void this.#session.negotiateGraphemeClusters();
-			// A terminal that does not implement a mode report may echo the
-			// request's final byte as text. Homing and erasing the line
-			// disposes of any echo before the first frame claims the row.
-			void this.#session.write("\r\x1b[K");
+			this.#session.scrubProbeEcho();
 			this.#attachBeginning = false;
 			begun();
 

--- a/src/internal/terminalsession.ts
+++ b/src/internal/terminalsession.ts
@@ -949,6 +949,16 @@ export class TerminalSession {
 	 * measurements do not change, because they were already cluster-based; what
 	 * changes is only whether the terminal agrees with them.
 	 */
+	/**
+	 * A terminal that does not implement a mode report may echo the
+	 * request's final byte as text. Homing and erasing the line disposes
+	 * of any echo, so the first frame starts on a clean row.
+	 */
+	scrubProbeEcho(): void {
+		if (!this.#interactive) return;
+		void this.write("\r\x1b[K");
+	}
+
 	async negotiateGraphemeClusters(): Promise<void> {
 		if (!this.#interactive) return;
 

--- a/tests/attach.test.ts
+++ b/tests/attach.test.ts
@@ -361,3 +361,29 @@ test("BeforeUnloadEvent is the interface a browser exposes", async () => {
 	expect(watched.closes()).toBe(0);
 	await dom.dispose();
 });
+
+test("the mode probes are followed by an erase for any echoed final", async () => {
+	// A terminal without DECRQM can stop parsing at the $ intermediate and
+	// print the trailing p as text. The line erase after the probes makes
+	// that echo invisible whatever the terminal did with the requests.
+	const terminal = new MockProcess({cols: 40, rows: 10});
+	// The sink only records: the assertion is about byte order, and a
+	// capture-only stream behaves the same under node and bun.
+	let out = "";
+	const transport = {
+		...terminal.transport,
+		writable: new WritableStream<string>({
+			write(chunk) {
+				out += chunk;
+			},
+		}),
+	};
+	const dom = new TermDOM({transport});
+	dom.attach();
+	await nextFrame(dom);
+	const lastProbe = out.lastIndexOf("$p");
+	const scrub = out.indexOf("\r\x1b[K", lastProbe);
+	expect(lastProbe).toBeGreaterThan(-1);
+	expect(scrub).toBeGreaterThan(lastProbe);
+	await dom.dispose();
+});


### PR DESCRIPTION
At attach the session probes bidi (`ESC[8$p`) and grapheme clustering (`ESC[?2027$p`). Terminal.app has no DECRQM; its parser stops at the `$` intermediate and prints the trailing `p` as text, which lands above the first frame and stays visible (reported with a screenshot, raw Terminal.app only — tmux consumes the sequence correctly).

Fix: a `CR ESC[K` after the probe writes erases anything a terminal echoed, before the first frame claims the row. One write, no behavior change on terminals that consume the probes.

Test: a capture-only transport asserts the erase follows the last probe in the output stream. Full suite passes: node 1228, bun 1253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD