### PR TITLE
Fix width-measurement starvation for right-aligned text

### DIFF
--- a/scripts/verify-tmux.ts
+++ b/scripts/verify-tmux.ts
@@ -165,6 +165,47 @@ const scenarios: Scenario[] = [
 		},
 	},
 	{
+		// Right-aligned Arabic is where in-place measurement starves: every
+		// shaped form lands against the right margin, where the guard turns it
+		// away, so the frame asks about them on a probe train at the far left
+		// of a row it is repainting anyway. What tmux must witness is a screen
+		// that shows no sign of it -- the boxes square, the row the train stood
+		// on holding its own text.
+		name: "right-aligned Arabic: the probe train leaves the screen square",
+		command: "node examples/rtl.ts",
+		cols: 40,
+		settle: 3000,
+		run: async (pane) => {
+			const screen = pane.screen();
+			const trained = screen.find((line) => line.includes("RTL rendering"));
+			assert(
+				trained?.trimEnd() === "  RTL rendering",
+				`the train left something behind: ${JSON.stringify(trained)}`,
+			);
+
+			// The Arabic card: its content row and the borders above and below
+			// it must end in the same column, which they do only if every
+			// cluster on the row advanced the way the frame counted.
+			// Arabic proper and the presentation forms the shaper emits.
+			const content = screen.findIndex((line) =>
+				/[\u0600-\u06FF\uFB50-\uFEFC]/.test(line),
+			);
+			assert(content > 0, "no Arabic row on screen");
+			const width = (line: string): number => line.trimEnd().length;
+			assert(
+				width(screen[content - 1]) === width(screen[content]) &&
+				width(screen[content]) === width(screen[content + 1]),
+				`Arabic box borders do not line up: ${JSON.stringify(
+					screen.slice(content - 1, content + 2),
+				)}`,
+			);
+			assert(
+				screen[content].trimEnd().endsWith("│"),
+				"Arabic row does not end at the box's right border",
+			);
+		},
+	},
+	{
 		// tmux measures these clusters the way the width tables do, so what it
 		// witnesses is the asking rather than the learning: a frame that appends
 		// DSR after emoji-presentation glyphs and repaints over itself must

--- a/src/internal/ansi.ts
+++ b/src/internal/ansi.ts
@@ -1045,6 +1045,77 @@ export interface WidthMeasurer {
 	 * column. Returns the bytes the frame appends after the glyph.
 	 */
 	probe(cluster: string, run: number, column: number, width: number): string;
+	/**
+	 * The margin guard turned this cluster away: it was painted too near the
+	 * last column for its answer to be readable.
+	 */
+	defer(cluster: string): void;
+	/**
+	 * Clusters the margin has starved: deferred, and never asked about anywhere
+	 * else either. Right-aligned text puts the same glyphs against the last
+	 * column every time it paints them, so in place they would wait forever.
+	 * The frame measures these somewhere with room instead; a cluster leaves
+	 * the set when it is probed.
+	 */
+	starved(): ReadonlySet<string>;
+}
+
+/**
+ * The columns a cluster's residue can reach: the widest advance a probe's
+ * reply is believed to describe, so the widest one a probe can leave behind.
+ */
+const PROBE_RESIDUE_COLUMNS = 4;
+
+/**
+ * Where a frame can paint a probe without being seen and without the margin in
+ * the way: a column in the frame's FIRST painted row whose next four columns
+ * the row's own content covers, far enough from the last column that the reply
+ * is unambiguous.
+ *
+ * The first painted row is the only candidate. Emission runs top to bottom and
+ * never moves the cursor back up, so a probe train on any later row could not
+ * be overwritten by the content that follows it.
+ */
+function safeProbeCell(grid: CellGrid): {row: number; col: number} | null {
+	const {rows, cols, char, border} = grid;
+	if (cols <= PROBE_RESIDUE_COLUMNS) {
+		return null;
+	}
+
+	for (let row = 0; row < rows; row++) {
+		const rowStart = row * cols;
+		let spanStart = -1;
+		let col = 0;
+		let rowHasContent = false;
+
+		while (col < cols) {
+			const index = rowStart + col;
+			if (char[index] === 0) {
+				spanStart = -1;
+				col++;
+				continue;
+			}
+			rowHasContent = true;
+			if (spanStart < 0) {
+				spanStart = col;
+			}
+			// A wide glyph covers its continuation column too, which the grid
+			// leaves empty: the span runs on across it.
+			col += border[index] > 0 ? 1 : Math.max(1, grid.widthAt(index));
+			if (
+				col - spanStart >= PROBE_RESIDUE_COLUMNS &&
+				spanStart + PROBE_RESIDUE_COLUMNS < cols
+			) {
+				return {row, col: spanStart};
+			}
+		}
+
+		if (rowHasContent) {
+			return null;
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -1079,6 +1150,38 @@ function generateANSI(
 	const measuring = measurer !== undefined;
 	let run = 0;
 	let unknownInRow = 0;
+
+	// Clusters the margin has starved are asked about off to the side, before
+	// the frame paints anything: the probe train goes to a cell the first
+	// painted row covers, and that row's own content lands on top of it in this
+	// same write, so nothing of it is ever on screen.
+	if (measuring) {
+		const starving = measurer!.starved();
+		if (starving.size > 0) {
+			const cell = safeProbeCell(grid);
+			if (cell !== null) {
+				const [moveSeq, movedRow] = moveCursor(0, 0, cell.row, 0);
+				output += moveSeq;
+				cursorRow = movedRow;
+				cursorCol = 0;
+				// probe() takes the cluster out of the set being iterated.
+				for (const cluster of [...starving]) {
+					output += "\r";
+					if (cell.col > 0) {
+						output += `\x1b[${cell.col}C`; // CUF
+					}
+					// Each probe is reached by naming its column outright, so
+					// no train glyph's advance carries into the next.
+					run++;
+					output +=
+						cluster +
+						measurer!.probe(cluster, run, cell.col, stringWidth(cluster));
+				}
+				output += "\r";
+				run++;
+			}
+		}
+	}
 
 	for (let row = 0; row < rows; row++) {
 		const rowStart = row * cols;
@@ -1182,8 +1285,13 @@ function generateANSI(
 					// pushed the real cursor past the predicted one. Defer --
 					// the cluster keeps its place in line and gets measured
 					// wherever it next appears with room.
-					if (col + 4 + 2 * unknownInRow < cols) {
+					// Defer -- the cluster keeps its place in line and gets
+					// measured wherever it next appears with room -- or, if it
+					// never has room, on a later frame's probe train.
+					if (col + PROBE_RESIDUE_COLUMNS + 2 * unknownInRow < cols) {
 						output += measurer!.probe(glyph, run, col, width);
+					} else {
+						measurer!.defer(glyph);
 					}
 					unknownInRow++;
 				}
@@ -1630,6 +1738,7 @@ const kHasSavedCursor = Symbol("hasSavedCursor");
 const kNeedsFullClear = Symbol("needsFullClear");
 const kRenderedLines = Symbol("renderedLines");
 const kEndFrame = Symbol("endFrame");
+const kForgotTopRow = Symbol("forgotTopRow");
 const kDiff = Symbol("diff");
 const kLastCaretVisible = Symbol("lastCaretVisible");
 
@@ -1654,12 +1763,16 @@ export class Screen {
 	declare [kHasSavedCursor]: boolean;
 	declare [kNeedsFullClear]: boolean;
 	declare [kNeedsScreenReset]: boolean;
+	// A row of the previous frame was dropped for a probe train to stand on:
+	// the next frame paints it again, though the document has not moved.
+	declare [kForgotTopRow]: boolean;
 	declare [kResetAtRow]: number;
 	declare [kRows]: number;
 	declare [kCols]: number;
 	declare [kColorDepth]: ColorDepth;
 
 	constructor(rows: number, cols: number, colorDepth: ColorDepth = "rgb") {
+		this[kForgotTopRow] = false;
 		this[kPrev] = null;
 		this[kSpare] = null;
 		this[kDiff] = null;
@@ -1740,6 +1853,34 @@ export class Screen {
 	 * describe, or a measurement corrected one it did. The next frame paints
 	 * every cell again, in place.
 	 */
+	/**
+	 * Forget the topmost row the previous frame painted, so the next frame
+	 * paints it again.
+	 *
+	 * A probe train needs a row whose own content lands on top of it, and a
+	 * document that has stopped changing offers none: the frames it produces
+	 * diff to nothing at all. This is the smallest repaint that gives the
+	 * train a place to stand -- one row, no erase, and cells identical to the
+	 * ones already on screen.
+	 */
+	repaintTopRow(): void {
+		const prev = this[kPrev];
+		if (prev === null) {
+			return;
+		}
+		const cols = prev.cols;
+		for (let row = 0; row < prev.rows; row++) {
+			const rowStart = row * cols;
+			for (let col = 0; col < cols; col++) {
+				if (prev.char[rowStart + col] !== 0) {
+					prev.clearRange(rowStart, rowStart + cols);
+					this[kForgotTopRow] = true;
+					return;
+				}
+			}
+		}
+	}
+
 	repaintAll(): void {
 		this[kSpare] = this[kPrev];
 		this[kPrev] = null;
@@ -1762,7 +1903,11 @@ export class Screen {
 
 	/** A reset or clear is pending: the next frame must actually paint. */
 	get needsRepaint(): boolean {
-		return this[kNeedsScreenReset] || this[kNeedsFullClear];
+		return (
+			this[kNeedsScreenReset] ||
+			this[kNeedsFullClear] ||
+			this[kForgotTopRow]
+		);
 	}
 
 	/**
@@ -1887,6 +2032,9 @@ export class Screen {
 	}): CellContext {
 		const frameRows = Math.max(this[kRows], regionRows ?? this[kRows]);
 		const overflowing = frameRows > this[kRows];
+		// The forgotten row is being painted by this frame, whatever else it
+		// carries; there is nothing left to remember.
+		this[kForgotTopRow] = false;
 
 		const cols = this[kCols];
 		const next = takeGrid(this, frameRows, cols);

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -2194,6 +2194,10 @@ function buildSession(
 				self[kScreen].repaintAll();
 				void render(self);
 			},
+			onWidthStarvation: () => {
+				self[kScreen].repaintTopRow();
+				void render(self);
+			},
 			// The terminal went away (hangup, disconnect, process exit):
 			// clean up this side. The transport is already closing; there
 			// is nothing to close back.

--- a/src/internal/terminalsession.ts
+++ b/src/internal/terminalsession.ts
@@ -384,6 +384,12 @@ interface TerminalSessionHandlers {
 	 * that cluster need repainting against the corrected measurement.
 	 */
 	onWidthCorrection(): void;
+	/**
+	 * A cluster the margin keeps turning away needs a frame to carry its probe
+	 * train, and the document is not producing one. Repaint the least that
+	 * gives the train a row to stand on.
+	 */
+	onWidthStarvation(): void;
 	/** The transport's `closed` settled: the terminal is gone. */
 	onClosed(info: TerminalCloseInfo): void;
 }
@@ -393,12 +399,16 @@ const kWidthProbes = Symbol("widthProbes");
 const kWriteEpoch = Symbol("writeEpoch");
 const kDsrSequence = Symbol("dsrSequence");
 const kWidthProbeTimer = Symbol("widthProbeTimer");
-const kWIdTH_PROBE_TIMEOUT_MS = Symbol("WIDTH_PROBE_TIMEOUT_MS");
+const kWidthProbeTimeout = Symbol("widthProbeTimeout");
 const kWidthAnswered = Symbol("widthAnswered");
 const kWidthProbing = Symbol("widthProbing");
 const kInteractive = Symbol("interactive");
 const kGraphemeClustersNegotiated = Symbol("graphemeClustersNegotiated");
 const kWidthMeasurer = Symbol("widthMeasurer");
+const kWidthAsked = Symbol("widthAsked");
+const kWidthStarved = Symbol("widthStarved");
+const kStarvationTimer = Symbol("starvationTimer");
+const kWidthStarvationWait = Symbol("widthStarvationWait");
 const kWidthRunEpoch = Symbol("widthRunEpoch");
 const kWidthRun = Symbol("widthRun");
 const kWidthDrift = Symbol("widthDrift");
@@ -505,6 +515,23 @@ export class TerminalSession {
 	 * the replies come back in the same order the glyphs were painted.
 	 */
 	declare [kWidthSettled]: Set<string>;
+	/**
+	 * Every cluster that has ever carried a query, wherever it was asked from.
+	 * A cluster in here is not starved however often the margin turns it away:
+	 * it has had its question put, and the answer's fate is the queue's
+	 * business. This is what bounds the probe train to one per cluster.
+	 */
+	declare [kWidthAsked]: Set<string>;
+	/**
+	 * Clusters the margin guard turned away that have never been asked about
+	 * at all, waiting for a frame to carry their probe train. Right-aligned
+	 * text is what fills this: its clusters land against the last column every
+	 * time they are painted, so in place they would be deferred for the whole
+	 * session.
+	 */
+	declare [kWidthStarved]: Set<string>;
+	/** The wait for a frame the starved clusters could have ridden. */
+	declare [kStarvationTimer]: ReturnType<typeof setTimeout> | null;
 	/** Whether frames may still probe. */
 	declare [kWidthProbing]: boolean;
 	/** Whether the terminal has ever answered a width probe. */
@@ -527,7 +554,13 @@ export class TerminalSession {
 	 * answering late is still answering. Only a session that gets NOTHING back
 	 * gives up probing, and it can afford to wait to be sure.
 	 */
-	static readonly [kWIdTH_PROBE_TIMEOUT_MS] = 2000;
+	static readonly [kWidthProbeTimeout] = 2000;
+	/**
+	 * How long a starved cluster waits for a frame of the document's own
+	 * before one is asked for on its behalf. Long enough that anything still
+	 * animating, typing or scrolling carries the train for free.
+	 */
+	static readonly [kWidthStarvationWait] = 500;
 
 	declare [kWidthMeasurer]: WidthMeasurer;
 
@@ -584,9 +617,30 @@ export class TerminalSession {
 		this[kWidthDrift] = 0;
 		this[kWidthRunLost] = false;
 		this[kWriteEpoch] = 0;
+		this[kWidthAsked] = new Set();
+		this[kWidthStarved] = new Set();
+		this[kStarvationTimer] = null;
 		this[kWidthMeasurer] = {
 			wants: (cluster: string) => !this[kWidthSettled].has(cluster),
+			starved: () => this[kWidthStarved],
+			defer: (cluster: string) => {
+				// A cluster that has been asked about somewhere is not
+				// starving, whatever this frame's margin did to it. So one
+				// deferral of a cluster nothing has ever asked about IS the
+				// starvation: the layout that put it there will put it there
+				// again.
+				if (
+					this[kWidthAsked].has(cluster) ||
+					this[kWidthStarved].has(cluster)
+				) {
+					return;
+				}
+				this[kWidthStarved].add(cluster);
+				requestStarvationFrame(this);
+			},
 			probe: (cluster: string, run: number, column: number, width: number) => {
+				this[kWidthAsked].add(cluster);
+				this[kWidthStarved].delete(cluster);
 				this[kWidthProbes].push({
 					cluster,
 					run,
@@ -953,6 +1007,10 @@ export class TerminalSession {
 			clearTimeout(this[kWidthProbeTimer]);
 			this[kWidthProbeTimer] = null;
 		}
+		if (this[kStarvationTimer] !== null) {
+			clearTimeout(this[kStarvationTimer]);
+			this[kStarvationTimer] = null;
+		}
 		this[kWidthProbes].length = 0;
 		this[kWidthProbing] = false;
 
@@ -976,6 +1034,30 @@ export class TerminalSession {
 }
 
 /**
+ * Wait for a frame the starved clusters can ride, and ask for one if none
+ * comes.
+ *
+ * Starvation is discovered while a frame is being emitted, and that frame is
+ * already past the point where its train would have gone -- so the clusters
+ * need a later frame. A document still painting gives them one for nothing:
+ * every frame carries whatever is starved when it starts. Only a document
+ * that has gone quiet needs to be made to paint, and the wait is what tells
+ * the two apart.
+ */
+function requestStarvationFrame(self: TerminalSession): void {
+	if (self[kStarvationTimer] !== null) {
+		return;
+	}
+	self[kStarvationTimer] = setTimeout(() => {
+		self[kStarvationTimer] = null;
+		if (self[kDisposed] || self[kWidthStarved].size === 0) {
+			return;
+		}
+		self[kHandlers].onWidthStarvation();
+	}, TerminalSession[kWidthStarvationWait]);
+}
+
+/**
  * Keep a deadline running for as long as any probe is outstanding, timed
  * from the oldest of them.
  */
@@ -991,7 +1073,7 @@ function armWidthProbeTimer(
 	}
 	const remaining = Math.max(
 		0,
-		oldest.sentAt + TerminalSession[kWIdTH_PROBE_TIMEOUT_MS] - Date.now(),
+		oldest.sentAt + TerminalSession[kWidthProbeTimeout] - Date.now(),
 	);
 	self[kWidthProbeTimer] = setTimeout(() => {
 		self[kWidthProbeTimer] = null;
@@ -1001,7 +1083,7 @@ function armWidthProbeTimer(
 		// written since the deadline was set are not late yet and keep
 		// their place -- the deadline is per probe, and re-arms for the
 		// oldest one still waiting.
-		const deadline = Date.now() - TerminalSession[kWIdTH_PROBE_TIMEOUT_MS];
+		const deadline = Date.now() - TerminalSession[kWidthProbeTimeout];
 		let expired = 0;
 		while (
 			expired < self[kWidthProbes].length &&
@@ -1016,6 +1098,7 @@ function armWidthProbeTimer(
 		if (expired > 0 && !self[kWidthAnswered]) {
 			self[kWidthProbing] = false;
 			self[kWidthProbes].length = 0;
+			self[kWidthStarved].clear();
 			return;
 		}
 		self[kWidthProbes].splice(0, expired);

--- a/tests/width-measurement.test.ts
+++ b/tests/width-measurement.test.ts
@@ -22,13 +22,15 @@ import {
 } from "../src/internal/text.js";
 
 /** A measurer that records what it was offered instead of asking anything. */
-function recordingMeasurer(): {
+function recordingMeasurer(starved = new Set<string>()): {
 	probes: Array<{
 		cluster: string;
 		run: number;
 		column: number;
 		width: number;
 	}>;
+	deferred: string[];
+	starved: Set<string>;
 	measurer: WidthMeasurer;
 } {
 	const probes: Array<{
@@ -37,13 +39,21 @@ function recordingMeasurer(): {
 		column: number;
 		width: number;
 	}> = [];
+	const deferred: string[] = [];
 	const asked = new Set<string>();
 	return {
 		probes,
+		deferred,
+		starved,
 		measurer: {
 			wants: (cluster) => !asked.has(cluster),
+			starved: () => starved,
+			defer: (cluster) => {
+				deferred.push(cluster);
+			},
 			probe: (cluster, run, column, width) => {
 				asked.add(cluster);
+				starved.delete(cluster);
 				probes.push({cluster, run, column, width});
 				return "\x1b[6n";
 			},
@@ -234,6 +244,75 @@ test("a cluster at the right margin is left for a frame with room", () => {
 
 	expect(probes.length).toBe(1);
 	expect(probes[0].column).toBe(0);
+});
+
+test("a cluster the margin turns away is offered to the next frame's train", () => {
+	const {probes, deferred, measurer} = recordingMeasurer();
+	emit(1, 10, [[8, "\u{1F31F}"]], measurer); // 🌟, flush with the margin
+
+	expect(probes).toEqual([]);
+	expect(deferred).toEqual(["\u{1F31F}"]);
+});
+
+test("a starved cluster rides a probe train the frame's own content covers", () => {
+	const cluster = "\uFEE0"; // ﻠ, shaped lam
+	// A row whose content starts at column 4 and runs to the margin: the train
+	// goes to column 4, and those columns are painted over as the row emits.
+	const cells: Array<[number, string]> = [];
+	for (let col = 4; col < 20; col++) {
+		cells.push([col, "-"]);
+	}
+	cells.push([20, "x"]);
+
+	const {probes, measurer} = recordingMeasurer(new Set([cluster]));
+	const output = emit(2, 20, cells, measurer);
+
+	expect(probes.length).toBe(1);
+	expect(probes[0].cluster).toBe(cluster);
+	expect(probes[0].column).toBe(4);
+	// Asked before anything is painted, at a column the row then overwrites.
+	expect(output.indexOf(`${cluster}\x1b[6n`)).toBe(output.indexOf(cluster));
+	expect(output.indexOf(cluster)).toBeLessThan(output.indexOf("-"));
+	expect(output).toContain(`\r\x1b[4C${cluster}\x1b[6n\r`);
+	// One train, and the frame it rode paints the row it stood on.
+	expect(output.split(cluster).length - 1).toBe(1);
+});
+
+test("nothing starving costs the frame nothing", () => {
+	const cells: Array<[number, string]> = [];
+	for (let col = 0; col < 20; col++) {
+		cells.push([col, "-"]);
+	}
+	const {probes, measurer} = recordingMeasurer();
+	const output = emit(1, 20, cells, measurer);
+
+	expect(probes).toEqual([]);
+	expect(output).not.toContain("\x1b[6n");
+});
+
+test("a starved cluster waits for a frame with a cell to hide in", () => {
+	// Nothing painted: there is no row whose content could cover a probe, so
+	// the train stays behind rather than writing where it would be seen.
+	const cluster = "\uFEE1"; // ﻡ, shaped meem, isolated
+	const starved = new Set([cluster]);
+
+	const first = recordingMeasurer(starved);
+	emit(2, 20, [], first.measurer);
+	expect(first.probes).toEqual([]);
+	expect(starved.has(cluster)).toBe(true);
+
+	// A row too short to cover the residue is no better.
+	const second = recordingMeasurer(starved);
+	emit(
+		1,
+		20,
+		[
+			[0, "-"],
+			[1, "-"],
+		],
+		second.measurer,
+	);
+	expect(second.probes).toEqual([]);
 });
 
 test("clusters reached by advancing share a run; a cursor move starts a new one", () => {
@@ -479,6 +558,65 @@ test("a burst of replies is matched to its probes in order", async () => {
 	expect(clusterAdvance(first)).toBe(1);
 	expect(clusterAdvance(second)).toBe(undefined);
 	expect(stringWidth(second)).toBe(2);
+
+	dom.dispose();
+});
+
+test("right-aligned text against the margin is measured anyway", async () => {
+	// The rtl example's case: an Arabic presentation form sits in the last
+	// column of a right-aligned line every frame, where its answer would be
+	// unreadable. Deferred in place, it would go unmeasured for the session
+	// and the box around it would stay one cell out.
+	const cluster = "\uFEE0"; // ﻠ, shaped lam
+	expect(stringWidth(cluster)).toBe(1);
+
+	const terminal = new MockProcess({cols: 20, rows: 6});
+	// The train probes from column 3, where the line starts; two cells where
+	// the tables said one puts the cursor in column 6, 1-based.
+	const script = scriptTerminal(terminal, () => "\x1b[1;6R");
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML =
+		"<div style=\"text-align:right\">" +
+		`abcdefghijklmnop<span id="e">${cluster}</span></div>`;
+
+	await nextFrame(dom);
+	// Past the wait a starved cluster gives the document to paint on its own.
+	await settle(800);
+
+	expect(clusterAdvance(cluster)).toBe(2);
+	const span = dom.document.getElementById("e")!;
+	expect(span.getBoundingClientRect().width).toBe(2);
+
+	// Asked once, and the frames that follow the correction ask nothing more:
+	// the train does not ride again.
+	const asked = script.probeCount();
+	dom.document.body.innerHTML +=
+		`<div style="text-align:right">${cluster}</div>`;
+	await nextFrame(dom);
+	await settle();
+	expect(script.probeCount()).toBe(asked);
+
+	dom.dispose();
+});
+
+test("the probe train leaves the screen as the frame's content dictates", async () => {
+	const cluster = "\uFEE2"; // ﻢ, shaped meem, final
+	const terminal = new MockProcess({cols: 20, rows: 6});
+	const script = scriptTerminal(terminal, () => "\x1b[1;5R");
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML =
+		`<div style="text-align:right">abcdefghijklmnop${cluster}</div>`;
+
+	await nextFrame(dom);
+	await settle(800);
+
+	// The train went out.
+	expect(script.written.join("")).toContain(`${cluster}\x1b[6n`);
+	// And the emulator, which saw everything but the queries, shows the line
+	// the document asked for: the probe wrote where the content lands.
+	expect(terminal.getPlainText().split("\n")[0]).toBe(
+		`   abcdefghijklmnop${cluster}`,
+	);
 
 	dom.dispose();
 });


### PR DESCRIPTION
Clusters near the right margin are never measured in place (pending-wrap poisons the arithmetic), and right-aligned RTL content puts its uncertain clusters — Arabic presentation forms — there every time. They deferred forever, stayed at table widths, and on terminals whose advances disagree (Terminal.app) the rtl example's box borders misaligned permanently.

Fix: a starved cluster rides a probe train on the next frame. The train hides in the first row the frame paints, at a column whose next four cells the row's own content covers, so the residue is overwritten in the same flush — nothing is visible. Starvation is detected the first time the guard defers a cluster that no query has ever carried (append-only set, one ride per cluster, O(1)); a quiet document is made to paint one row rather than clearing the screen (a full clear is archived into tmux scrollback). The margin guard itself is unchanged, and frames with nothing starved pay a single size check.

Tests: six new cases including the repro (right-aligned uncertain clusters on a narrow terminal learn a disagreeing advance and the layout stays corrected — fails without the fix) and a train-invisibility assertion; a tmux scenario runs the rtl example at 40 columns and checks the borders stay square with ~28 forms probed. Full suite after rebasing onto 0.1.3: node 1253, bun 1278, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD