### PR TITLE
Fix @layer/@scope cascade participation, selector specificity, and missing shorthands

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,8 +7,8 @@ properties. Every row is a probe -- the feature applied to a real
 document and rendered, with the row recording whether the output
 changed.
 
-162 features supported, 61 probed and unsupported,
-156 CSS properties not applicable to a character grid,
+170 features supported, 54 probed and unsupported,
+157 CSS properties not applicable to a character grid,
 129 applicable and not implemented,
 4 not yet probed.
 
@@ -49,6 +49,8 @@ changed.
 | `@media (width)` | yes |
 | `@media (height)` | yes |
 | `@supports` | yes |
+| `@layer` | yes |
+| `@scope` | yes |
 | `Custom properties (var)` | yes |
 | `!important` | yes |
 
@@ -193,8 +195,8 @@ changed.
 | `text-align` | yes |
 | `text-indent` | yes |
 | `white-space` | yes |
-| `word-break` | no (no effect) |
-| `overflow-wrap` | no (no effect) |
+| `word-break` | yes |
+| `overflow-wrap` | yes |
 | `line-height` | no (no effect) |
 | `direction` | yes |
 | `opacity` | no (no effect) |
@@ -221,7 +223,6 @@ changed.
 
 | feature | supported |
 | --- | --- |
-| `transform` | no (no effect) |
 | `transition` | no (no effect) |
 | `animation` | no (no effect) |
 | `box-shadow` | no (no effect) |
@@ -258,10 +259,10 @@ changed.
 | `max-inline-size` | yes |
 | `min-block-size` | yes |
 | `max-block-size` | yes |
-| `flex-flow` | no (no effect) |
-| `place-content` | no (no effect) |
-| `place-items` | no (no effect) |
-| `place-self` | no (no effect) |
+| `flex-flow` | yes |
+| `place-content` | yes |
+| `place-items` | yes |
+| `place-self` | yes |
 | `justify-items` | no (no effect) |
 | `justify-self` | no (no effect) |
 | `caption-side` | no (no effect) |
@@ -294,7 +295,7 @@ changed.
 
 These properties have no rendering a grid of characters can carry.
 
-**Transforms, 3D and motion paths, which need sub-cell geometry.** `backface-visibility`, `offset`, `offset-anchor`, `offset-distance`, `offset-path`, `offset-position`, `offset-rotate`, `perspective`, `perspective-origin`, `rotate`, `scale`, `transform-box`, `transform-origin`, `transform-style`, `translate`, `zoom`
+**Transforms, 3D and motion paths, which need sub-cell geometry.** `backface-visibility`, `offset`, `offset-anchor`, `offset-distance`, `offset-path`, `offset-position`, `offset-rotate`, `perspective`, `perspective-origin`, `rotate`, `scale`, `transform`, `transform-box`, `transform-origin`, `transform-style`, `translate`, `zoom`
 
 **Raster imagery and compositing, which need pixels.** `backdrop-filter`, `background-attachment`, `background-blend-mode`, `background-image`, `background-origin`, `background-position`, `background-position-x`, `background-position-y`, `background-repeat`, `background-size`, `border-image`, `border-image-outset`, `border-image-repeat`, `border-image-slice`, `border-image-source`, `border-image-width`, `clip-path`, `dynamic-range-limit`, `image-orientation`, `image-rendering`, `mask`, `mask-border`, `mask-border-mode`, `mask-border-outset`, `mask-border-repeat`, `mask-border-slice`, `mask-border-source`, `mask-border-width`, `mask-clip`, `mask-composite`, `mask-image`, `mask-mode`, `mask-origin`, `mask-position`, `mask-repeat`, `mask-size`, `mix-blend-mode`, `object-fit`, `object-position`, `shape-image-threshold`, `shape-margin`, `shape-outside`
 

--- a/scripts/support-matrix.ts
+++ b/scripts/support-matrix.ts
@@ -63,6 +63,8 @@ interface Feature {
 }
 
 const LONG = "the quick brown fox jumps over the lazy dog again and again";
+/** A word no line of the probe document is wide enough to hold. */
+const UNBREAKABLE = "supercalifragilisticexpialidocious";
 const FLEX = "#parent { display: flex; }";
 const NARROW = "#probe { width: 10ch; }";
 
@@ -247,11 +249,13 @@ const FEATURES: Record<string, Feature> = {
 	"text-align": {value: "right"},
 	"text-indent": {value: "4ch"},
 	"white-space": {value: "pre", setup: NARROW, text: LONG},
-	"word-break": {value: "break-all", setup: NARROW, text: LONG},
+	// Breaking inside a word takes a word too long for the line: every word of
+	// LONG fits in ten columns, so LONG measures nothing here.
+	"word-break": {value: "break-all", setup: NARROW, text: UNBREAKABLE},
 	"overflow-wrap": {
 		value: "break-word",
 		setup: NARROW,
-		markup: "supercalifragilisticexpialidocious",
+		text: UNBREAKABLE,
 	},
 	"line-height": {value: "2"},
 	direction: {value: "rtl"},
@@ -308,7 +312,6 @@ const FEATURES: Record<string, Feature> = {
 	"counter-increment": {value: "c 2"},
 
 	// Deliberately unsupported, probed so the claim stays honest
-	transform: {value: "rotate(45deg)"},
 	transition: {value: "color 1s"},
 	animation: {value: "spin 1s"},
 	"box-shadow": {value: "1px 1px red"},
@@ -474,11 +477,7 @@ function generatedFeatures(): Record<string, Feature> {
 	out["text-wrap"] = {value: "nowrap", setup: NARROW, text: LONG};
 	out["text-wrap-mode"] = {value: "nowrap", setup: NARROW, text: LONG};
 	out["white-space-collapse"] = {value: "preserve", setup: NARROW, text: LONG};
-	out["word-wrap"] = {
-		value: "break-word",
-		setup: NARROW,
-		text: "supercalifragilisticexpialidocious",
-	};
+	out["word-wrap"] = {value: "break-word", setup: NARROW, text: UNBREAKABLE};
 	out["line-clamp"] = {value: "1", setup: NARROW, text: LONG};
 	out["counter-set"] = {value: "c 3"};
 	out["font"] = {value: "bold 1px monospace"};
@@ -539,6 +538,11 @@ function generatedFeatures(): Record<string, Feature> {
  * stops the run.
  */
 const NOT_APPLICABLE: Array<[string, string[]]> = [
+	// `transform` is here rather than probed: a rotation or a scale has no
+	// reading on a grid of whole cells, and the one transform that would --
+	// translating a box by whole cells -- is refused, because supporting the
+	// property for the values that happen to land on the grid would report as
+	// support for the property.
 	[
 		"Transforms, 3D and motion paths, which need sub-cell geometry",
 		[
@@ -553,6 +557,7 @@ const NOT_APPLICABLE: Array<[string, string[]]> = [
 			"perspective-origin",
 			"rotate",
 			"scale",
+			"transform",
 			"transform-box",
 			"transform-origin",
 			"transform-style",
@@ -1105,7 +1110,6 @@ const CATEGORIES: Array<[string, string[]]> = [
 	[
 		"Graphical effects",
 		[
-			"transform",
 			"transition",
 			"animation",
 			"box-shadow",
@@ -1252,6 +1256,16 @@ function buildProbes(): Probe[] {
 		cssBlockProbe(
 			"@supports",
 			`@supports (color: red) { ${paints("#probe")} }`,
+			"At-rules",
+		),
+		cssBlockProbe(
+			"@layer",
+			`@layer base, theme; @layer theme { ${paints("#probe")} }`,
+			"At-rules",
+		),
+		cssBlockProbe(
+			"@scope",
+			`@scope (#parent) { ${paints("#probe")} }`,
 			"At-rules",
 		),
 		cssBlockProbe(

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -1167,10 +1167,28 @@ for (const [shorthand, all] of Object.entries(CSS_SHORTHANDS)) {
 							longhand.endsWith(`-${LINE_COMPONENTS[index]}`),
 					  )
 					? "line"
-					: indexed.length === 2
+					: indexed.length === 2 && axisPair(shorthand, indexed)
 						? "pair"
 						: "sequence",
 	);
+}
+
+/**
+ * Whether a two-longhand shorthand states ONE property on two axes -- `gap`,
+ * `overflow`, `place-content`, `margin-inline` -- rather than two properties
+ * side by side. An axis pair writes one value where its two agree, and copies
+ * a single stated value to both; a shorthand like `flex-flow` writes each
+ * component it has and drops the ones left at their initial value.
+ *
+ * The two longhands of an axis pair name the shorthand's own property: they
+ * are built on it as a stem, or they end in the segment it ends in.
+ */
+function axisPair(shorthand: string, longhands: readonly string[]): boolean {
+	if (longhands.every((longhand) => longhand.startsWith(shorthand))) {
+		return true;
+	}
+	const segment = shorthand.slice(shorthand.lastIndexOf("-") + 1);
+	return longhands.every((longhand) => longhand.endsWith(`-${segment}`));
 }
 
 /**

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -7599,6 +7599,8 @@ export class StyleManager {
 	#pseudoRulesByType = new Map<string, ParsedCSSRule[]>();
 	#counterRulesExist = false;
 	#listItemRulesExist = false;
+	/** Whether any rule is scoped, which is what puts proximity in the sort. */
+	#scopedRulesExist = false;
 	// The `:focus-visible` state, driven by TermDOM from the last input modality
 	// (keyboard true, pointer false). #ruleMatches gates such rules on it.
 	#focusVisibleActive = true;
@@ -8221,6 +8223,7 @@ export class StyleManager {
 		this.#pseudoSubjectTags = undefined;
 		this.#counterRulesExist = false;
 		this.#listItemRulesExist = false;
+		this.#scopedRulesExist = false;
 		this.#stylesheetsDirty = false;
 		this.#layerPaths = [];
 		this.#anonymousLayers = 0;
@@ -8593,7 +8596,11 @@ export class StyleManager {
 		// only known once every sheet has been read: the rank is filled in
 		// then, and this is the value it is filled in from.
 		const layer = context.layer;
-		const scopes = context.scopes.length > 0 ? context.scopes : undefined;
+		let scopes: readonly ScopeCondition[] | undefined;
+		if (context.scopes.length > 0) {
+			scopes = context.scopes;
+			this.#scopedRulesExist = true;
+		}
 		let namespace: string | null | undefined;
 		if (sheetNamespaces !== NO_NAMESPACES || selector.includes("|")) {
 			const resolved = selectorNamespace(selector, sheetNamespaces);
@@ -8754,7 +8761,7 @@ export class StyleManager {
 		// is infinitely far from one. The rules arrive in cascade order and
 		// the sort is stable, so a comparison that only answers for proximity
 		// leaves every other tier as it found it.
-		if (!matched.some((rule) => rule.scopes)) return matched;
+		if (!this.#scopedRulesExist) return matched;
 		const proximity = new Map(
 			matched.map(
 				(rule) =>
@@ -8770,6 +8777,21 @@ export class StyleManager {
 			if (a.specificity !== b.specificity) return 0;
 			return proximity.get(b)! - proximity.get(a)!;
 		});
+	}
+
+	/**
+	 * Whether an element matches one of a rule's selectors. A scoped rule's
+	 * selector is written relative to a scoping root and reaches only the
+	 * elements that root has in scope; every other rule's is matched by the
+	 * DOM outright.
+	 */
+	#matchesRule(
+		element: Element,
+		rule: ParsedCSSRule,
+		selector: string,
+	): boolean {
+		if (!rule.scopes) return element.matches(selector);
+		return this.#scopingRoot(element, {...rule, selector}) !== null;
 	}
 
 	/**
@@ -8883,12 +8905,6 @@ export class StyleManager {
 			) {
 				return false;
 			}
-			// A scoped rule's selector is written relative to a scoping root,
-			// and reaches only the elements that root has in scope.
-			const matchesRule = (selector: string): boolean =>
-				rule.scopes
-					? this.#scopingRoot(element, {...rule, selector}) !== null
-					: element.matches(selector);
 			// The selector engine treats `:focus-visible` as `:focus`, so gate it
 			// on our own flag.
 			if (
@@ -8910,12 +8926,14 @@ export class StyleManager {
 			}
 			const root = element.getRootNode();
 			if (rule.scope) {
-				return root === rule.scope && matchesRule(rule.selector);
+				return (
+					root === rule.scope && this.#matchesRule(element, rule, rule.selector)
+				);
 			}
 			// UA document rules apply in EVERY tree scope, as a browser's own
 			// UA sheet styles shadow trees.
 			if (rule.uaOrigin) {
-				return matchesRule(rule.selector);
+				return this.#matchesRule(element, rule, rule.selector);
 			}
 			// AUTHOR document rules match everything OUTSIDE shadow trees --
 			// including detached elements (styles resolve before insertion,
@@ -8923,7 +8941,7 @@ export class StyleManager {
 			// shadow root.
 			const inShadowTree =
 				root.nodeType === 11 && Boolean((root as ShadowRoot).host);
-			return !inShadowTree && matchesRule(rule.selector);
+			return !inShadowTree && this.#matchesRule(element, rule, rule.selector);
 		} catch (err) {
 			// Fallback for unsupported selectors
 			return false;

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -6290,12 +6290,26 @@ export class ComputedStyleDeclaration extends CSSStyleProperties {
 		// so within each tier the last match wins.
 		let ruleValue: string | null = null;
 		let importantRuleValue: string | null = null;
+		// `!important` reverses the layer order (css-cascade-5 §6.4.4): the
+		// EARLIEST layer wins, and unlayered declarations -- which win the
+		// normal cascade -- lose to every layer. The rules arrive with the
+		// earliest layer first, so the first layer to declare the property
+		// keeps it, and later ones only tie it within the same layer.
+		let importantOrigin = false;
+		let importantLayer = 0;
 		for (const rule of this.#cssRules) {
 			const name = declaredName(rule, names, false, mapsHere);
 			if (name !== null) ruleValue = rule.declarations[name];
 			const importantName = declaredName(rule, names, true, mapsHere);
-			if (importantName !== null) {
+			if (
+				importantName !== null &&
+				(importantRuleValue === null ||
+					Boolean(rule.uaOrigin) !== importantOrigin ||
+					rule.layerRank === importantLayer)
+			) {
 				importantRuleValue = rule.declarations[importantName];
+				importantOrigin = Boolean(rule.uaOrigin);
+				importantLayer = rule.layerRank;
 			}
 		}
 
@@ -7333,6 +7347,156 @@ interface ParsedCSSRule {
 	 * higher specificity -- exactly the browser's origin ordering.
 	 */
 	uaOrigin?: boolean;
+	/**
+	 * The cascade layer this rule was declared in, dot-joined through every
+	 * enclosing `@layer`, or null for a rule in no layer.
+	 */
+	layer: string | null;
+	/**
+	 * Where the rule's layer sorts, smallest first: layers in the order their
+	 * names were declared, then -- last, and so winning the normal cascade --
+	 * every unlayered rule. Filled in once the whole layer order is known.
+	 */
+	layerRank: number;
+	/**
+	 * The `@scope` conditions the rule was declared inside, outermost first.
+	 * Absent for a rule no `@scope` encloses, which is in scope everywhere.
+	 */
+	scopes?: readonly ScopeCondition[];
+}
+
+/**
+ * One `@scope (start) to (end)` prelude: the selector lists naming the scoping
+ * roots and the scoping limits. `start` is null for `@scope` written without a
+ * root, whose root is the element the stylesheet's owner node sits in.
+ */
+interface ScopeCondition {
+	start: string | null;
+	end: string | null;
+	/** The implicit scoping root, for a condition that names none. */
+	owner: Element | null;
+}
+
+/** The conditional rules a style rule was found inside, as the cascade reads them. */
+interface RuleContext {
+	layer: string | null;
+	scopes: readonly ScopeCondition[];
+}
+
+/** The context of a rule at the top level of a stylesheet. */
+const UNCONDITIONAL: RuleContext = {layer: null, scopes: []};
+
+/**
+ * The proximity of a declaration in no scope: farther from any element than
+ * any scoping root can be, and the same distance for every one of them.
+ */
+const UNSCOPED = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Whether an element is a scoping root of this condition. A condition naming
+ * no root has one all the same: the element the stylesheet was written in.
+ */
+function scopeRootMatches(
+	element: Element,
+	condition: ScopeCondition,
+	outer: Element | null,
+): boolean {
+	if (condition.start === null) return element === condition.owner;
+	return splitSelectorList(condition.start).some((selector) =>
+		outer
+			? matchesInScope(element, selector, outer)
+			: matchesSelector(element, selector),
+	);
+}
+
+/**
+ * Whether an element is in the scope a root opens: inside it, and with no
+ * scoping limit between the two. The root is always in its own scope, limit
+ * or no limit.
+ */
+function inScopeOf(
+	element: Element,
+	root: Element,
+	condition: ScopeCondition,
+): boolean {
+	const limits = condition.end ? splitSelectorList(condition.end) : [];
+	let node: Element | null = element;
+	for (; node && node !== root; node = node.parentElement) {
+		if (limits.some((selector) => matchesInScope(node!, selector, root))) {
+			return false;
+		}
+	}
+	return node === root;
+}
+
+/** `element.matches`, with a selector the matcher rejects matching nothing. */
+function matchesSelector(element: Element, selector: string): boolean {
+	try {
+		return element.matches(selector);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Whether an element matches a scoped selector, `:scope` standing for the
+ * given scoping root.
+ *
+ * A selector opening with a combinator is relative to the root, which is what
+ * `@scope { > .a { } }` means. The root's own subtree is the DOM's own scoping
+ * root, so a selector reaching down from `:scope` is matched by asking it for
+ * the elements it selects; a selector whose subject IS the root cannot be, and
+ * matches with `:scope` standing for any element -- the identity it asserts is
+ * already established.
+ */
+function matchesInScope(
+	element: Element,
+	selector: string,
+	root: Element,
+): boolean {
+	let text = selector.trim();
+	if (/^[>+~]/.test(text)) text = `:scope ${text}`;
+	try {
+		if (!text.includes(":scope")) return element.matches(text);
+		if (element === root) {
+			const subject = subjectCompoundStart(text);
+			// `:scope` on a non-subject compound asks the root to be a strict
+			// descendant of itself.
+			if (text.slice(0, subject).includes(":scope")) return false;
+			return element.matches(
+				text.slice(0, subject) + text.slice(subject).replaceAll(":scope", "*"),
+			);
+		}
+		for (const found of root.querySelectorAll(text)) {
+			if (found === element) return true;
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+/** Where a complex selector's subject compound starts: past its last combinator. */
+function subjectCompoundStart(selector: string): number {
+	let depth = 0;
+	let quote = "";
+	let start = 0;
+	for (let index = 0; index < selector.length; index++) {
+		const char = selector[index];
+		if (quote) {
+			if (char === "\\") index++;
+			else if (char === quote) quote = "";
+		} else if (char === '"' || char === "'") {
+			quote = char;
+		} else if (char === "(" || char === "[") {
+			depth++;
+		} else if (char === ")" || char === "]") {
+			depth--;
+		} else if (depth === 0 && /[\s>+~]/.test(char)) {
+			start = index + 1;
+		}
+	}
+	return start;
 }
 
 // CSS Counter interfaces
@@ -8040,6 +8204,8 @@ export class StyleManager {
 		this.#counterRulesExist = false;
 		this.#listItemRulesExist = false;
 		this.#stylesheetsDirty = false;
+		this.#layerPaths = [];
+		this.#anonymousLayers = 0;
 		this.#parsedStyleSheetCount = this.#styleSheetCount();
 
 		// The UA document sheet parses first; origin ordering (not source
@@ -8059,20 +8225,83 @@ export class StyleManager {
 			}
 		}
 
+		const layerRanks = this.#rankLayers();
+		for (const rule of this.#parsedRules) {
+			rule.layerRank =
+				rule.layer === null
+					? this.#unlayeredRank
+					: (layerRanks.get(rule.layer) ?? this.#unlayeredRank);
+		}
+
 		// Sort rules for cascade resolution: origin first (UA rules sort
-		// below every author rule -- later wins), then specificity.
+		// below every author rule -- later wins), then cascade layer, then
+		// specificity, then the order the rules were read in.
+		const sourceOrder = new Map(
+			this.#parsedRules.map((rule, index) => [rule, index] as const),
+		);
 		this.#parsedRules.sort((a, b) => {
 			if (Boolean(a.uaOrigin) !== Boolean(b.uaOrigin)) {
 				return a.uaOrigin ? -1 : 1;
 			}
+			if (a.layerRank !== b.layerRank) return a.layerRank - b.layerRank;
 			if (a.specificity !== b.specificity) {
 				return a.specificity < b.specificity ? -1 : 1;
 			}
-			// Use array index as source order tie-breaker
-			return this.#parsedRules.indexOf(a) - this.#parsedRules.indexOf(b);
+			return sourceOrder.get(a)! - sourceOrder.get(b)!;
 		});
 		this.clearCache();
 		this.#attachPseudoElements();
+	}
+
+	/**
+	 * Every cascade layer, in the order its name was first declared: a
+	 * `@layer a, b;` statement, a `@layer a { }` block, or the anonymous layer
+	 * an unnamed block opens. A nested layer's path is dot-joined through its
+	 * ancestors, which is the name `@layer a.b` writes for itself.
+	 */
+	#layerPaths: string[] = [];
+	#anonymousLayers = 0;
+
+	/** Where an unlayered rule sorts: after every layer, and so above them. */
+	#unlayeredRank = 0;
+
+	/** Name a layer, and every layer its path nests inside, in declaration order. */
+	#declareLayer(outer: string | null, name: string): string {
+		const path = outer === null ? name : `${outer}.${name}`;
+		const segments = path.split(".");
+		for (let depth = 1; depth <= segments.length; depth++) {
+			const prefix = segments.slice(0, depth).join(".");
+			if (!this.#layerPaths.includes(prefix)) this.#layerPaths.push(prefix);
+		}
+		return path;
+	}
+
+	/**
+	 * Where each layer sorts. Layers sort in the order their names were
+	 * declared, and a layer's OWN rules sort after the rules of every layer
+	 * nested inside it -- the same relation unlayered rules have to layers,
+	 * one level down. Smallest first, so the last layer, and then the
+	 * unlayered rules above it, win the normal cascade; the important cascade
+	 * reads the same order backwards.
+	 */
+	#rankLayers(): Map<string, number> {
+		const nested = new Map<string, string[]>();
+		for (const path of this.#layerPaths) {
+			const dot = path.lastIndexOf(".");
+			const outer = dot === -1 ? "" : path.slice(0, dot);
+			const siblings = nested.get(outer);
+			if (siblings) siblings.push(path);
+			else nested.set(outer, [path]);
+		}
+		const ranks = new Map<string, number>();
+		let next = 0;
+		const rank = (path: string): void => {
+			for (const inner of nested.get(path) ?? []) rank(inner);
+			if (path !== "") ranks.set(path, next++);
+		};
+		rank("");
+		this.#unlayeredRank = next;
+		return ranks;
 	}
 
 	/**
@@ -8082,11 +8311,19 @@ export class StyleManager {
 	 * contributes its rules, since what this engine supports is what it
 	 * renders. `@font-face`, `@keyframes` and `@import` have no terminal
 	 * rendering and declare nothing to the cascade.
+	 *
+	 * A grouping rule this walk has no branch for is walked THROUGH: its rules
+	 * cascade without whatever its prelude says about them. For a conditional
+	 * rule that is the wrong answer where the condition is false -- a
+	 * `@container` query the box does not satisfy still paints -- and it is
+	 * the better wrong answer: a rule that applies too widely is one an author
+	 * can see, and one that vanishes with the whole at-rule is not.
 	 */
 	#parseStyleSheet(
 		container: CSSStyleSheet | CSSGroupingRule,
 		scope?: Node,
 		uaOrigin?: boolean,
+		context: RuleContext = UNCONDITIONAL,
 	): void {
 		if (container instanceof CSSStyleSheet) {
 			if (container.disabled) return;
@@ -8094,13 +8331,48 @@ export class StyleManager {
 		}
 		for (const rule of container.cssRules) {
 			if (rule instanceof CSSStyleRule) {
-				this.#parseStyleRule(rule, scope, uaOrigin);
+				this.#parseStyleRule(rule, scope, uaOrigin, context);
 			} else if (rule instanceof CSSMediaRule) {
 				if (this.mediaQueryMatches(rule.conditionText)) {
-					this.#parseStyleSheet(rule, scope, uaOrigin);
+					this.#parseStyleSheet(rule, scope, uaOrigin, context);
 				}
 			} else if (rule instanceof CSSSupportsRule) {
-				this.#parseStyleSheet(rule, scope, uaOrigin);
+				this.#parseStyleSheet(rule, scope, uaOrigin, context);
+			} else if (rule instanceof CSSLayerStatementRule) {
+				// `@layer a, b;` declares the order of layers whose rules come
+				// later, and declares nothing else.
+				for (const name of rule.nameList) {
+					this.#declareLayer(context.layer, name);
+				}
+			} else if (rule instanceof CSSLayerBlockRule) {
+				// An unnamed block opens a layer nothing else can name or reach,
+				// which is a layer of its own wherever it stands.
+				const layer = rule.name
+					? this.#declareLayer(context.layer, rule.name)
+					: this.#declareLayer(context.layer, ` ${this.#anonymousLayers++}`);
+				this.#parseStyleSheet(rule, scope, uaOrigin, {...context, layer});
+			} else if (rule instanceof CSSScopeRule) {
+				const owner = rule.parentStyleSheet?.ownerNode ?? null;
+				this.#parseStyleSheet(rule, scope, uaOrigin, {
+					...context,
+					scopes: [
+						...context.scopes,
+						{
+							start: rule.start,
+							end: rule.end,
+							owner: owner ? owner.parentElement : null,
+						},
+					],
+				});
+			} else if (rule instanceof CSSStartingStyleRule) {
+				// `@starting-style` declares the style a box starts a transition
+				// FROM. This engine runs no transitions, so a rule inside it
+				// would have no moment to stop applying in and would style the
+				// box for good: it parses into the CSSOM and reaches the
+				// cascade never.
+				continue;
+			} else if (rule instanceof CSSGroupingRule) {
+				this.#parseStyleSheet(rule, scope, uaOrigin, context);
 			}
 		}
 	}
@@ -8170,6 +8442,7 @@ export class StyleManager {
 		styleRule: CSSStyleRule,
 		scope?: Node,
 		uaOriginSheet?: boolean,
+		context: RuleContext = UNCONDITIONAL,
 	): void {
 		// A rule's selector list is a set of selectors that share a block, and
 		// each is matched -- and weighed -- on its own. `#a::before, #b` is one
@@ -8177,7 +8450,14 @@ export class StyleManager {
 		const block = styleRule.style.declarationBlock();
 		const namespaces = sheetNamespaces(styleRule.parentStyleSheet);
 		for (const selector of splitSelectorList(styleRule.selectorText)) {
-			this.#parseSelector(selector, block, scope, uaOriginSheet, namespaces);
+			this.#parseSelector(
+				selector,
+				block,
+				scope,
+				uaOriginSheet,
+				namespaces,
+				context,
+			);
 		}
 	}
 
@@ -8288,8 +8568,14 @@ export class StyleManager {
 		scope?: Node,
 		uaOriginSheet?: boolean,
 		sheetNamespaces: SelectorNamespaces = NO_NAMESPACES,
+		context: RuleContext = UNCONDITIONAL,
 	): void {
 		const {declarations, important, order} = block;
+		// A rule's layer decides where it sorts, and the whole layer order is
+		// only known once every sheet has been read: the rank is filled in
+		// then, and this is the value it is filled in from.
+		const layer = context.layer;
+		const scopes = context.scopes.length > 0 ? context.scopes : undefined;
 		let namespace: string | null | undefined;
 		if (sheetNamespaces !== NO_NAMESPACES || selector.includes("|")) {
 			const resolved = selectorNamespace(selector, sheetNamespaces);
@@ -8345,6 +8631,9 @@ export class StyleManager {
 					scope,
 					host: {predicate, rest, child: Boolean(child)},
 					uaOrigin,
+					layer,
+					layerRank: 0,
+					scopes,
 				});
 				return;
 			}
@@ -8376,6 +8665,9 @@ export class StyleManager {
 				scope,
 				uaOrigin,
 				namespace,
+				layer,
+				layerRank: 0,
+				scopes,
 			};
 			this.#parsedRules.push(rule);
 			const byType = this.#pseudoRulesByType.get(pseudoElement);
@@ -8392,6 +8684,9 @@ export class StyleManager {
 				scope,
 				uaOrigin,
 				namespace,
+				layer,
+				layerRank: 0,
+				scopes,
 			});
 		}
 	}
@@ -8411,7 +8706,7 @@ export class StyleManager {
 		const partNames = (element.getAttribute("part") ?? "")
 			.split(/\s+/)
 			.filter(Boolean);
-		return this.#parsedRules.filter((rule) => {
+		const matched = this.#parsedRules.filter((rule) => {
 			if (rule.pseudoElement) {
 				// ::part(name): an author styling an exposed shadow part from
 				// outside. The rule matches the shadow's HOST; its declarations
@@ -8435,6 +8730,88 @@ export class StyleManager {
 			}
 			return this.#ruleMatches(element, rule);
 		});
+		// Scope proximity sorts between specificity and order of appearance
+		// (css-cascade-6 §3.1.3), and unlike either it is a fact about THIS
+		// element: the closer scoping root wins, and a rule in no scope at all
+		// is infinitely far from one. The rules arrive in cascade order and
+		// the sort is stable, so a comparison that only answers for proximity
+		// leaves every other tier as it found it.
+		if (!matched.some((rule) => rule.scopes)) return matched;
+		const proximity = new Map(
+			matched.map(
+				(rule) =>
+					[
+						rule,
+						rule.scopes ? this.#scopeProximity(element, rule) : UNSCOPED,
+					] as const,
+			),
+		);
+		return matched.sort((a, b) => {
+			if (Boolean(a.uaOrigin) !== Boolean(b.uaOrigin)) return 0;
+			if (a.layerRank !== b.layerRank) return 0;
+			if (a.specificity !== b.specificity) return 0;
+			return proximity.get(b)! - proximity.get(a)!;
+		});
+	}
+
+	/**
+	 * How many generations lie between an element and the nearest scoping root
+	 * its rule applies from, or Infinity when the rule names no scope. Only
+	 * ever asked of a rule that matches, so a rule out of scope everywhere has
+	 * already been filtered out.
+	 */
+	#scopeProximity(element: Element, rule: ParsedCSSRule): number {
+		const root = this.#scopingRoot(element, rule);
+		if (!root) return UNSCOPED;
+		let generations = 0;
+		for (
+			let node: Element | null = element;
+			node && node !== root;
+			node = node.parentElement
+		) {
+			generations++;
+		}
+		return generations;
+	}
+
+	/**
+	 * The scoping root a scoped rule reaches this element from, or null when
+	 * no chain of roots puts the element in the rule's scope and matches its
+	 * selector.
+	 *
+	 * Every root is an inclusive ancestor of the element -- that is what being
+	 * in scope means -- so the chain is read outermost first, each condition
+	 * taking the HIGHEST root it can (which constrains the roots inside it
+	 * least), and the innermost taking the NEAREST, which is the one the
+	 * element's selector and its proximity are measured from.
+	 */
+	#scopingRoot(element: Element, rule: ParsedCSSRule): Element | null {
+		const conditions = rule.scopes!;
+		let outer: Element | null = null;
+		for (let index = 0; index < conditions.length; index++) {
+			const condition = conditions[index];
+			const innermost = index === conditions.length - 1;
+			let found: Element | null = null;
+			for (
+				let candidate: Element | null = element;
+				candidate;
+				candidate = candidate.parentElement
+			) {
+				if (outer && candidate !== outer && !outer.contains(candidate)) break;
+				if (!scopeRootMatches(candidate, condition, outer)) continue;
+				if (!inScopeOf(element, candidate, condition)) continue;
+				if (innermost) {
+					if (!matchesInScope(element, rule.selector, candidate)) continue;
+					// The nearest root the rule reaches the element from.
+					found = candidate;
+					break;
+				}
+				found = candidate;
+			}
+			if (!found) return null;
+			outer = found;
+		}
+		return outer;
 	}
 
 	/**
@@ -8488,6 +8865,12 @@ export class StyleManager {
 			) {
 				return false;
 			}
+			// A scoped rule's selector is written relative to a scoping root,
+			// and reaches only the elements that root has in scope.
+			const matchesRule = (selector: string): boolean =>
+				rule.scopes
+					? this.#scopingRoot(element, {...rule, selector}) !== null
+					: element.matches(selector);
 			// The selector engine treats `:focus-visible` as `:focus`, so gate it
 			// on our own flag.
 			if (
@@ -8509,12 +8892,12 @@ export class StyleManager {
 			}
 			const root = element.getRootNode();
 			if (rule.scope) {
-				return root === rule.scope && element.matches(rule.selector);
+				return root === rule.scope && matchesRule(rule.selector);
 			}
 			// UA document rules apply in EVERY tree scope, as a browser's own
 			// UA sheet styles shadow trees.
 			if (rule.uaOrigin) {
-				return element.matches(rule.selector);
+				return matchesRule(rule.selector);
 			}
 			// AUTHOR document rules match everything OUTSIDE shadow trees --
 			// including detached elements (styles resolve before insertion,
@@ -8522,7 +8905,7 @@ export class StyleManager {
 			// shadow root.
 			const inShadowTree =
 				root.nodeType === 11 && Boolean((root as ShadowRoot).host);
-			return !inShadowTree && element.matches(rule.selector);
+			return !inShadowTree && matchesRule(rule.selector);
 		} catch (err) {
 			// Fallback for unsupported selectors
 			return false;

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -4223,31 +4223,140 @@ const SELECTOR_CLASS_NAME = /\.(-?[A-Za-z_][\w-]*)/g;
 /** The ids a compound selector tests. */
 const SELECTOR_ID_NAME = /#(-?[A-Za-z_][\w-]*)/g;
 
-/** Matches a full attribute selector, e.g. `[data-id="#root"]`. */
-const ATTRIBUTE_SELECTOR_MATCHER = /\[[^\]]+\]/g;
+/**
+ * A selector's weight, as the three counts selectors-4 §17 keeps: ids,
+ * then classes/attributes/pseudo-classes, then types/pseudo-elements.
+ */
+type Specificity = [number, number, number];
 
-/** Matches a full pseudo-element expression, e.g. `::part(label)`. */
-const PSEUDO_ELEMENT_EXPRESSION_MATCHER = /::[^\s+>~.#[]+/g;
+/**
+ * The pseudo-classes whose weight is the weight of their most specific
+ * argument, their own name counting for nothing.
+ */
+const ARGUMENT_WEIGHTED_PSEUDO_CLASSES = new Set([
+	"has",
+	"is",
+	"matches",
+	"not",
+	"-moz-any",
+	"-webkit-any",
+]);
 
-/** Matches an id selector, e.g. `#root`. */
-const ID_SELECTOR_MATCHER = /#[^\s+>~.:[]+/g;
+/**
+ * The pseudo-classes that weigh as a class AND take the weight of their most
+ * specific argument on top: `:host(.a)` is a pseudo-class testing a compound,
+ * and `:nth-child(2n of .a)` an index testing one.
+ */
+const COMPOUND_WEIGHTED_PSEUDO_CLASSES = new Set([
+	"host",
+	"host-context",
+	"nth-child",
+	"nth-last-child",
+]);
 
-/** Matches a class selector, e.g. `.item`. */
-const CLASS_SELECTOR_MATCHER = /\.[a-zA-Z][\w-]*/g;
+/** The weight of the heaviest selector in a list; zero for an empty one. */
+function listSpecificity(list: SelectorNode): Specificity {
+	let most: Specificity = [0, 0, 0];
+	for (const selector of childrenOf(list)) {
+		const weight = selectorSpecificityOf(selector);
+		if (
+			weight[0] > most[0] ||
+			(weight[0] === most[0] &&
+				(weight[1] > most[1] || (weight[1] === most[1] && weight[2] > most[2])))
+		) {
+			most = weight;
+		}
+	}
+	return most;
+}
 
-/** Matches a pseudo-class selector, e.g. `:focus`. */
-const PSEUDO_CLASS_SELECTOR_MATCHER = /:(?!:)[a-zA-Z][\w-]*/g;
+/** The weight of one complex selector: every simple selector in it, summed. */
+function selectorSpecificityOf(selector: SelectorNode): Specificity {
+	const total: Specificity = [0, 0, 0];
+	const add = (weight: Specificity): void => {
+		total[0] += weight[0];
+		total[1] += weight[1];
+		total[2] += weight[2];
+	};
+	const argumentWeight = (node: SelectorNode): Specificity => {
+		for (const child of childrenOf(node)) {
+			if (child.type === "SelectorList") return listSpecificity(child);
+			if (child.type === "Selector") return selectorSpecificityOf(child);
+			if (child.type === "Nth" && child.selector) {
+				return listSpecificity(child.selector);
+			}
+		}
+		return [0, 0, 0];
+	};
+	for (const part of childrenOf(selector)) {
+		switch (part.type) {
+			case "IdSelector":
+				total[0]++;
+				break;
+			case "ClassSelector":
+			case "AttributeSelector":
+				total[1]++;
+				break;
+			// The universal selector weighs nothing, in any namespace.
+			case "TypeSelector": {
+				const name = String(part.name ?? "");
+				if (!name.endsWith("*")) total[2]++;
+				break;
+			}
+			// `::slotted(.a)` and `::part(name)`: the pseudo-element weighs as
+			// an element, and a compound it takes weighs on top of that.
+			case "PseudoElementSelector":
+				total[2]++;
+				add(argumentWeight(part));
+				break;
+			case "PseudoClassSelector": {
+				const name = pseudoName(String(part.name ?? ""));
+				// `:before` is the CSS 2 spelling of a pseudo-element, and
+				// weighs as one.
+				if (LEGACY_PSEUDO_ELEMENTS.has(name)) {
+					total[2]++;
+					break;
+				}
+				// `:where()` contributes nothing at all, arguments included.
+				if (name === "where") break;
+				if (ARGUMENT_WEIGHTED_PSEUDO_CLASSES.has(name)) {
+					add(argumentWeight(part));
+					break;
+				}
+				total[1]++;
+				if (COMPOUND_WEIGHTED_PSEUDO_CLASSES.has(name)) {
+					add(argumentWeight(part));
+				}
+				break;
+			}
+		}
+	}
+	return total;
+}
 
-/** Matches a type selector with its leading boundary, e.g. `>button`. */
-const TYPE_SELECTOR_MATCHER = /(?:^|[\s+>~])[a-zA-Z][\w-]*/g;
-
-/** Matches a pseudo-element name, e.g. `::before`. */
-const PSEUDO_ELEMENT_NAME_MATCHER = /::[a-zA-Z][\w-]*/g;
-
-function determineMatchCount(text: string, matcher: RegExp): number {
-	const matches = text.match(matcher);
-	if (!matches) return 0;
-	return matches.length;
+/**
+ * A selector's specificity, zero-padded to "ids-classes-elements" so the
+ * cascade can compare two of them as strings.
+ *
+ * A selector the parser cannot read weighs nothing: the matcher may still
+ * accept it -- it reads a wider selector grammar than this parser does -- and
+ * a rule whose weight cannot be counted is the one that should lose a tie.
+ */
+function selectorSpecificity(selector: string): string {
+	let list: SelectorNode | null = null;
+	try {
+		list = cssTree.parse(selector, {
+			context: "selectorList",
+			onParseError(error: Error) {
+				throw error;
+			},
+		}) as unknown as SelectorNode;
+	} catch {
+		list = null;
+	}
+	const weight =
+		list && list.type === "SelectorList" ? listSpecificity(list) : [0, 0, 0];
+	return weight.map((count) => String(count).padStart(3, "0")).join("-");
 }
 
 /**
@@ -8205,7 +8314,7 @@ export class StyleManager {
 		if (declarations["display"] === "list-item") {
 			this.#listItemRulesExist = true;
 		}
-		const specificity = this.#calculateSpecificity(selector);
+		const specificity = selectorSpecificity(selector);
 		const uaOrigin = Boolean(
 			uaOriginSheet || (scope != null && isUAShadowRoot(scope)),
 		);
@@ -8285,49 +8394,6 @@ export class StyleManager {
 				namespace,
 			});
 		}
-	}
-
-	/**
-	 * Calculate CSS specificity for a selector as zero-padded string
-	 * Format: "000-000-000" (ids-classes-elements) for lexicographic comparison
-	 */
-	#calculateSpecificity(selector: string): string {
-		const withoutAttributes = selector.replace(
-			ATTRIBUTE_SELECTOR_MATCHER,
-			"[]",
-		);
-		const withoutPseudoElements = withoutAttributes.replace(
-			PSEUDO_ELEMENT_EXPRESSION_MATCHER,
-			"",
-		);
-		const idCount = determineMatchCount(withoutAttributes, ID_SELECTOR_MATCHER);
-		const classCount = determineMatchCount(
-			withoutAttributes,
-			CLASS_SELECTOR_MATCHER,
-		);
-		const attributeCount = determineMatchCount(
-			selector,
-			ATTRIBUTE_SELECTOR_MATCHER,
-		);
-		const pseudoClassCount = determineMatchCount(
-			withoutPseudoElements,
-			PSEUDO_CLASS_SELECTOR_MATCHER,
-		);
-		const typeCount = determineMatchCount(
-			withoutAttributes,
-			TYPE_SELECTOR_MATCHER,
-		);
-		const pseudoElementCount = determineMatchCount(
-			withoutAttributes,
-			PSEUDO_ELEMENT_NAME_MATCHER,
-		);
-		const classTotal = classCount + attributeCount + pseudoClassCount;
-		const elementTotal = typeCount + pseudoElementCount;
-		const idSpecificity = idCount.toString().padStart(3, "0");
-		const classSpecificity = classTotal.toString().padStart(3, "0");
-		const elementSpecificity = elementTotal.toString().padStart(3, "0");
-
-		return `${idSpecificity}-${classSpecificity}-${elementSpecificity}`;
 	}
 
 	/**

--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -97,6 +97,66 @@ function splitLineValue(value: string): {
 	return {width, lineStyle, color};
 }
 
+/** The values `flex-direction` takes, which is how `flex-flow` knows one. */
+const FLEX_DIRECTIONS = new Set([
+	"row",
+	"row-reverse",
+	"column",
+	"column-reverse",
+]);
+
+/** The values `flex-wrap` takes. */
+const FLEX_WRAPS = new Set(["nowrap", "wrap", "wrap-reverse"]);
+
+/**
+ * The keywords that qualify the alignment keyword after them rather than
+ * standing as a value of their own: `safe center`, `first baseline`.
+ */
+const ALIGNMENT_QUALIFIERS = new Set(["safe", "unsafe", "first", "last"]);
+
+/**
+ * Expand `flex-flow` (css-flexbox-1 §7.1): a direction and a wrap in either
+ * order, either one omitted and left at its initial value.
+ */
+function expandFlexFlow(value: string): Record<string, string> {
+	const out: Record<string, string> = {
+		"flex-direction": "row",
+		"flex-wrap": "nowrap",
+	};
+	for (const token of splitComponents(value)) {
+		const keyword = token.toLowerCase();
+		if (FLEX_DIRECTIONS.has(keyword)) out["flex-direction"] = keyword;
+		else if (FLEX_WRAPS.has(keyword)) out["flex-wrap"] = keyword;
+	}
+	return out;
+}
+
+/**
+ * Expand a `place-*` shorthand (css-align-3 §10): the block axis first, then
+ * the inline axis, and one value stated for both when only one is written.
+ * A value is one keyword, or two where the first only qualifies the second.
+ */
+function expandPlace(
+	value: string,
+	block: string,
+	inline: string,
+): Record<string, string> {
+	const values: string[] = [];
+	for (const token of splitComponents(value)) {
+		const previous = values[values.length - 1];
+		if (
+			previous !== undefined &&
+			ALIGNMENT_QUALIFIERS.has(previous.toLowerCase())
+		) {
+			values[values.length - 1] = `${previous} ${token}`;
+		} else {
+			values.push(token);
+		}
+	}
+	if (values.length === 0) return {};
+	return {[block]: values[0], [inline]: values[1] ?? values[0]};
+}
+
 /**
  * Expand the `flex` shorthand (css-flexbox-1 §7.1.1): `none` is 0 0 auto,
  * `auto` 1 1 auto, `initial` 0 1 auto; otherwise the first number is grow,
@@ -393,6 +453,22 @@ export function expandShorthands(
 				Object.assign(out, expandFlex(value) ?? {});
 				break;
 			}
+			case "flex-flow": {
+				Object.assign(out, expandFlexFlow(value));
+				break;
+			}
+			case "place-content":
+				Object.assign(
+					out,
+					expandPlace(value, "align-content", "justify-content"),
+				);
+				break;
+			case "place-items":
+				Object.assign(out, expandPlace(value, "align-items", "justify-items"));
+				break;
+			case "place-self":
+				Object.assign(out, expandPlace(value, "align-self", "justify-self"));
+				break;
 			case "list-style":
 				Object.assign(out, expandListStyle(value));
 				break;

--- a/tests/css-conformance.test.ts
+++ b/tests/css-conformance.test.ts
@@ -447,3 +447,171 @@ test("css: color:inherit resolves the parent's value", async () => {
 		),
 	).toBe("rgb(128, 0, 128)");
 });
+
+const RED = "rgb(255, 0, 0)";
+const BLUE = "rgb(0, 0, 255)";
+
+test("css: @layer rules lose to unlayered rules of the same origin", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer base{#a{color:red}} p{color:blue}</style><p id="a">x</p>`,
+			"#a",
+		),
+	).toBe(BLUE);
+});
+
+test("css: layers cascade in the order their names were declared", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer late{p{color:blue}} @layer early{p{color:red}}</style><p>x</p>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: a @layer statement declares the order rules later fall into", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer early, late;` +
+				`@layer late{p{color:blue}} @layer early{p{color:red}}</style><p>x</p>`,
+			"p",
+		),
+	).toBe(BLUE);
+});
+
+test("css: a nested layer loses to its own layer's unnested rules", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer outer{@layer inner{p{color:red}} p{color:blue}}</style>` +
+				`<p>x</p>`,
+			"p",
+		),
+	).toBe(BLUE);
+});
+
+test("css: each unnamed @layer block is a layer of its own", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer{p{color:blue}}@layer{p{color:red}}</style><p>x</p>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: !important reverses the layer order", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer a{p{color:red!important}} p{color:blue!important}</style>` +
+				`<p>x</p>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: !important makes the earliest layer win", async () => {
+	expect(
+		await colorOf(
+			`<style>@layer first, second;` +
+				`@layer second{p{color:blue!important}}` +
+				`@layer first{p{color:red!important}}</style><p>x</p>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: @scope rules apply inside their root", async () => {
+	expect(
+		await colorOf(
+			`<style>@scope (.card){p{color:red}}</style>` +
+				`<div class="card"><p>x</p></div>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: @scope rules do not apply outside their root", async () => {
+	expect(
+		await colorOf(
+			`<style>p{color:blue} @scope (.card){p{color:red}}</style>` +
+				`<div class="other"><p>x</p></div>`,
+			"p",
+		),
+	).toBe(BLUE);
+});
+
+test("css: a @scope limit ends the scope above the element", async () => {
+	expect(
+		await colorOf(
+			`<style>p{color:blue} @scope (.card) to (.inner){p{color:red}}</style>` +
+				`<div class="card"><div class="inner"><p>x</p></div></div>`,
+			"p",
+		),
+	).toBe(BLUE);
+});
+
+test("css: :scope selects the scoping root itself", async () => {
+	expect(
+		await colorOf(
+			`<style>@scope (.card){:scope{color:red}}</style>` +
+				`<div class="card"><p>x</p></div>`,
+			".card",
+		),
+	).toBe(RED);
+});
+
+test("css: a scoped selector may be written relative to its root", async () => {
+	expect(
+		await colorOf(
+			`<style>p{color:blue} @scope (.inner){> p{color:red}}</style>` +
+				`<div class="inner"><p>x</p></div>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: the nearer scoping root wins, whatever the source order", async () => {
+	expect(
+		await colorOf(
+			`<style>@scope (.inner){p{color:red}} @scope (.card){p{color:blue}}</style>` +
+				`<div class="card"><div class="inner"><p>x</p></div></div>`,
+			"p",
+		),
+	).toBe(RED);
+	expect(
+		await colorOf(
+			`<style>@scope (.card){p{color:blue}} @scope (.inner){p{color:red}}</style>` +
+				`<div class="card"><div class="inner"><p>x</p></div></div>`,
+			"p",
+		),
+	).toBe(RED);
+});
+
+test("css: specificity outranks scope proximity", async () => {
+	expect(
+		await colorOf(
+			`<style>@scope (.inner){p{color:red}} @scope (.card){p#a{color:blue}}</style>` +
+				`<div class="card"><div class="inner"><p id="a">x</p></div></div>`,
+			"#a",
+		),
+	).toBe(BLUE);
+});
+
+test("css: @starting-style declares nothing to the cascade", async () => {
+	expect(
+		await colorOf(
+			`<style>p{color:blue} @starting-style{p{color:red}}</style><p>x</p>`,
+			"p",
+		),
+	).toBe(BLUE);
+});
+
+test("css: an unrecognized grouping rule cascades its rules through", async () => {
+	// @container has no branch in the rule walk: its rules reach the cascade
+	// without its query, rather than not at all.
+	expect(
+		await colorOf(
+			`<style>@container (min-width: 1px){p{color:red}}</style><p>x</p>`,
+			"p",
+		),
+	).toBe(RED);
+});

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -4,6 +4,8 @@ import {LayoutEngine} from "../src/internal/layout.js";
 import {TermDOM} from "../src/internal/termdom.js";
 import {MockProcess, nextFrame} from "./test-utils.js";
 import {createDocumentWindow} from "../src/internal/termdom.js";
+import {CSS_SHORTHANDS} from "../src/internal/cssproperties.js";
+import {expandShorthands} from "../src/internal/useragent.js";
 
 /** A document of this DOM, from markup, displayed in a window of its own. */
 function documentWindow(html: string) {
@@ -1010,4 +1012,145 @@ test("an author's shorthand read does not poison the computed value", async () =
 	expect(declaration.computedValueOf("margin-top")).toBe("50%");
 
 	dom.dispose();
+});
+
+/**
+ * A value for every shorthand `expandShorthands` decomposes, chosen to state
+ * something on each longhand the grammar names.
+ */
+const EXPANDED_SHORTHANDS: Record<string, string> = {
+	background: "red",
+	border: "1px solid red",
+	"border-block": "1px solid red",
+	"border-block-color": "red blue",
+	"border-block-end": "1px solid red",
+	"border-block-start": "1px solid red",
+	"border-block-style": "solid dashed",
+	"border-block-width": "1px 2px",
+	"border-bottom": "1px solid red",
+	"border-color": "red",
+	"border-image": "none",
+	"border-inline": "1px solid red",
+	"border-inline-color": "red blue",
+	"border-inline-end": "1px solid red",
+	"border-inline-start": "1px solid red",
+	"border-inline-style": "solid dashed",
+	"border-inline-width": "1px 2px",
+	"border-left": "1px solid red",
+	"border-radius": "1ch",
+	"border-right": "1px solid red",
+	"border-style": "solid",
+	"border-top": "1px solid red",
+	"border-width": "1px",
+	flex: "1 1 auto",
+	"flex-flow": "column wrap",
+	gap: "1px 2ch",
+	inset: "1px 2ch",
+	"inset-block": "1px 2px",
+	"inset-inline": "1ch 2ch",
+	"list-style": "square inside",
+	margin: "1px 2ch",
+	"margin-block": "1px 2px",
+	"margin-inline": "1ch 2ch",
+	outline: "1px solid red",
+	overflow: "hidden scroll",
+	padding: "1px 2ch",
+	"padding-block": "1px 2px",
+	"padding-inline": "1ch 2ch",
+	"place-content": "space-between center",
+	"place-items": "center start",
+	"place-self": "center start",
+	"text-decoration": "underline",
+};
+
+/**
+ * The shorthands that reach the cascade whole, each with what it is waiting
+ * for. A shorthand here declares nothing to its longhands: an author writing
+ * one gets the declaration back from CSSOM and no rendering from it.
+ */
+const UNEXPANDED_SHORTHANDS: Record<string, string> = {
+	"-webkit-border-after": "vendor alias for border-block-end",
+	"-webkit-border-before": "vendor alias for border-block-start",
+	"-webkit-border-end": "vendor alias for border-inline-end",
+	"-webkit-border-start": "vendor alias for border-inline-start",
+	"-webkit-mask": "vendor alias for mask, which needs pixels",
+	"-webkit-text-stroke": "glyph outlines, which the emulator owns",
+	all: "stands for every property there is; the cascade reads it directly",
+	animation: "no animation clock",
+	"animation-range": "no animation clock",
+	"background-position": "an image to position, which needs pixels",
+	caret: "the caret is the terminal's own cursor",
+	"column-rule": "multi-column layout",
+	columns: "multi-column layout",
+	"contain-intrinsic-size": "containment",
+	container: "container queries",
+	"corner-block-end-shape": "corner shapes are finer than a cell",
+	"corner-block-start-shape": "corner shapes are finer than a cell",
+	"corner-bottom-shape": "corner shapes are finer than a cell",
+	"corner-inline-end-shape": "corner shapes are finer than a cell",
+	"corner-inline-start-shape": "corner shapes are finer than a cell",
+	"corner-left-shape": "corner shapes are finer than a cell",
+	"corner-right-shape": "corner shapes are finer than a cell",
+	"corner-shape": "corner shapes are finer than a cell",
+	"corner-top-shape": "corner shapes are finer than a cell",
+	font: "system font keywords and a line-height the grid fixes",
+	grid: "grid layout",
+	"grid-area": "grid layout",
+	"grid-column": "grid layout",
+	"grid-gap": "grid layout",
+	"grid-row": "grid layout",
+	"grid-template": "grid layout",
+	"interest-delay": "no interest timers",
+	mask: "masking, which needs pixels",
+	"mask-border": "masking, which needs pixels",
+	offset: "motion paths, which need sub-cell geometry",
+	"overscroll-behavior": "overscroll behavior",
+	"position-try": "anchor positioning",
+	"scroll-margin": "scroll snapping",
+	"scroll-margin-block": "scroll snapping",
+	"scroll-margin-inline": "scroll snapping",
+	"scroll-padding": "scroll snapping",
+	"scroll-padding-block": "scroll snapping",
+	"scroll-padding-inline": "scroll snapping",
+	"scroll-timeline": "scroll-driven animations",
+	"text-emphasis": "emphasis marks are finer than a cell",
+	"text-wrap": "text-wrap-style, its second half",
+	"timeline-trigger": "no animation clock",
+	"timeline-trigger-activation-range": "no animation clock",
+	"timeline-trigger-active-range": "no animation clock",
+	transition: "no transitions",
+	"view-timeline": "scroll-driven animations",
+};
+
+test("every CSS shorthand is expanded or listed as unexpanded", () => {
+	// The property table is generated from mdn-data, so a shorthand the
+	// platform adds arrives here on its own. It is handled or it is named --
+	// and either way somebody looked at it.
+	for (const shorthand of Object.keys(CSS_SHORTHANDS)) {
+		const expanded = shorthand in EXPANDED_SHORTHANDS;
+		const unexpanded = shorthand in UNEXPANDED_SHORTHANDS;
+		expect(`${shorthand}: ${expanded !== unexpanded}`).toBe(
+			`${shorthand}: true`,
+		);
+		if (!expanded) continue;
+		const value = EXPANDED_SHORTHANDS[shorthand];
+		const longhands = Object.keys(
+			expandShorthands({[shorthand]: value}),
+		).filter((name) => name !== shorthand);
+		expect(`${shorthand} -> ${longhands.length > 0}`).toBe(
+			`${shorthand} -> true`,
+		);
+		for (const longhand of longhands) {
+			expect(`${shorthand} declares ${longhand}`).toBe(
+				`${shorthand} declares ${
+					CSS_SHORTHANDS[shorthand].includes(longhand) ? longhand : "?"
+				}`,
+			);
+		}
+	}
+	for (const shorthand of Object.keys(UNEXPANDED_SHORTHANDS)) {
+		expect(`${shorthand} is a shorthand: ${shorthand in CSS_SHORTHANDS}`).toBe(
+			`${shorthand} is a shorthand: true`,
+		);
+	}
 });

--- a/tests/stylesheet.test.ts
+++ b/tests/stylesheet.test.ts
@@ -46,6 +46,82 @@ test("CSS specificity calculation", async () => {
 	termdom.dispose();
 });
 
+test("selector-list pseudo-classes weigh their most specific argument", async () => {
+	const terminal = new MockProcess();
+	const termdom = new TermDOM({transport: terminal.transport});
+	const {document} = termdom;
+
+	const style = document.createElement("style");
+	// Each pair states the argument-weighted rule FIRST, so source order can
+	// only produce the second colour: the first wins on weight or not at all.
+	style.textContent = `
+		.is-target:is(#nothing, .other) { color: red; }
+		.is-target.a.b { color: blue; }
+
+		.where-target:where(#nothing) { color: red; }
+		.where-target.a { color: blue; }
+
+		.not-target:not(#nothing) { color: red; }
+		.not-target.a.b { color: blue; }
+
+		.has-target:has(#child) { color: red; }
+		.has-target.a.b { color: blue; }
+	`;
+	document.head.appendChild(style);
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	const host = document.createElement("div");
+	host.innerHTML =
+		`<div class="is-target other a b"></div>` +
+		`<div class="where-target a"></div>` +
+		`<div class="not-target a b"></div>` +
+		`<div class="has-target a b"><span id="child"></span></div>`;
+	document.body.appendChild(host);
+
+	const colorOf = (selector: string): string =>
+		termdom.window
+			.getComputedStyle(document.querySelector(selector)!)
+			.getPropertyValue("color");
+
+	// :is() carries its #nothing branch: 001-001-000 beats 000-003-000.
+	expect(colorOf(".is-target")).toBe("rgb(255, 0, 0)");
+	// :where() carries nothing: 000-001-000 loses to 000-002-000.
+	expect(colorOf(".where-target")).toBe("rgb(0, 0, 255)");
+	// :not(#nothing) is an id's worth of weight.
+	expect(colorOf(".not-target")).toBe("rgb(255, 0, 0)");
+	// So is the id inside :has().
+	expect(colorOf(".has-target")).toBe("rgb(255, 0, 0)");
+
+	termdom.dispose();
+});
+
+test("the CSS 2 pseudo-element spelling weighs as an element", async () => {
+	const terminal = new MockProcess();
+	const termdom = new TermDOM({transport: terminal.transport});
+	const {document} = termdom;
+
+	const style = document.createElement("style");
+	style.textContent = `
+		div:before { content: "x"; color: red; }
+		.legacy::before { content: "x"; color: blue; }
+	`;
+	document.head.appendChild(style);
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	const element = document.createElement("div");
+	element.className = "legacy";
+	document.body.appendChild(element);
+
+	// `div:before` is 000-000-002 and `.legacy::before` 000-001-001.
+	expect(
+		termdom.window
+			.getComputedStyle(element, "::before")
+			.getPropertyValue("color"),
+	).toBe("rgb(0, 0, 255)");
+
+	termdom.dispose();
+});
+
 test("attribute values do not affect selector specificity", async () => {
 	const terminal = new MockProcess();
 	const termdom = new TermDOM({transport: terminal.transport});


### PR DESCRIPTION
Four verified defects plus two hardening guards.

- **@layer and @scope rules were silently dropped from the cascade.** The rule-collection walk recursed into @media/@supports only; layered and scoped rules parsed into the CSSOM and never styled anything (a Tailwind v4 stylesheet did nothing). Now: full css-cascade-5 layer ordering — declaration-order layer ranks, nested layers, unlayered-beats-layered for normal declarations and the reverse for !important — and full @scope with root/limit selector lists, implicit roots, nested scopes, and proximity as the specificity/source tiebreak. @starting-style is recognized and deliberately inert (no transitions; a matching rule would style permanently), documented at the site.
- **Specificity is computed from css-tree's selector AST** instead of six regexes. :is()/:not()/:has() weigh their heaviest argument, :where() zero, :host()/:nth-child(of S) per selectors-4. A 54-selector corpus check found 10 disagreements with the old counter, every one the old counter's error. The regex matchers are deleted; #39's attribute-metacharacter case stays as a regression test.
- **flex-flow, place-content, place-items, place-self now expand.** Their longhands always worked; the shorthand values vanished. A new test asserts every generated shorthand either expands or sits on an explicit exclusion list with a reason — the guard that would have caught these four. The forced exclusion list (51 entries: grid, animation, font, mask families and friends) is the honest expansion backlog.
- **Unrecognized grouping rules now cascade transparently** rather than vanishing, so a future rule type degrades to missing-condition-semantics instead of silence.
- **The compatibility probes stop understating the engine**: word-break and overflow-wrap were implemented and working but probed with text that couldn't exercise them — both rows flip to yes. transform reclassified to not-applicable with the whole-cell-translate refusal noted. 170 properties supported, up from 162, plus @layer/@scope rows.

Exclusions, documented in code: revert-layer (revert itself is absent; half-adding it is the subset the house rule forbids), shadow-tree layer-name scoping (needs the encapsulation-context tier), nth-child(An+B of S) matching (nwsapi rejects the syntax; the weight is correct).

Incidental: the cascade sort's indexOf tiebreak was O(n²·log n); a positions Map makes a 300-rule reparse ~30% faster.

Tests: 19 new across stylesheet/css-conformance/styles suites. Full battery green (node 1246, bun 1271; one fuzz-file timeout under concurrent-agent load passed in isolation with exit 0). WPT cssom identical to baseline (the cssom suite contains no @layer/@scope files, noted for honesty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD