### PR TITLE
Wrap RTL runs in directional overrides for terminals that reorder

### DIFF
--- a/src/internal/ansi.ts
+++ b/src/internal/ansi.ts
@@ -740,6 +740,34 @@ export interface WidthMeasurer {
 }
 
 /**
+ * Whether a glyph's leading code point is a strong right-to-left character
+ * as this engine emits text: Hebrew, Arabic and their extensions, and the
+ * shaped presentation forms.
+ */
+function isStrongRTL(glyph: string): boolean {
+	const code = glyph.codePointAt(0)!;
+	return (
+		(code >= 0x0590 && code <= 0x08ff) ||
+		(code >= 0xfb1d && code <= 0xfdff) ||
+		(code >= 0xfe70 && code <= 0xfeff) ||
+		(code >= 0x1e800 && code <= 0x1efff)
+	);
+}
+
+// A terminal that runs its own bidi algorithm would reorder the visual-order
+// text this engine emits a second time. Each contiguous right-to-left run is
+// wrapped in an explicit directional override (LRO ... PDF), which UAX #9
+// obliges such a terminal to display in the order given; a terminal without
+// bidi shows the format characters as nothing. The emission is the same for
+// every terminal, so no capability needs detecting.
+//
+// Nothing obliges a terminal to spend no cell on a format character, and some
+// do spend one, so every control is written on the cell of the glyph that
+// follows it and the column is named again before that glyph goes down.
+const LRO = "\u202d";
+const PDF = "\u202c";
+
+/**
  * Emit the grid as ANSI, row by row.
  *
  * Empty cells are skipped rather than painted, so the cursor jumps them with
@@ -752,6 +780,7 @@ export function generateANSI(
 	colorDepth: ColorDepth = "rgb",
 	renderedLines?: Set<number>,
 	measurer?: WidthMeasurer,
+	wrapRTL = true,
 ): string {
 	const {rows, cols, char, border} = grid;
 
@@ -763,6 +792,11 @@ export function generateANSI(
 	let prevIndex = -1;
 
 	let skipNextCol = -1;
+	// Whether the output is inside an open override. It opens and closes only
+	// in front of a glyph, never over a cell this frame leaves alone, and the
+	// end of the row closes whatever is still open: a line is a paragraph, and
+	// a paragraph terminates its own embeddings.
+	let rtlOpen = false;
 
 	// Measurement bookkeeping: whether to look at all, which emission run the
 	// cursor is in (every move ends one), and how many clusters of unknown
@@ -835,15 +869,30 @@ export function generateANSI(
 				if (measuring) run++;
 			}
 
+			const encoding = border[index];
+			const glyph =
+				encoding > 0 ? getBorderChar(encoding) : decodeGrapheme(char[index]);
+			const rtl = wrapRTL && encoding === 0 && isStrongRTL(glyph);
+			if (rtl !== rtlOpen) {
+				// A terminal that folds the control into the glyph before it
+				// spends nothing on it, and one that does not spends a cell --
+				// this cell, which the glyph below overwrites. Either way the
+				// column is named again before the glyph goes down, so the
+				// grid lands where it was computed to land.
+				output += rtl ? LRO : PDF;
+				output += `\x1b[${col + 1}G`; // CHA - Cursor Char Absolute
+				rtlOpen = rtl;
+				// An absolutely named column is a fresh start for the column
+				// arithmetic the width probes are read against.
+				if (measuring) run++;
+			}
+
 			const styleSeq = styleDiff(grid, index, prevIndex, colorDepth);
 			if (styleSeq !== "") {
 				output += `\x1b[${styleSeq}m`; // SGR - Select Graphic Rendition
 				rowHasAnsi = true;
 			}
 
-			const encoding = border[index];
-			const glyph =
-				encoding > 0 ? getBorderChar(encoding) : decodeGrapheme(char[index]);
 			output += glyph;
 
 			const width = grid.widthAt(index);
@@ -886,6 +935,7 @@ export function generateANSI(
 		}
 
 		if (rowHasContent) {
+			rtlOpen = false;
 			prevIndex = -1;
 			if (rowHasAnsi) {
 				output += "\x1b[0m"; // SGR - Reset all attributes
@@ -1509,6 +1559,7 @@ export class Renderer {
 		regionRows?: number,
 		scroll?: {delta: number; bands: Array<[number, number]>},
 		measurer?: WidthMeasurer,
+		wrapRTL = true,
 	): string {
 		const frameRows = Math.max(this.#rows, regionRows ?? this.#rows);
 		const overflowing = frameRows > this.#rows;
@@ -1819,6 +1870,7 @@ export class Renderer {
 			this.#colorDepth,
 			this.#renderedLines,
 			measurer,
+			wrapRTL,
 		);
 
 		// Strip trailing \r\n from generateANSI — in Renderer-managed mode,

--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -1259,6 +1259,11 @@ export class LayoutEngine {
 		for (const flexNode of this.#measureNodes) flexNode.markDirty();
 	}
 
+	/** Whether the terminal declared that it reorders bidi text itself. */
+	terminalReordersText(): boolean {
+		return this.#terminalReordersText;
+	}
+
 	setTerminalReordersText(value: boolean): void {
 		// Flips the visual order of every RTL run without a mutation.
 		this.invalidateStructure();

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -3369,6 +3369,10 @@ export class TermDOM {
 			top + regionHeight,
 			scroll,
 			this.#session.widthMeasurer,
+			// A terminal that reorders bidi itself receives logical-order
+			// text; wrapping that in a directional override would force the
+			// logical order onto the screen literally.
+			!this[kLayoutEngine].terminalReordersText(),
 		);
 		this.#lastFrameScrollTop = scrollTop;
 		this.#lastFrameEpoch = this[kLayoutEngine].invalidationEpoch;

--- a/tests/bidi.test.ts
+++ b/tests/bidi.test.ts
@@ -291,3 +291,30 @@ test("shaped Arabic ends exactly at the RTL padding boundary", async () => {
 	expect(inner.trim().length).toBe(13);
 	dom.dispose();
 });
+
+test("engine-ordered RTL runs travel inside a directional override", async () => {
+	// A terminal running its own bidi would reorder visual-order text a
+	// second time; LRO...PDF around each run obliges it to display the
+	// order given, and a terminal without bidi shows the pair as nothing.
+	const terminal = new MockProcess({cols: 30, rows: 4});
+	let out = "";
+	const transport = {
+		...terminal.transport,
+		writable: new WritableStream<string>({
+			write(chunk) {
+				out += chunk;
+			},
+		}),
+	};
+	const dom = new TermDOM({transport});
+	dom.document.body.innerHTML = `<div>ab ${HEBREW} cd</div>`;
+	await nextFrame(dom);
+	// Every control is followed by CHA naming the column of the glyph behind
+	// it, so a terminal that spends a cell on the control still paints the
+	// run in the columns the engine chose.
+	const wrapped = out.match(/‭\x1b\[(\d+)G([֐-׿]+)‬\x1b\[(\d+)G/u);
+	expect(wrapped).not.toBe(null);
+	expect(wrapped![2]).toBe([...HEBREW].reverse().join(""));
+	expect(Number(wrapped![3]) - Number(wrapped![1])).toBe(HEBREW.length);
+	await dom.dispose();
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -276,7 +276,12 @@ export class MockProcess extends EventEmitter implements ProcessLike {
 		for (let row = 0; row < this.terminal.rows; row++) {
 			const line = buffer.getLine(buffer.viewportY + row);
 			if (line) {
-				const lineText = line.translateToString(true); // true = trim right
+				// The directional override controls are chrome for terminals
+				// that run their own bidi, and no part of the text on screen.
+				// Assertions about the controls read the byte stream instead.
+				const lineText = line
+					.translateToString(true) // true = trim right
+					.replace(/[\u202c\u202d]/g, "");
 				lines.push(lineText);
 			} else {
 				lines.push("");


### PR DESCRIPTION
Terminal.app runs its own bidi algorithm and has no DECRQM, so the engine's reorder detection can never fire there: it re-reorders the engine's visual-order RTL text and displaces it under box borders (the rtl example's third card, off by two cells). Verified by feeding logical-order Arabic to a bare Terminal.app tab — it reorders and shapes it.

The fix needs no detection. Each contiguous strong-RTL run in the emission is wrapped in an explicit directional override, U+202D … U+202C: a terminal that implements UAX #9 is obliged to display the wrapped run in the order given, and a terminal without bidi renders the format characters as nothing. The wrap is gated off for terminals that declared (mode 8) they reorder — that path hands over logical order on purpose.

The subtle part: xterm-family terminals give a zero-width control its own cell when an escape sequence precedes it, which shifted runs one column and poisoned the width ledger (the run's first probe measured the control's cell as part of the glyph's advance). Every override control is therefore followed by CHA naming the column of the glyph behind it — the glyph overwrites the control where it cost a cell, the CHA is a no-op where it did not, and probes re-anchor their column arithmetic at the absolute position. A byte-stream test pins the full contract: LRO, CHA, the visual-order run, PDF, CHA, with the two named columns differing by exactly the run's length.

Also: the mock's getPlainText strips the two controls (invisible chrome; byte-stream assertions cover the controls themselves).

Full suite exit 0 on both platforms (node 1248, bun 1273); tmux harness 7/7 with the rtl example's borders at identical columns on every row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD