### PR TITLE
Fire the resize event on window

### DIFF
--- a/docs/guides/03-events-and-input.md
+++ b/docs/guides/03-events-and-input.md
@@ -134,10 +134,29 @@ styles. Exiting restores the main screen and scrollback.
 
 ## Resizing
 
-A terminal resize re-evaluates `@media` rules and fires `change` on live
+A terminal resize fires `resize` at the window:
+
+```ts
+window.addEventListener("resize", () => {
+	draw(window.innerWidth, window.innerHeight);
+});
+```
+
+The event carries no dimensions; read them off the window, the document, or
+any element — the new size is in place before listeners run. `window.onresize`
+takes a handler too.
+
+The same resize re-evaluates `@media` rules and fires `change` on live
 `MediaQueryList` objects:
 
 ```ts
 const wide = window.matchMedia("(min-width: 80ch)");
 wide.addEventListener("change", relayout);
 ```
+
+`resize` runs before those `change` events, as in a browser; a `MediaQueryList`
+read from a `resize` listener already answers with the new size.
+
+A burst of resizes — dragging a terminal's edge — is coalesced into one
+redraw, and fires one `resize`, at the size the drag settled on. A resize
+notification that reports the same size fires nothing.

--- a/docs/guides/04-api.md
+++ b/docs/guides/04-api.md
@@ -34,6 +34,8 @@ these members are wired to the terminal:
 - `requestAnimationFrame()`, `cancelAnimationFrame()` — the callback fires
   after the frame that includes your pending mutations has been written
 - `matchMedia()` — live `MediaQueryList`s, re-evaluated on resize
+- `resize` — fired at the window when the terminal size changes, before the
+  `MediaQueryList` `change` events for the same resize; `onresize` works too
 - `getSelection()` — the document selection
 - `navigator.clipboard.writeText()` — the system clipboard, over OSC 52;
   `readText()` rejects, since terminals do not answer clipboard reads

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -297,7 +297,21 @@ export class FullscreenManager {
  * reaches for through `window`. Everything on it is either a DOM constructor
  * or something the engine itself serves.
  */
-export interface EngineWindow extends EventTarget {
+/**
+ * The on* attributes a window carries. The two mixins are installed on
+ * Window.prototype whole, so the type names them whole -- every attribute both
+ * define exists, whether or not this engine has something that fires it. The
+ * listener pair comes from EventTarget; the mixins' redeclarations of it are
+ * dropped so the two agree.
+ */
+type WindowEventHandlerAttributes = Omit<
+	GlobalEventHandlers & WindowEventHandlers,
+	"addEventListener" | "removeEventListener"
+>;
+
+export interface EngineWindow
+	extends EventTarget,
+		WindowEventHandlerAttributes {
 	readonly document: Document;
 	readonly window: EngineWindow;
 	readonly self: EngineWindow;
@@ -955,11 +969,20 @@ export class TermDOM {
 		window.matchMedia = ((query: string): MediaQueryList => {
 			const media = String(query);
 			const mql = new (window as any).EventTarget();
-			let matches = termDOM.#styleManager.mediaQueryMatches(media);
+			// The value the last "change" reported. `matches` is evaluated on
+			// every read instead of answering with this, so a script that asks
+			// during the resize steps -- a "resize" listener, which the
+			// rendering steps run BEFORE media queries are reported -- gets the
+			// answer for the size it is being told about, not the previous one.
+			let notified = termDOM.#styleManager.mediaQueryMatches(media);
 			let onchange: ((ev: Event) => void) | null = null;
 			Object.defineProperties(mql, {
 				media: {get: () => media, enumerable: true, configurable: true},
-				matches: {get: () => matches, enumerable: true, configurable: true},
+				matches: {
+					get: () => termDOM.#styleManager.mediaQueryMatches(media),
+					enumerable: true,
+					configurable: true,
+				},
 				onchange: {
 					get: () => onchange,
 					set: (value: ((ev: Event) => void) | null) => {
@@ -990,8 +1013,8 @@ export class TermDOM {
 			});
 			termDOM.#mediaQueryUpdaters.add(() => {
 				const now = termDOM.#styleManager.mediaQueryMatches(media);
-				if (now === matches) return;
-				matches = now;
+				if (now === notified) return;
+				notified = now;
 				const event = new window.Event("change");
 				Object.defineProperties(event, {
 					matches: {value: now, enumerable: true},
@@ -1880,6 +1903,12 @@ export class TermDOM {
 	 * to the caller -- a resize resizes it in place, a rebind replaces it.
 	 */
 	#applyTerminalSize(newWidth: number, newHeight: number): void {
+		// The resize steps fire only when the viewport's width or height
+		// actually differs from the last time they ran. A SIGWINCH that reports
+		// the same terminal still takes the whole re-anchor path below -- the
+		// terminal may have rewrapped our frame regardless -- but nothing about
+		// the viewport changed, so no event is due.
+		const sizeChanged = newWidth !== this.#width || newHeight !== this.#height;
 		this.#width = newWidth;
 		this.#height = newHeight;
 
@@ -1905,6 +1934,20 @@ export class TermDOM {
 		// epoch, which is what retires the viewport-relative values every
 		// computed style resolved under the old size.
 		this.#styleManager.refreshStylesheets();
+
+		// Then the rendering steps, in their order: the resize steps first,
+		// media queries reported after. A "resize" listener therefore runs
+		// before any MediaQueryList "change" listener, and everything it can
+		// read -- innerWidth/innerHeight, document and body geometry, the
+		// layout engine's viewport, every matchMedia answer -- already
+		// describes the new size.
+		//
+		// The event coalesces exactly as the redraw does: SIGWINCH bursts are
+		// debounced by scheduleResize, so dragging a terminal's edge fires one
+		// resize event, carrying the size the drag settled on.
+		if (sizeChanged) {
+			this.window.dispatchEvent(new this.window.Event("resize"));
+		}
 		for (const update of this.#mediaQueryUpdaters) update();
 	}
 

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -298,11 +298,8 @@ export class FullscreenManager {
  * or something the engine itself serves.
  */
 /**
- * The on* attributes a window carries. The two mixins are installed on
- * Window.prototype whole, so the type names them whole -- every attribute both
- * define exists, whether or not this engine has something that fires it. The
- * listener pair comes from EventTarget; the mixins' redeclarations of it are
- * dropped so the two agree.
+ * The on* attributes a window carries. addEventListener/removeEventListener
+ * come from EventTarget, so the mixins' redeclarations are dropped.
  */
 type WindowEventHandlerAttributes = Omit<
 	GlobalEventHandlers & WindowEventHandlers,
@@ -969,11 +966,8 @@ export class TermDOM {
 		window.matchMedia = ((query: string): MediaQueryList => {
 			const media = String(query);
 			const mql = new (window as any).EventTarget();
-			// The value the last "change" reported. `matches` is evaluated on
-			// every read instead of answering with this, so a script that asks
-			// during the resize steps -- a "resize" listener, which the
-			// rendering steps run BEFORE media queries are reported -- gets the
-			// answer for the size it is being told about, not the previous one.
+			// `matches` reads live; this holds the value the last "change"
+			// event reported.
 			let notified = termDOM.#styleManager.mediaQueryMatches(media);
 			let onchange: ((ev: Event) => void) | null = null;
 			Object.defineProperties(mql, {
@@ -1903,11 +1897,8 @@ export class TermDOM {
 	 * to the caller -- a resize resizes it in place, a rebind replaces it.
 	 */
 	#applyTerminalSize(newWidth: number, newHeight: number): void {
-		// The resize steps fire only when the viewport's width or height
-		// actually differs from the last time they ran. A SIGWINCH that reports
-		// the same terminal still takes the whole re-anchor path below -- the
-		// terminal may have rewrapped our frame regardless -- but nothing about
-		// the viewport changed, so no event is due.
+		// A SIGWINCH reporting an unchanged size still redraws but fires no
+		// resize event.
 		const sizeChanged = newWidth !== this.#width || newHeight !== this.#height;
 		this.#width = newWidth;
 		this.#height = newHeight;
@@ -1935,16 +1926,8 @@ export class TermDOM {
 		// computed style resolved under the old size.
 		this.#styleManager.refreshStylesheets();
 
-		// Then the rendering steps, in their order: the resize steps first,
-		// media queries reported after. A "resize" listener therefore runs
-		// before any MediaQueryList "change" listener, and everything it can
-		// read -- innerWidth/innerHeight, document and body geometry, the
-		// layout engine's viewport, every matchMedia answer -- already
-		// describes the new size.
-		//
-		// The event coalesces exactly as the redraw does: SIGWINCH bursts are
-		// debounced by scheduleResize, so dragging a terminal's edge fires one
-		// resize event, carrying the size the drag settled on.
+		// Per the rendering steps, resize fires before media query "change"
+		// events, and everything a listener reads already has the new size.
 		if (sizeChanged) {
 			this.window.dispatchEvent(new this.window.Event("resize"));
 		}

--- a/tests/viewport.test.ts
+++ b/tests/viewport.test.ts
@@ -833,8 +833,6 @@ test("a terminal resize fires a resize event at the window", async () => {
 	(terminal as any).emit("SIGWINCH");
 	await new Promise((r) => setTimeout(r, 100));
 
-	// The event carries no size of its own; a listener reads it off the window,
-	// and every dimension it can reach already describes the new terminal.
 	expect(seen).toEqual([
 		{
 			type: "resize",
@@ -862,9 +860,6 @@ test("the resize event precedes MediaQueryList change, which already answers wit
 	await nextFrame(dom);
 
 	const order: string[] = [];
-	// The rendering steps run the resize steps before media queries are
-	// reported, so the resize listener runs first -- and matchMedia answers it
-	// with the size it is being told about, not the one that just went away.
 	window.addEventListener("resize", () => {
 		order.push(`resize matches=${mql.matches}`);
 	});
@@ -901,8 +896,6 @@ test("every resize listener runs, onresize among them, until it is removed", asy
 	await new Promise((r) => setTimeout(r, 100));
 	expect(calls).toEqual(["first:50", "second:50", "onresize:50"]);
 
-	// removeEventListener stops one listener and leaves the others; the
-	// onresize attribute is a listener like any other, and null removes it.
 	window.removeEventListener("resize", first);
 	window.onresize = null;
 	calls.length = 0;
@@ -927,9 +920,6 @@ test("a SIGWINCH reporting the same size fires no resize event", async () => {
 	let count = 0;
 	window.addEventListener("resize", () => count++);
 
-	// The pipeline delivers every SIGWINCH -- the terminal may have rewrapped
-	// the frame regardless -- and the re-anchored redraw runs. The viewport did
-	// not change, so the resize steps fire nothing.
 	(terminal as any).emit("SIGWINCH");
 	await new Promise((r) => setTimeout(r, 100));
 	expect(count).toBe(0);
@@ -953,8 +943,6 @@ test("a burst of SIGWINCHes fires one resize event, at the size it settled on", 
 	const widths: number[] = [];
 	window.addEventListener("resize", () => widths.push(window.innerWidth));
 
-	// Dragging an edge fires a SIGWINCH per column passed through. The redraw
-	// is debounced into one; the event rides that same debounce.
 	for (const cols of [90, 80, 70, 60]) {
 		terminal.resize(cols, 30);
 		(terminal as any).emit("SIGWINCH");

--- a/tests/viewport.test.ts
+++ b/tests/viewport.test.ts
@@ -808,6 +808,164 @@ test("matchMedia answers with the stylesheet evaluator and goes live on resize",
 	dom.dispose();
 });
 
+test("a terminal resize fires a resize event at the window", async () => {
+	const terminal = new MockProcess({cols: 100, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {window, document} = dom;
+
+	document.body.innerHTML = `<div id="d" style="width: 100%">x</div>`;
+	await nextFrame(dom);
+
+	const seen: any[] = [];
+	window.addEventListener("resize", (event: any) => {
+		seen.push({
+			type: event.type,
+			bubbles: event.bubbles,
+			cancelable: event.cancelable,
+			isWindow: event.target === window,
+			innerWidth: window.innerWidth,
+			innerHeight: window.innerHeight,
+			divWidth: document.getElementById("d")!.getBoundingClientRect().width,
+		});
+	});
+
+	terminal.resize(50, 20);
+	(terminal as any).emit("SIGWINCH");
+	await new Promise((r) => setTimeout(r, 100));
+
+	// The event carries no size of its own; a listener reads it off the window,
+	// and every dimension it can reach already describes the new terminal.
+	expect(seen).toEqual([
+		{
+			type: "resize",
+			bubbles: false,
+			cancelable: false,
+			isWindow: true,
+			innerWidth: 50,
+			innerHeight: 20,
+			divWidth: 50,
+		},
+	]);
+
+	dom.dispose();
+});
+
+test("the resize event precedes MediaQueryList change, which already answers with the new size", async () => {
+	const terminal = new MockProcess({cols: 100, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {window, document} = dom;
+
+	const mql = window.matchMedia("(max-width: 60px)");
+	expect(mql.matches).toBe(false);
+
+	document.body.innerHTML = "<div>x</div>";
+	await nextFrame(dom);
+
+	const order: string[] = [];
+	// The rendering steps run the resize steps before media queries are
+	// reported, so the resize listener runs first -- and matchMedia answers it
+	// with the size it is being told about, not the one that just went away.
+	window.addEventListener("resize", () => {
+		order.push(`resize matches=${mql.matches}`);
+	});
+	mql.addEventListener("change", (event: any) => {
+		order.push(`change matches=${event.matches}`);
+	});
+
+	terminal.resize(50, 30);
+	(terminal as any).emit("SIGWINCH");
+	await new Promise((r) => setTimeout(r, 100));
+
+	expect(order).toEqual(["resize matches=true", "change matches=true"]);
+
+	dom.dispose();
+});
+
+test("every resize listener runs, onresize among them, until it is removed", async () => {
+	const terminal = new MockProcess({cols: 100, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {window, document} = dom;
+
+	document.body.innerHTML = "<div>x</div>";
+	await nextFrame(dom);
+
+	const calls: string[] = [];
+	const first = () => calls.push(`first:${window.innerWidth}`);
+	const second = () => calls.push(`second:${window.innerWidth}`);
+	window.addEventListener("resize", first);
+	window.addEventListener("resize", second);
+	window.onresize = () => calls.push(`onresize:${window.innerWidth}`);
+
+	terminal.resize(50, 30);
+	(terminal as any).emit("SIGWINCH");
+	await new Promise((r) => setTimeout(r, 100));
+	expect(calls).toEqual(["first:50", "second:50", "onresize:50"]);
+
+	// removeEventListener stops one listener and leaves the others; the
+	// onresize attribute is a listener like any other, and null removes it.
+	window.removeEventListener("resize", first);
+	window.onresize = null;
+	calls.length = 0;
+
+	terminal.resize(40, 30);
+	(terminal as any).emit("SIGWINCH");
+	await new Promise((r) => setTimeout(r, 100));
+	expect(calls).toEqual(["second:40"]);
+	expect(window.onresize).toBe(null);
+
+	dom.dispose();
+});
+
+test("a SIGWINCH reporting the same size fires no resize event", async () => {
+	const terminal = new MockProcess({cols: 100, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {window, document} = dom;
+
+	document.body.innerHTML = "<div>x</div>";
+	await nextFrame(dom);
+
+	let count = 0;
+	window.addEventListener("resize", () => count++);
+
+	// The pipeline delivers every SIGWINCH -- the terminal may have rewrapped
+	// the frame regardless -- and the re-anchored redraw runs. The viewport did
+	// not change, so the resize steps fire nothing.
+	(terminal as any).emit("SIGWINCH");
+	await new Promise((r) => setTimeout(r, 100));
+	expect(count).toBe(0);
+
+	terminal.resize(50, 30);
+	(terminal as any).emit("SIGWINCH");
+	await new Promise((r) => setTimeout(r, 100));
+	expect(count).toBe(1);
+
+	dom.dispose();
+});
+
+test("a burst of SIGWINCHes fires one resize event, at the size it settled on", async () => {
+	const terminal = new MockProcess({cols: 100, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {window, document} = dom;
+
+	document.body.innerHTML = "<div>x</div>";
+	await nextFrame(dom);
+
+	const widths: number[] = [];
+	window.addEventListener("resize", () => widths.push(window.innerWidth));
+
+	// Dragging an edge fires a SIGWINCH per column passed through. The redraw
+	// is debounced into one; the event rides that same debounce.
+	for (const cols of [90, 80, 70, 60]) {
+		terminal.resize(cols, 30);
+		(terminal as any).emit("SIGWINCH");
+	}
+	await new Promise((r) => setTimeout(r, 100));
+
+	expect(widths).toEqual([60]);
+
+	dom.dispose();
+});
+
 test("@media stylesheet rules re-evaluate when the terminal resizes", async () => {
 	const terminal = new MockProcess({cols: 100, rows: 30});
 	const dom = new TermDOM({transport: terminal.transport});


### PR DESCRIPTION
What it says on the tin.

Five tests in tests/viewport.test.ts; guide and API docs updated. Suite: node 1252/0, bun 1277/0, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD