### PR TITLE
Give number inputs a number's editing: filter the text, gate the value, step on arrows

### DIFF
--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -11788,6 +11788,25 @@ function applySharedFieldEdit(
 }
 
 /**
+ * The characters a field's type lets through. A number input takes only what
+ * can spell a floating-point number -- digits, sign, decimal point, and
+ * exponent -- the same per-character filter a browser applies to typing and
+ * pasting; every other type takes the text as it came.
+ */
+function sanitizeFieldInsertion(
+	field: HTMLInputElement | HTMLTextAreaElement,
+	text: string,
+): string {
+	if (
+		field.tagName === "INPUT" &&
+		(field as HTMLInputElement).type === "number"
+	) {
+		return text.replace(/[^0-9eE+\-.]/g, "");
+	}
+	return text;
+}
+
+/**
  * A typed character replacing the field's selection.
  *
  * Reached from `beforeinput`, which is where a browser reaches it: the
@@ -12119,14 +12138,23 @@ export class HTMLInputElement extends HTMLElement {
 			}
 			if (event.inputType === "insertText") {
 				event.preventDefault();
-				applyFieldEdit(this, printableFieldEdit(this, event.data));
+				const text = sanitizeFieldInsertion(this, event.data);
+				if (text) {
+					applyFieldEdit(this, printableFieldEdit(this, text));
+				}
 				return;
 			}
 			if (event.inputType !== "insertFromPaste") {
 				return;
 			}
 			event.preventDefault();
-			insertPaste(this, event.data.replace(/[\r\n]+/g, ""));
+			const pasted = sanitizeFieldInsertion(
+				this,
+				event.data.replace(/[\r\n]+/g, ""),
+			);
+			if (pasted) {
+				insertPaste(this, pasted);
+			}
 		};
 		this[kOnKeydown] = (event: KeyboardEvent): void => {
 			if (event.defaultPrevented) {
@@ -12228,6 +12256,16 @@ export class HTMLInputElement extends HTMLElement {
 	get value(): string {
 		switch (inputValueMode(this.type)) {
 			case "value":
+				// A number input mid-edit holds text on its way to being a
+				// number -- "4.", "4e-" -- which the control keeps and renders;
+				// the IDL attribute reports the empty string until the text
+				// arrives at a number, as a browser's does.
+				if (
+					this.type === "number" &&
+					parseFloatingPoint(this[kValue]) === null
+				) {
+					return "";
+				}
 				return this[kValue];
 			case "default":
 				return this.getAttribute("value") ?? "";
@@ -12287,7 +12325,15 @@ export class HTMLInputElement extends HTMLElement {
 		if (inputValueMode(this.type) !== "value") {
 			return;
 		}
-		this[kValue] = sanitizeInputValue(this, value);
+		// A user edit passes through the states a number passes through on
+		// its way to being one -- "4.", "4e-" -- which full sanitization
+		// would empty on every keystroke. The edit keeps its text (the
+		// insertion filter has already limited the characters); the value
+		// getter is what reports the empty string until the text is a
+		// number. Programmatic writes keep the full sanitization.
+		this[kValue] = this.type === "number" ?
+				value.replace(/[\r\n]/g, "") :
+				sanitizeInputValue(this, value);
 		this[kDirtyValue] = true;
 		widgetChanged(this);
 	}

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -11788,22 +11788,25 @@ function applySharedFieldEdit(
 }
 
 /**
- * The characters a field's type lets through. A number input takes only what
- * can spell a floating-point number -- digits, sign, decimal point, and
- * exponent -- the same per-character filter a browser applies to typing and
- * pasting; every other type takes the text as it came.
+ * Insert typed or pasted text at an input's selection.
+ *
+ * A number input's text can be any prefix of a valid floating-point number
+ * and nothing else: an insertion that would take it outside the grammar is
+ * refused whole, the way a browser's number field refuses a second decimal
+ * point. Deletions are never gated, so text a deletion strands outside the
+ * grammar can always be cleared.
  */
-function sanitizeFieldInsertion(
-	field: HTMLInputElement | HTMLTextAreaElement,
-	text: string,
-): string {
-	if (
-		field.tagName === "INPUT" &&
-		(field as HTMLInputElement).type === "number"
-	) {
-		return text.replace(/[^0-9eE+\-.]/g, "");
+function insertFieldText(field: HTMLInputElement, text: string): void {
+	if (!text) {
+		return;
 	}
-	return text;
+	const value = field[kUAValue];
+	const {start, end} = uaSelectionOf(field);
+	const next = value.slice(0, start) + text + value.slice(end);
+	if (field.type === "number" && !isFloatPrefix(next)) {
+		return;
+	}
+	applyFieldEdit(field, collapsedEdit(next, start + text.length));
 }
 
 /**
@@ -12138,23 +12141,14 @@ export class HTMLInputElement extends HTMLElement {
 			}
 			if (event.inputType === "insertText") {
 				event.preventDefault();
-				const text = sanitizeFieldInsertion(this, event.data);
-				if (text) {
-					applyFieldEdit(this, printableFieldEdit(this, text));
-				}
+				insertFieldText(this, event.data);
 				return;
 			}
 			if (event.inputType !== "insertFromPaste") {
 				return;
 			}
 			event.preventDefault();
-			const pasted = sanitizeFieldInsertion(
-				this,
-				event.data.replace(/[\r\n]+/g, ""),
-			);
-			if (pasted) {
-				insertPaste(this, pasted);
-			}
+			insertFieldText(this, event.data.replace(/[\r\n]+/g, ""));
 		};
 		this[kOnKeydown] = (event: KeyboardEvent): void => {
 			if (event.defaultPrevented) {
@@ -12175,6 +12169,23 @@ export class HTMLInputElement extends HTMLElement {
 			// control. It toggles, for the same reason the readline chords edit.
 				if (key === " " || key === "Enter") {
 					this.click();
+				}
+				return;
+			}
+
+			// ArrowUp and ArrowDown step a number input, standing in for
+			// the up/down buttons a browser draws on one -- a terminal has
+			// none, and every hand is already on the keyboard. Stepping is
+			// a user edit, so it fires input and then change, as pressing
+			// those buttons does.
+			if (
+				this.type === "number" &&
+				(key === "ArrowUp" || key === "ArrowDown")
+			) {
+				const stepped = steppedValue(this, key === "ArrowUp" ? 1 : -1);
+				if (stepped !== null) {
+					applyFieldEdit(this, collapsedEdit(stepped, stepped.length));
+					dispatch(this, new Event("change", {bubbles: true}));
 				}
 				return;
 			}
@@ -12302,6 +12313,49 @@ export class HTMLInputElement extends HTMLElement {
 				this.setAttribute("value", string);
 		}
 		widgetChanged(this);
+	}
+
+	/**
+	 * The value as the number it parses to: NaN when it does not, and only
+	 * the numeric types answer. Assigning NaN empties the field; assigning
+	 * a non-finite number is the TypeError the spec makes it.
+	 */
+	get valueAsNumber(): number {
+		if (this.type !== "number" && this.type !== "range") {
+			return NaN;
+		}
+		return parseFloatingPoint(this.value) ?? NaN;
+	}
+
+	set valueAsNumber(value: number) {
+		if (this.type !== "number" && this.type !== "range") {
+			throw domError(
+				"InvalidStateError",
+				"This input type does not hold a number",
+			);
+		}
+		const number = Number(value);
+		if (Number.isNaN(number)) {
+			this.value = "";
+			return;
+		}
+		if (!Number.isFinite(number)) {
+			throw new TypeError("valueAsNumber must be finite");
+		}
+		this.value = String(number);
+	}
+
+	/**
+	 * The spec's step methods: move along the step grid without events, the
+	 * programmatic siblings of the arrow keys. A step of "any" names no grid
+	 * to move on, which is the InvalidStateError the spec makes it.
+	 */
+	stepUp(n = 1): void {
+		stepInputBy(this, Math.trunc(Number(n)));
+	}
+
+	stepDown(n = 1): void {
+		stepInputBy(this, -Math.trunc(Number(n)));
 	}
 
 	/**
@@ -12847,6 +12901,104 @@ function parseFloatingPoint(value: string): number | null {
 	}
 	const number = Number(value);
 	return Number.isFinite(number) ? number : null;
+}
+
+/**
+ * Whether `value` is a prefix of a valid floating-point number: the states a
+ * number input's text passes through on the way to one -- "-", "4.", "1e-"
+ * among them. Every state of the grammar either accepts already or accepts
+ * after one more digit, so the prefix test is the grammar itself, twice,
+ * rather than a second grammar that could drift from it.
+ */
+function isFloatPrefix(value: string): boolean {
+	return VALID_FLOAT.test(value) || VALID_FLOAT.test(value + "0");
+}
+
+/**
+ * The decimal places a float literal spells, which is what toFixed needs to
+ * write a step-grid value without binary dust: stepping 0.1 at a time must
+ * produce "0.3", never "0.30000000000000004". An exponent literal names no
+ * place count and answers zero.
+ */
+function decimalPlacesOf(text: string | null | undefined): number {
+	if (!text) {
+		return 0;
+	}
+	const match = /^-?[0-9]*(?:\.([0-9]+))?$/.exec(text.trim());
+	if (!match || match[1] === undefined) {
+		return 0;
+	}
+	return match[1].length;
+}
+
+/** stepUp/stepDown: validate, step, and assign without firing events. */
+function stepInputBy(input: HTMLInputElement, steps: number): void {
+	if (input.type !== "number" && input.type !== "range") {
+		throw domError(
+			"InvalidStateError",
+			"This input type does not step",
+		);
+	}
+	const stepAttribute = input.getAttribute("step")?.trim();
+	if (stepAttribute !== undefined && /^any$/i.test(stepAttribute)) {
+		throw domError(
+			"InvalidStateError",
+			'A step of "any" names no grid to step on',
+		);
+	}
+	if (steps === 0) {
+		return;
+	}
+	const stepped = steppedValue(input, steps);
+	if (stepped !== null) {
+		input.value = stepped;
+	}
+}
+
+/**
+ * The value a number input steps to: `steps` grid points away, on the grid
+ * `step` spaces and `min` anchors (zero anchors it when there is no min),
+ * clamped to [min, max]. A value between grid points moves to the nearest
+ * point in the direction of travel. Null when there is nowhere to go, so a
+ * caller can leave the field untouched. An out-of-range value steps to the
+ * nearest bound whichever way it was pushed, which is how a browser's
+ * up/down buttons pull a field into range.
+ */
+function steppedValue(input: HTMLInputElement, steps: number): string | null {
+	const stepAttribute = input.getAttribute("step")?.trim();
+	const step =
+		stepAttribute === undefined || /^any$/i.test(stepAttribute) ?
+			1 :
+				(parseFloatingPoint(stepAttribute) ?? 1);
+	const spacing = step > 0 ? step : 1;
+	const min = parseFloatingPoint(input.getAttribute("min")?.trim() ?? "");
+	const max = parseFloatingPoint(input.getAttribute("max")?.trim() ?? "");
+	const current = parseFloatingPoint(input[kUAValue]) ?? 0;
+	const base = min ?? 0;
+
+	// The offset in grid units, rounded enough that a value the grid itself
+	// produced counts as on the grid despite binary representation.
+	const offset = Math.round(((current - base) / spacing) * 1e9) / 1e9;
+	const k =
+		steps > 0 ? Math.floor(offset) + steps : Math.ceil(offset) + steps;
+	let next = base + k * spacing;
+	if (max !== null && next > max) {
+		// The last grid point inside the range, not max itself.
+		const room = Math.round(((max - base) / spacing) * 1e9) / 1e9;
+		next = base + Math.floor(room) * spacing;
+	}
+	if (min !== null && next < min) {
+		next = min;
+	}
+	if (next === current) {
+		return null;
+	}
+	const places = Math.max(
+		decimalPlacesOf(stepAttribute),
+		decimalPlacesOf(input.getAttribute("min")),
+		decimalPlacesOf(input[kUAValue]),
+	);
+	return String(Number(next.toFixed(Math.min(places, 20))));
 }
 /**
  * The value an input stores for what was written to it.

--- a/tests/keyboard.test.ts
+++ b/tests/keyboard.test.ts
@@ -1479,25 +1479,142 @@ test("focusing a field inside a fullscreen element leaves the camera alone", asy
 	dom.dispose();
 });
 
-test("a number input takes digits and drops the rest", async () => {
+async function numberInput(): Promise<{
+	terminal: MockProcess;
+	dom: TermDOM;
+	input: HTMLInputElement;
+	press: (data: string) => Promise<void>;
+}> {
 	const terminal = new MockProcess({rows: 10, cols: 40});
 	const dom = new TermDOM({transport: transportFromProcess(terminal as any)});
 	dom.attach();
 	await new Promise((r) => setTimeout(r, 0));
-	const {document} = dom;
-	const input = document.createElement("input");
+	const input = dom.document.createElement("input") as HTMLInputElement;
 	input.type = "number";
-	document.body.appendChild(input);
+	dom.document.body.appendChild(input);
 	input.focus();
+	const press = async (data: string) => {
+		(terminal.stdin as any).emit("data", Buffer.from(data));
+		await new Promise((r) => setTimeout(r, 10));
+	};
+	return {terminal, dom, input, press};
+}
 
-	(terminal.stdin as any).emit("data", Buffer.from("4a2!"));
-	await new Promise((r) => setTimeout(r, 10));
+test("a number input's text stays a prefix of a valid float", async () => {
+	const {dom, input, press} = await numberInput();
+
+	// Letters and punctuation outside the grammar never land.
+	await press("4a2!");
 	expect(input.value).toBe("42");
 
-	// The characters that can spell a float pass: sign, point, exponent.
-	(terminal.stdin as any).emit("data", Buffer.from(".5e-1"));
-	await new Promise((r) => setTimeout(r, 10));
+	// The states a float passes through are all reachable...
+	await press(".5e-1");
 	expect(input.value).toBe("42.5e-1");
+
+	// ...but a second decimal point or exponent is refused whole.
+	await press(".");
+	await press("e3");
+	expect(input.value).toBe("42.5e-13");
+
+	dom.dispose();
+});
+
+test("a number input's value reports nothing until the text is a number", async () => {
+	const {dom, input, press} = await numberInput();
+
+	// "-", "-4", "-4." -- the value gate opens exactly when the grammar does.
+	await press("-");
+	expect(input.value).toBe("");
+	await press("4");
+	expect(input.value).toBe("-4");
+	await press(".");
+	expect(input.value).toBe("");
+	await press("2");
+	expect(input.value).toBe("-4.2");
+
+	// A deletion may strand the text outside the grammar -- Ctrl+A to the
+	// start, Ctrl+D deleting the "-" leaves "4.2"; deleting again leaves
+	// ".2", still a number; deleting once more strands "2"... clear with
+	// Ctrl+E then Ctrl+U and the field takes text again.
+	await press("\x01\x04");
+	expect(input.value).toBe("4.2");
+	await press("\x05\x15");
+	expect(input.value).toBe("");
+	await press("7");
+	expect(input.value).toBe("7");
+
+	dom.dispose();
+});
+
+test("arrows step a number input along its grid, inside min and max", async () => {
+	const {dom, input, press} = await numberInput();
+	input.setAttribute("min", "1");
+	input.setAttribute("max", "6");
+	input.setAttribute("step", "2");
+	const events: string[] = [];
+	input.addEventListener("input", () => events.push("input"));
+	input.addEventListener("change", () => events.push("change"));
+
+	// Up from empty lands on the grid's first point inside the range.
+	await press("\x1b[A");
+	expect(input.value).toBe("1");
+	expect(events).toEqual(["input", "change"]);
+	await press("\x1b[A");
+	expect(input.value).toBe("3");
+	await press("\x1b[A");
+	expect(input.value).toBe("5");
+	// The next point is past max, so the field stays and nothing fires.
+	events.length = 0;
+	await press("\x1b[A");
+	expect(input.value).toBe("5");
+	expect(events).toEqual([]);
+	await press("\x1b[B");
+	expect(input.value).toBe("3");
+
+	dom.dispose();
+});
+
+test("a decimal step writes its grid without float dust", async () => {
+	const {dom, input, press} = await numberInput();
+	input.setAttribute("step", "0.1");
+	await press("\x1b[A");
+	await press("\x1b[A");
+	await press("\x1b[A");
+	expect(input.value).toBe("0.3");
+	await press("\x1b[B");
+	expect(input.value).toBe("0.2");
+	dom.dispose();
+});
+
+test("valueAsNumber and the step methods", async () => {
+	const {dom, input} = await numberInput();
+
+	input.value = "1.5e1";
+	expect(input.valueAsNumber).toBe(15);
+	input.valueAsNumber = 42;
+	expect(input.value).toBe("42");
+	input.valueAsNumber = NaN;
+	expect(input.value).toBe("");
+	expect(() => {
+		input.valueAsNumber = Infinity;
+	}).toThrow(TypeError);
+
+	// The methods step silently -- no input or change events.
+	const events: string[] = [];
+	input.addEventListener("input", () => events.push("input"));
+	input.stepUp(3);
+	expect(input.value).toBe("3");
+	input.stepDown();
+	expect(input.value).toBe("2");
+	expect(events).toEqual([]);
+
+	input.setAttribute("step", "any");
+	expect(() => input.stepUp()).toThrow(/any/);
+
+	const text = dom.document.createElement("input") as HTMLInputElement;
+	expect(text.valueAsNumber).toBeNaN();
+	expect(() => text.stepUp()).toThrow(/step/);
+
 	dom.dispose();
 });
 

--- a/tests/keyboard.test.ts
+++ b/tests/keyboard.test.ts
@@ -1479,6 +1479,28 @@ test("focusing a field inside a fullscreen element leaves the camera alone", asy
 	dom.dispose();
 });
 
+test("a number input takes digits and drops the rest", async () => {
+	const terminal = new MockProcess({rows: 10, cols: 40});
+	const dom = new TermDOM({transport: transportFromProcess(terminal as any)});
+	dom.attach();
+	await new Promise((r) => setTimeout(r, 0));
+	const {document} = dom;
+	const input = document.createElement("input");
+	input.type = "number";
+	document.body.appendChild(input);
+	input.focus();
+
+	(terminal.stdin as any).emit("data", Buffer.from("4a2!"));
+	await new Promise((r) => setTimeout(r, 10));
+	expect(input.value).toBe("42");
+
+	// The characters that can spell a float pass: sign, point, exponent.
+	(terminal.stdin as any).emit("data", Buffer.from(".5e-1"));
+	await new Promise((r) => setTimeout(r, 10));
+	expect(input.value).toBe("42.5e-1");
+	dom.dispose();
+});
+
 test("a focused descendant inside a fullscreen element still wins over the element itself", async () => {
 	const terminal = new MockProcess({rows: 10, cols: 40});
 	const dom = new TermDOM({transport: transportFromProcess(terminal as any)});


### PR DESCRIPTION
Number inputs existed as an attribute but not as a control: full value sanitization ran per keystroke, so any intermediate state that was not yet a valid float — "4.", "4e-" — emptied the field, and nothing stepped.

- **The editing language is prefixes of HTML's valid floating-point number grammar** (`VALID_FLOAT`, the one regex). A string is a prefix exactly when it or it plus one digit matches, so the prefix test is the grammar itself, twice — not a second grammar that can drift. Insertions (typed or pasted) that would leave the prefix language are refused whole: a second decimal point never lands. Deletions are never gated, so stranded text can always be cleared.
- **The control keeps what was typed; `value` reports "" until the text is a number** — the split between the editing buffer and the IDL attribute that browsers make.
- **ArrowUp and ArrowDown step the value** along the `step` grid (anchored at `min`, else zero), clamped to [`min`, `max`], firing `input` then `change`. The keys stand in for the up/down buttons a browser draws on the field, which a terminal cannot show or click. Decimal grids print clean ("0.3", not "0.30000000000000004"); an out-of-range value steps to the nearest bound either way, pulling the field into range.
- **`valueAsNumber` and `stepUp`/`stepDown`** complete the IDL surface; the methods step silently and refuse `step="any"`, per spec.

Six tests in `tests/keyboard.test.ts` pin the grammar gating, the value gate, deletion freedom, arrow stepping with min/max/step, decimal grids, and the IDL members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
