### PR TITLE
Write user edits to the value slot, not the value accessor

### DIFF
--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -116,6 +116,8 @@ const kUASelectionRange = Symbol("what an element's own selection covers");
 type UAListener = (event: Event) => void;
 const kUASelection = Symbol("a control's selection, whatever its type");
 const kSetUASelection = Symbol("move a control's selection, whatever its type");
+const kUAValue = Symbol("a text control's value, beneath the IDL attribute");
+const kSetUAValue = Symbol("write a text control's value, as a user edit does");
 
 /** A text control's selection, read past the type gate the author meets. */
 function uaSelectionOf(control: object): {
@@ -10375,7 +10377,7 @@ function applySharedFieldEdit(
 	shiftKey: boolean,
 	ctrlKey: boolean,
 ): FieldEditResult | null {
-	const value = field.value;
+	const value = field[kUAValue];
 	const {start, end, direction} = uaSelectionOf(field);
 	const backward = direction === "backward";
 	const caret = backward ? start : end;
@@ -10479,7 +10481,7 @@ function printableFieldEdit(
 	field: HTMLInputElement | HTMLTextAreaElement,
 	text: string,
 ): FieldEditResult {
-	const value = field.value;
+	const value = field[kUAValue];
 	const {start, end} = uaSelectionOf(field);
 	return collapsedEdit(
 		value.slice(0, start) + text + value.slice(end),
@@ -10509,17 +10511,22 @@ function collapsedEdit(value: string, pos: number): FieldEditResult {
  * Apply an edit result to a field's own value and selection, firing `input` on
  * a real value change (the value write reconciles the control's tree) and
  * `select` on a selection the user moved -- both events the render loop hears.
- * Order matters: assigning `.value` collapses the selection to the end (per
- * spec), so the caret is set after.
+ *
+ * The write lands on the control's value itself, never on the `value` IDL
+ * attribute over it -- a user edit in a browser changes the value without the
+ * setter running, which is how a page can tell what the user typed from what
+ * it assigned. (A framework that tracks user input replaces the accessor on
+ * the element and compares what it reads back; going through the setter would
+ * make every keystroke look like the page's own write.)
  */
 function applyFieldEdit(
 	field: HTMLInputElement | HTMLTextAreaElement,
 	result: FieldEditResult,
 ): void {
-	const value = field.value;
+	const value = field[kUAValue];
 	const {start, end, direction} = uaSelectionOf(field);
 	if (result.value !== value) {
-		field.value = result.value;
+		field[kSetUAValue](result.value);
 		field[kSetUASelection](result.start, result.end, result.direction);
 		dispatch(field, new Event("input", {bubbles: true, cancelable: false}));
 	} else if (
@@ -10538,7 +10545,7 @@ function insertPaste(
 	text: string,
 ): void {
 	if (!text) return;
-	const value = field.value;
+	const value = field[kUAValue];
 	const {start, end} = uaSelectionOf(field);
 	applyFieldEdit(
 		field,
@@ -10820,6 +10827,30 @@ export class HTMLInputElement extends HTMLElement {
 			default:
 				this.setAttribute("value", string);
 		}
+		widgetChanged(this);
+	}
+
+	/**
+	 * The control's value itself, which is what the widget below renders and
+	 * edits through. The IDL attribute above it answers with an attribute for
+	 * the types that have no value of their own; those types render no field,
+	 * so their value here is the empty string a caret would sit in.
+	 */
+	get [kUAValue](): string {
+		return inputValueMode(this.type) === "value" ? this.#value : "";
+	}
+
+	/**
+	 * Set the value from a user edit: the value changes and the dirty value
+	 * flag is set, and nothing else -- the selection is the edit's to place,
+	 * where the IDL setter would collapse it to the end. A control with no
+	 * value of its own (a file input's filename list) has nothing a keystroke
+	 * can write, as in a browser, where its UI accepts no typing at all.
+	 */
+	[kSetUAValue](value: string): void {
+		if (inputValueMode(this.type) !== "value") return;
+		this.#value = sanitizeInputValue(this, value);
+		this.#dirtyValue = true;
 		widgetChanged(this);
 	}
 
@@ -11193,7 +11224,7 @@ export class HTMLInputElement extends HTMLElement {
 			return;
 		}
 		if (!this.#valueText) return;
-		const value = this.value;
+		const value = this[kUAValue];
 		const placeholder = this.getAttribute("placeholder") ?? "";
 		// A password puts one bullet per code unit into the shadow, never the
 		// real value -- so what lays out, paints, and can be selected is only the
@@ -11253,7 +11284,7 @@ export class HTMLInputElement extends HTMLElement {
 			return;
 		}
 
-		const value = this.value;
+		const value = this[kUAValue];
 		const {start, end, direction} = uaSelectionOf(this);
 		const anchor = direction === "backward" ? end : start;
 		const caret = direction === "backward" ? start : end;
@@ -12199,11 +12230,11 @@ export class HTMLTextAreaElement extends HTMLElement {
 	}
 
 	get value(): string {
-		return this.#dirty ? this.#value : normalizeNewlines(descendantText(this));
+		return this[kUAValue];
 	}
 
 	set value(value: string) {
-		const previous = this.value;
+		const previous = this[kUAValue];
 		this.#value = normalizeNewlines(value === null ? "" : String(value));
 		this.#dirty = true;
 		if (previous !== this.#value) {
@@ -12211,6 +12242,25 @@ export class HTMLTextAreaElement extends HTMLElement {
 			this.#selectionEnd = this.#value.length;
 			this.#selectionDirection = "none";
 		}
+		widgetChanged(this);
+	}
+
+	/**
+	 * The control's value itself, which is what the widget below renders and
+	 * edits through: the raw value once the dirty flag is set, the child text
+	 * until then. @see HTMLInputElement's own door.
+	 */
+	get [kUAValue](): string {
+		return this.#dirty ? this.#value : normalizeNewlines(descendantText(this));
+	}
+
+	/**
+	 * Set the value from a user edit: the raw value changes and the dirty
+	 * value flag is set, leaving the selection to the edit that made it.
+	 */
+	[kSetUAValue](value: string): void {
+		this.#value = normalizeNewlines(value);
+		this.#dirty = true;
 		widgetChanged(this);
 	}
 
@@ -12281,7 +12331,7 @@ export class HTMLTextAreaElement extends HTMLElement {
 			toUnsignedLong(start),
 			toUnsignedLong(end),
 			direction,
-			this.value.length,
+			this[kUAValue].length,
 			(selection) => {
 				this.#selectionStart = selection[0];
 				this.#selectionEnd = selection[1];
@@ -12393,7 +12443,7 @@ export class HTMLTextAreaElement extends HTMLElement {
 	[kUAReconcile](): void {
 		const engine = this.#engine;
 		if (engine === null) return;
-		const value = this.value;
+		const value = this[kUAValue];
 		const placeholder = this.getAttribute("placeholder") ?? "";
 		let changed = false;
 		if (this.#valueText!.data !== value) {
@@ -12433,7 +12483,7 @@ export class HTMLTextAreaElement extends HTMLElement {
 		// The goal column survives only an unbroken run of vertical moves.
 		if (key !== "ArrowUp" && key !== "ArrowDown") this.#goalColumn = null;
 
-		const value = this.value;
+		const value = this[kUAValue];
 		const {start, end, direction} = uaSelectionOf(this);
 		const backward = direction === "backward";
 		const caret = backward ? start : end;

--- a/tests/value-tracking.test.ts
+++ b/tests/value-tracking.test.ts
@@ -1,0 +1,247 @@
+/**
+ * What a user edit writes, and what it does not touch.
+ *
+ * A browser's editing internals change a control's value itself, never the
+ * `value` IDL attribute over it -- so a page that replaces the accessor on the
+ * element (the shape every controlled-input library uses to tell a user's
+ * keystroke from its own assignment) sees its setter run for its own writes
+ * and never for typing. The same distinction holds here, and the dirty value
+ * flag follows the HTML Standard on both sides of it.
+ */
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+function type(terminal: MockProcess, data: string): Promise<void> {
+	(terminal.stdin as any).emit("data", Buffer.from(data));
+	// Input rides the transport's readable: delivery is a microtask away.
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Wrap an element's own `value`/`checked` accessor the way an input-tracking
+ * library does: an instance property shadowing the prototype's, delegating
+ * both ways, remembering every value the page assigns.
+ */
+function trackAccessor(node: any, property: "value" | "checked") {
+	const descriptor = Object.getOwnPropertyDescriptor(
+		Object.getPrototypeOf(node),
+		property,
+	)!;
+	const assigned: unknown[] = [];
+	let seen = node[property];
+	Object.defineProperty(node, property, {
+		configurable: true,
+		enumerable: false,
+		get() {
+			return descriptor.get!.call(this);
+		},
+		set(value: unknown) {
+			assigned.push(value);
+			seen = value;
+			descriptor.set!.call(this, value);
+		},
+	});
+	return {
+		assigned,
+		/** Whether the element's value has moved out from under the tracker. */
+		drifted: () => node[property] !== seen,
+	};
+}
+
+/** A focused field in a running terminal, ready to be typed into. */
+async function fieldFixture(tag: "input" | "textarea") {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.attach();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	const field = dom.document.createElement(tag) as any;
+	dom.document.body.appendChild(field);
+	field.focus();
+	await nextFrame(dom);
+	return {terminal, dom, field};
+}
+
+/* ------------------------------------------- the user's edit, not the page's */
+
+test("typing an input never runs the page's value setter", async () => {
+	const {terminal, dom, field} = await fieldFixture("input");
+	const tracker = trackAccessor(field, "value");
+	const events: string[] = [];
+	field.addEventListener("input", () => events.push("input"));
+
+	await type(terminal, "hi");
+
+	expect(field.value).toBe("hi");
+	expect(tracker.assigned).toEqual([]);
+	expect(tracker.drifted()).toBe(true);
+	expect(events).toEqual(["input", "input"]);
+
+	dom.dispose();
+});
+
+test("backspace and paste stay off the page's value setter", async () => {
+	const {terminal, dom, field} = await fieldFixture("input");
+	await type(terminal, "abc");
+	const tracker = trackAccessor(field, "value");
+
+	await type(terminal, "\x7f");
+	expect(field.value).toBe("ab");
+	// A bracketed paste is one atomic insert.
+	await type(terminal, "\x1b[200~xyz\x1b[201~");
+	expect(field.value).toBe("abxyz");
+	expect(tracker.assigned).toEqual([]);
+
+	dom.dispose();
+});
+
+test("typing a textarea never runs the page's value setter", async () => {
+	const {terminal, dom, field} = await fieldFixture("textarea");
+	const tracker = trackAccessor(field, "value");
+	const events: string[] = [];
+	field.addEventListener("input", () => events.push("input"));
+
+	await type(terminal, "ab");
+	await type(terminal, "\r");
+	await type(terminal, "c");
+
+	expect(field.value).toBe("ab\nc");
+	expect(tracker.assigned).toEqual([]);
+	expect(tracker.drifted()).toBe(true);
+	expect(events.length).toBe(4);
+
+	dom.dispose();
+});
+
+test("clicking a checkbox never runs the page's checked setter", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	const box = dom.document.createElement("input") as any;
+	box.type = "checkbox";
+	dom.document.body.appendChild(box);
+	await nextFrame(dom);
+	const tracker = trackAccessor(box, "checked");
+	const events: string[] = [];
+	box.addEventListener("input", () => events.push("input"));
+	box.addEventListener("change", () => events.push("change"));
+
+	box.click();
+
+	expect(box.checked).toBe(true);
+	expect(tracker.assigned).toEqual([]);
+	expect(tracker.drifted()).toBe(true);
+	expect(events).toEqual(["input", "change"]);
+
+	dom.dispose();
+});
+
+test("the page's own assignment still runs its wrapped setter", async () => {
+	const {dom, field} = await fieldFixture("input");
+	const tracker = trackAccessor(field, "value");
+
+	field.value = "written";
+
+	expect(field.value).toBe("written");
+	expect(tracker.assigned).toEqual(["written"]);
+	expect(tracker.drifted()).toBe(false);
+
+	dom.dispose();
+});
+
+test("a page assignment after typing runs the setter, and wins", async () => {
+	const {terminal, dom, field} = await fieldFixture("input");
+	await type(terminal, "typed");
+	const tracker = trackAccessor(field, "value");
+
+	field.value = "typed!";
+	await type(terminal, "?");
+
+	expect(field.value).toBe("typed!?");
+	expect(tracker.assigned).toEqual(["typed!"]);
+
+	dom.dispose();
+});
+
+/* ------------------------------------------------------ the dirty value flag */
+
+test("typing sets an input's dirty value flag", async () => {
+	const {terminal, dom, field} = await fieldFixture("input");
+	field.setAttribute("value", "default");
+	expect(field.value).toBe("default");
+
+	await type(terminal, "!");
+
+	// The attribute stops feeding the value once the user has edited it, and
+	// keeps answering for the default.
+	expect(field.value).toBe("!default");
+	field.setAttribute("value", "ignored now");
+	expect(field.value).toBe("!default");
+	expect(field.defaultValue).toBe("ignored now");
+
+	dom.dispose();
+});
+
+test("a form reset clears the flag a user edit set", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.attach();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	const {document} = dom;
+	document.body.innerHTML = `<form><input value="default"><textarea>child text</textarea></form>`;
+	const form = document.querySelector("form") as any;
+	const input = document.querySelector("input") as any;
+	const textarea = document.querySelector("textarea") as any;
+	input.focus();
+	await nextFrame(dom);
+	await type(terminal, "!");
+	textarea.focus();
+	await nextFrame(dom);
+	await type(terminal, "!");
+
+	expect(input.value).toBe("!default");
+	expect(textarea.value).toBe("!child text");
+
+	form.reset();
+
+	expect(input.value).toBe("default");
+	expect(textarea.value).toBe("child text");
+	// And the attribute feeds the value again, the flag being clear.
+	input.setAttribute("value", "moved");
+	expect(input.value).toBe("moved");
+
+	dom.dispose();
+});
+
+test("typing sets a textarea's dirty value flag", async () => {
+	const {terminal, dom, field} = await fieldFixture("textarea");
+	field.appendChild(dom.document.createTextNode("child"));
+	expect(field.value).toBe("child");
+
+	await type(terminal, "!");
+
+	expect(field.value).toBe("!child");
+	field.firstChild.data = "ignored now";
+	expect(field.value).toBe("!child");
+	expect(field.defaultValue).toBe("ignored now");
+
+	dom.dispose();
+});
+
+/* ------------------------------------------------- what the widget renders */
+
+test("a user edit reaches the rendered value, not only the IDL attribute", async () => {
+	const {terminal, dom, field} = await fieldFixture("input");
+	// A page that replaces the accessor outright still sees its field paint.
+	Object.defineProperty(field, "value", {
+		configurable: true,
+		get: () => "not the value",
+		set: () => {},
+	});
+
+	await type(terminal, "painted");
+	await nextFrame(dom);
+
+	expect(terminal.getPlainText()).toContain("painted");
+
+	dom.dispose();
+});


### PR DESCRIPTION
React 19's controlled inputs freeze under TermDOM: react-dom wraps each field's value accessor with a tracker and fires onChange only when the value it reads back differs from what it last wrote. In a browser, typing writes the field's internal value slot without invoking the JS accessor, so user input always reads as a change — but TermDOM's UA editing assigned field.value, going through the (wrapped) public setter, so React attributed every user edit to itself and swallowed the change events.

The fix restores the author-write vs user-edit distinction. The entire edit core funnels through one site (applyFieldEdit), which now writes an internal slot via module-private symbols; every UA read of the value moves off the public getter too, so a page that replaces the accessor outright cannot blind the widget. The author-facing accessors are untouched: programmatic value still sanitizes, sets the dirty flag, and collapses the selection to the end per spec.

Semantics pinned with spec citations: a user edit sets the dirty value flag and nothing else (the selection jump belongs to the IDL setter, not to editing); sanitization still runs; form reset clears the flag and restores defaults. One behavior improvement: typing into a type=file input is now a no-op instead of throwing InvalidStateError out of a keydown listener.

Checkbox/radio toggling already wrote its slot directly — verified, and pinned by regression so it stays that way. One adjacent case flagged, not changed: the select's UA commit writes this.selectedIndex through the accessor — same shape, not the React bug (react-dom uses the native change event for select), left for a later sweep.

Tests: ten cases in tests/value-tracking.test.ts with a tracker mirroring react-dom's exactly (instance property shadowing the prototype accessor); five fail on main, five pin surrounding semantics. Suite: node 1257/0, bun 1282/0, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD