### PR TITLE
Remove the compile cache and vestigial example idioms

### DIFF
--- a/examples/chat.ts
+++ b/examples/chat.ts
@@ -4,7 +4,7 @@ import {TermDOM} from "@b9g/termdom";
 const term = new TermDOM();
 
 term.attach();
-const {document, window} = term;
+const {document} = term;
 
 const style = document.createElement("style");
 style.textContent = `
@@ -39,6 +39,7 @@ const sigil = document.createElement("span");
 sigil.className = "sigil";
 sigil.textContent = "› ";
 const input = document.createElement("textarea");
+input.autofocus = true;
 input.setAttribute("rows", "1");
 input.setAttribute("placeholder", "message ch.at…");
 prompt.append(sigil, input);
@@ -65,9 +66,8 @@ function addMessage(role: "user" | "assistant", text: string): Text {
 	return node;
 }
 
-async function scrollToPrompt(): Promise<void> {
+function scrollToPrompt(): void {
 	prompt.scrollIntoView();
-	await new Promise<void>((r) => window.requestAnimationFrame(() => r()));
 }
 
 // The reply is streamed. ch.at echoes the whole prompt as `Q: ...` then adds a
@@ -93,7 +93,7 @@ async function send(): Promise<void> {
 	const bot = addMessage("assistant", "…");
 	const botMsg = bot.parentElement!.parentElement as HTMLElement;
 	botMsg.classList.add("pending");
-	await scrollToPrompt();
+	scrollToPrompt();
 
 	const conversation = turns
 		.map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.text}`)
@@ -120,7 +120,7 @@ async function send(): Promise<void> {
 			if (answer) {
 				botMsg.classList.remove("pending");
 				bot.data = answer;
-				await scrollToPrompt();
+				scrollToPrompt();
 			}
 		}
 		clearTimeout(timeout);
@@ -134,7 +134,7 @@ async function send(): Promise<void> {
 		turns.pop(); // drop the user turn whose reply failed, so context stays clean
 	} finally {
 		busy = false;
-		await scrollToPrompt();
+		scrollToPrompt();
 	}
 }
 
@@ -162,8 +162,7 @@ document.addEventListener(
 	true,
 );
 
-input.focus();
-await scrollToPrompt();
+scrollToPrompt();
 
 // No terminal (piped/CI): run one scripted exchange so the example is testable
 // and inspectable without typing, then exit.

--- a/examples/commit-editor.ts
+++ b/examples/commit-editor.ts
@@ -45,7 +45,7 @@ editor.className = "editor";
 editor.innerHTML = `
   <div class="title">Compose commit</div>
   <div class="row"><div class="label">Type</div><select id="type"><option value="feat">feat</option><option value="fix">fix</option><option value="docs">docs</option><option value="refactor">refactor</option><option value="test">test</option><option value="chore">chore</option></select><div class="counter" id="counter"></div></div>
-  <div class="row"><div class="label">Subject</div><input id="subject" placeholder="imperative, ≤50 chars, no period"></div>
+  <div class="row"><div class="label">Subject</div><input id="subject" autofocus placeholder="imperative, ≤50 chars, no period"></div>
   <div class="row"><div class="label">Body</div><textarea id="body" rows="5" cols="60" placeholder="What and why -- wrapped for you at the field edge; blank line between paragraphs."></textarea></div>
   <div class="status" id="status"></div>
   <div class="hint">tab moves · ↑/↓ changes type / walks lines · ctrl+c quits</div>
@@ -74,5 +74,3 @@ type.addEventListener("change", update);
 subject.addEventListener("input", update);
 body.addEventListener("input", update);
 update();
-
-subject.focus();

--- a/examples/form.ts
+++ b/examples/form.ts
@@ -23,7 +23,7 @@ const form = document.createElement("div");
 form.className = "form";
 form.innerHTML = `
   <div class="title">New profile</div>
-  <div class="field"><div class="label">Name</div><input id="name" type="text"></div>
+  <div class="field"><div class="label">Name</div><input id="name" type="text" autofocus></div>
   <div class="field"><div class="label">Email</div><input id="email" type="text"></div>
   <div class="field"><div class="label">Handle</div><input id="handle" type="text"></div>
   <div class="preview" id="preview"></div>
@@ -64,5 +64,3 @@ document.addEventListener("keydown", (event: Event) => {
 });
 
 updatePreview();
-fields[0].focus();
-await new Promise<void>((r) => term.window.requestAnimationFrame(() => r()));

--- a/examples/fuzzy-finder.ts
+++ b/examples/fuzzy-finder.ts
@@ -85,7 +85,7 @@ function score(item: string, query: string): number | null {
 // ---- DOM ---------------------------------------------------------------------
 const term = new TermDOM();
 term.attach();
-const {document, window} = term;
+const {document} = term;
 
 const style = document.createElement("style");
 style.textContent = `
@@ -108,6 +108,7 @@ const sigil = document.createElement("span");
 sigil.className = "sigil";
 sigil.textContent = "\u203a\u00a0";
 const input = document.createElement("input");
+input.autofocus = true;
 input.setAttribute("placeholder", "type to filter…");
 prompt.append(sigil, input);
 
@@ -220,11 +221,9 @@ document.addEventListener("keydown", (event: Event) => {
 });
 
 render();
-input.focus();
 
 // Piped or redirected (no terminal): just print the current list and exit, so
 // the example is inspectable without a TTY.
-await new Promise<void>((r) => window.requestAnimationFrame(() => r()));
 if (!process.stdout.isTTY) {
 	term.window.close();
 }

--- a/examples/git-log.ts
+++ b/examples/git-log.ts
@@ -137,12 +137,11 @@ function select(index: number): void {
 	header.textContent = ` ${commits.length} commits · ${selected + 1}`;
 }
 
-async function refresh(): Promise<void> {
+function refresh(): void {
 	rows()[selected]?.scrollIntoView();
 	if (selected === 0) {
 		window.scrollBy(0, -document.body.scrollHeight);
 	}
-	await new Promise<void>((r) => window.requestAnimationFrame(() => r()));
 }
 
 document.addEventListener("keydown", (event: Event) => {
@@ -173,7 +172,7 @@ document.addEventListener("keydown", (event: Event) => {
 	} else {
 		return;
 	}
-	void refresh();
+	refresh();
 });
 
 document.addEventListener("click", (event: Event) => {
@@ -187,11 +186,11 @@ document.addEventListener("click", (event: Event) => {
 	} else {
 		expand(row);
 	}
-	void refresh();
+	refresh();
 });
 
 select(0);
-await refresh();
+refresh();
 
 if (!process.stdout.isTTY) {
 	term.window.close();

--- a/examples/markdown.ts
+++ b/examples/markdown.ts
@@ -193,9 +193,6 @@ const article = document.createElement("article");
 article.innerHTML = html;
 document.body.appendChild(article);
 
-// Let layout settle and the first frame paint before measuring the page.
-await new Promise<void>((r) => window.requestAnimationFrame(() => r()));
-
 // Flow mode: a page that fits (or output that isn't a terminal, e.g. piped to a
 // file) just prints and exits -- dispose pays the whole document out to the
 // terminal's scrollback on the way.

--- a/examples/popover.ts
+++ b/examples/popover.ts
@@ -68,7 +68,7 @@ document.body.innerHTML = `
 		<div>This one stacked on the Help menu.</div>
 	</div>
 	<div id="saved" popover="manual">Saved.</div>
-	<textarea placeholder="type here, then explore the menus…"></textarea>
+	<textarea autofocus placeholder="type here, then explore the menus…"></textarea>
 	<div class="status"> Tab to the menu bar · Enter opens · Escape or a click closes</div>
 `;
 
@@ -106,5 +106,3 @@ document.addEventListener("click", (event) => {
 	}
 	editor.focus();
 });
-
-editor.focus();

--- a/examples/tree.ts
+++ b/examples/tree.ts
@@ -166,7 +166,7 @@ function parentOf(row: HTMLElement): HTMLElement | undefined {
 	return undefined;
 }
 
-async function refresh(): Promise<void> {
+function refresh(): void {
 	// getBoundingClientRect flushes pending mutations itself, so the camera can
 	// be placed before the single paint -- one render per keystroke.
 	rows()[selected]?.scrollIntoView();
@@ -175,7 +175,6 @@ async function refresh(): Promise<void> {
 	if (selected === 0) {
 		window.scrollBy(0, -document.body.scrollHeight);
 	}
-	await new Promise<void>((r) => term.window.requestAnimationFrame(() => r()));
 }
 
 function rebuild(): void {
@@ -220,7 +219,7 @@ document.addEventListener("keydown", (event: Event) => {
 	} else {
 		return;
 	}
-	void refresh();
+	refresh();
 });
 
 // The whole mouse story: the wheel scrolls the camera on its own (a
@@ -243,4 +242,4 @@ document.addEventListener("click", (event: Event) => {
 });
 
 rebuild();
-await refresh();
+refresh();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,3 @@
-// V8's compile cache: the module graph is most of a CLI invocation's
-// startup. Namespace access because runtimes with their own cache (Bun)
-// do not export it.
-import * as NodeModule from "node:module";
-try {
-	(NodeModule as {enableCompileCache?: () => void}).enableCompileCache?.();
-} catch (_err) {
-	// Nothing to do; the runtime just recompiles.
-}
-
 export {TermDOM} from "./internal/termdom.js";
 export type {TermDOMOptions} from "./internal/termdom.js";
 export {transportFromProcess} from "./internal/terminalsession.js";


### PR DESCRIPTION
Two jsdom-era vestiges:

- **The V8 compile cache in the library entry.** It warmed jsdom's hundred-module graph; the engine now bundles to one file and warm startup measures identically with the cache disabled (0.17s either way), while the cache directory had accumulated 90MB in tmp. It was also process-global policy — a library deciding caching for the whole consuming app.
- **The examples' trailing `await requestAnimationFrame` waits**, from when a script had to pump a frame before anything painted. `attach()` renders off mutations, so they were dead weight; scroll-only refresh helpers become synchronous. Initial focus also moves from manual `.focus()` calls to the `autofocus` attribute the engine implements (dynamic refocusing stays imperative).

20/20 examples verified, full battery green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD