### PR TITLE
Resolve a pseudo-element's used box metrics

### DIFF
--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -6325,14 +6325,14 @@ function shorthand(
 }
 
 function measure(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 	property: string,
 	computed: string,
 ): string {
 	// A border with no style draws nothing and takes no space, whatever
 	// width it declares.
 	if (property.startsWith("border-") && property.endsWith("-width")) {
-		const style = self.computedValueOf(
+		const style = declaration.computedValueOf(
 			`${property.slice(0, -"-width".length)}-style`,
 		);
 		if (!style || style === "none" || style === "hidden") {
@@ -6342,12 +6342,12 @@ function measure(
 	const inset = INSET_PROPERTIES.has(property);
 	// An inset only applies to a positioned box; on a static one it stays
 	// as declared.
-	const position = inset ? self.getPropertyValue("position") : "";
+	const position = inset ? declaration.getPropertyValue("position") : "";
 	if (inset && position === "static") {
 		return computed;
 	}
 
-	const rect = self[kManager]!.usedRect(self[kElement]);
+	const rect = declaration[kManager]!.usedRect(declaration[kElement]);
 	// No box -- display:none, or a tree layout never reached -- so the
 	// computed value is the answer, exactly as CSSOM says.
 	if (!rect) {
@@ -6355,20 +6355,23 @@ function measure(
 	}
 
 	if (inset) {
-		return usedInset(self, property, computed, rect, position);
+		return usedInset(declaration, property, computed, rect, position);
 	}
 
 	if (property === "width" || property === "height") {
 		const vertical = property === "height";
 		const edges =
-			edge(self, vertical ? "border-top-width" : "border-left-width") +
-			edge(self, vertical ? "border-bottom-width" : "border-right-width") +
-			edge(self, vertical ? "padding-top" : "padding-left") +
-			edge(self, vertical ? "padding-bottom" : "padding-right");
+			edge(declaration, vertical ? "border-top-width" : "border-left-width") +
+			edge(
+				declaration,
+				vertical ? "border-bottom-width" : "border-right-width",
+			) +
+			edge(declaration, vertical ? "padding-top" : "padding-left") +
+			edge(declaration, vertical ? "padding-bottom" : "padding-right");
 		const border = vertical ? rect.height : rect.width;
 		// `box-sizing: border-box` measures the border box itself.
 		const content =
-			self.getPropertyValue("box-sizing") === "border-box" ?
+			declaration.getPropertyValue("box-sizing") === "border-box" ?
 				border :
 				border - edges;
 		return usedLength(Math.max(0, content));
@@ -6377,14 +6380,14 @@ function measure(
 	// An `auto` margin is whatever space the box was given: the distance
 	// between its border box and its containing block's content edge.
 	if (computed === "auto" && property.startsWith("margin-")) {
-		return usedLength(autoMargin(self, property, rect));
+		return usedLength(autoMargin(declaration, property, rect));
 	}
 
 	// Every other used length is already absolute in this engine's own
 	// unit, so the computed value carries it; only a percentage still has
 	// to be resolved, against the containing block's width.
 	if (computed.endsWith("%")) {
-		const basis = containingWidth(self);
+		const basis = containingWidth(declaration);
 		if (basis === null) {
 			return computed;
 		}
@@ -6402,13 +6405,13 @@ function measure(
  * that has to be measured: it is whatever distance the box ended up at.
  */
 function usedInset(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 	property: string,
 	computed: string,
 	rect: DOMRect,
 	position: string,
 ): string {
-	const block = containingBlockBox(self, position);
+	const block = containingBlockBox(declaration, position);
 	if (!block) {
 		return computed;
 	}
@@ -6425,7 +6428,7 @@ function usedInset(
 	}
 
 	const opposite = OPPOSITE_INSET[property];
-	const other = insetLength(self.computedValueOf(opposite), basis);
+	const other = insetLength(declaration.computedValueOf(opposite), basis);
 	// A relatively positioned box is offset from where it already was, so
 	// an `auto` inset is the negative of its opposite -- and zero when both
 	// are auto, which moves the box nowhere.
@@ -6442,22 +6445,24 @@ function usedInset(
 	if (other !== null) {
 		const size =
 			(vertical ? rect.height : rect.width) +
-			edge(self, start) +
-			edge(self, end);
+			edge(declaration, start) +
+			edge(declaration, end);
 		return usedLength(basis - other - size);
 	}
 	switch (property) {
 		case "top":
-			return usedLength(rect.y - edge(self, start) - block.y);
+			return usedLength(rect.y - edge(declaration, start) - block.y);
 		case "left":
-			return usedLength(rect.x - edge(self, start) - block.x);
+			return usedLength(rect.x - edge(declaration, start) - block.x);
 		case "bottom":
 			return usedLength(
-				block.y + block.height - (rect.y + rect.height + edge(self, end)),
+				block.y +
+				block.height -
+				(rect.y + rect.height + edge(declaration, end)),
 			);
 		default:
 			return usedLength(
-				block.x + block.width - (rect.x + rect.width + edge(self, end)),
+				block.x + block.width - (rect.x + rect.width + edge(declaration, end)),
 			);
 	}
 }
@@ -6469,49 +6474,49 @@ function usedInset(
  * this one flows in.
  */
 function containingBlockBox(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 	position: string,
 ): DOMRect | null {
 	if (position === "fixed") {
-		return viewportBox(self);
+		return viewportBox(declaration);
 	}
 	if (position === "absolute") {
 		for (
-			let ancestor = flatParentElement<Element>(self[kElement]);
+			let ancestor = flatParentElement<Element>(declaration[kElement]);
 			ancestor;
 			ancestor = flatParentElement<Element>(ancestor)
 		) {
 			const ancestorPosition =
 				computedStyleOf(ancestor).computedValueOf("position");
 			if (ancestorPosition && ancestorPosition !== "static") {
-				return boxOf(self, ancestor, false);
+				return boxOf(declaration, ancestor, false);
 			}
 		}
-		return viewportBox(self);
+		return viewportBox(declaration);
 	}
 	if (position === "sticky") {
 		for (
-			let ancestor = flatParentElement<Element>(self[kElement]);
+			let ancestor = flatParentElement<Element>(declaration[kElement]);
 			ancestor;
 			ancestor = flatParentElement<Element>(ancestor)
 		) {
 			const overflow = computedStyleOf(ancestor).computedValueOf("overflow");
 			if (overflow && overflow !== "visible") {
-				return boxOf(self, ancestor, true);
+				return boxOf(declaration, ancestor, true);
 			}
 		}
 	}
-	const parent = flatParentElement<Element>(self[kElement]);
-	return parent ? boxOf(self, parent, true) : viewportBox(self);
+	const parent = flatParentElement<Element>(declaration[kElement]);
+	return parent ? boxOf(declaration, parent, true) : viewportBox(declaration);
 }
 
 /** An ancestor's padding box, or its content box, in the same coordinates as a rect. */
 function boxOf(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 	element: Element,
 	content: boolean,
 ): DOMRect | null {
-	const rect = self[kManager]!.usedRect(element);
+	const rect = declaration[kManager]!.usedRect(element);
 	if (!rect) {
 		return null;
 	}
@@ -6538,13 +6543,13 @@ function boxOf(
 
 /** The initial containing block: the grid itself. */
 function viewportBox(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 ): DOMRect | null {
-	const viewport = self[kManager]!.viewportSize();
+	const viewport = declaration[kManager]!.viewportSize();
 	if (!viewport) {
 		return null;
 	}
-	const rect = self[kManager]!.usedRect(self[kElement]);
+	const rect = declaration[kManager]!.usedRect(declaration[kElement]);
 	if (!rect) {
 		return null;
 	}
@@ -6594,20 +6599,20 @@ function resolvedMinSize(
 
 /** One edge length in cells, for the arithmetic above. */
 function edge(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 	property: string,
 ): number {
-	return parseFloat(self.getPropertyValue(property)) || 0;
+	return parseFloat(declaration.getPropertyValue(property)) || 0;
 }
 
 /** The space an `auto` margin actually took, measured off the two boxes. */
 function autoMargin(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 	property: string,
 	rect: DOMRect,
 ): number {
-	const parent = flatParentElement<Element>(self[kElement]);
-	const parentRect = parent ? self[kManager]!.usedRect(parent) : null;
+	const parent = flatParentElement<Element>(declaration[kElement]);
+	const parentRect = parent ? declaration[kManager]!.usedRect(parent) : null;
 	if (!parent || !parentRect) {
 		return 0;
 	}
@@ -6641,13 +6646,13 @@ function autoMargin(
 
 /** The width a percentage on this element resolves against. */
 function containingWidth(
-	self: MeasuredDeclaration,
+	declaration: MeasuredDeclaration,
 ): number | null {
-	const parent = flatParentElement<Element>(self[kElement]);
+	const parent = flatParentElement<Element>(declaration[kElement]);
 	if (!parent) {
 		return null;
 	}
-	const rect = self[kManager]!.usedRect(parent);
+	const rect = declaration[kManager]!.usedRect(parent);
 	return rect ? rect.width : null;
 }
 

--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -5799,6 +5799,20 @@ function usedLength(cells: number): string {
 }
 
 /**
+ * The reads a used-value measurement takes, from whichever declaration owns
+ * the box. An element's computed declaration is one directly; a
+ * pseudo-element's declaration answers through a view whose [kElement] is the
+ * pseudo-element's own node, which is where its box lives -- the measurement
+ * arithmetic is the same either way, so there is one copy of it.
+ */
+interface MeasuredDeclaration {
+	[kElement]: Element;
+	[kManager]: StyleManager | null;
+	computedValueOf(property: string): string;
+	getPropertyValue(property: string): string;
+}
+
+/**
  * The colors whose `auto` names the element's own color: a caret is drawn in
  * the text's color, and an outline whose color was left to the UA takes it
  * too. The resolved value CSSOM reports is that used color.
@@ -6311,7 +6325,7 @@ function shorthand(
 }
 
 function measure(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 	property: string,
 	computed: string,
 ): string {
@@ -6388,7 +6402,7 @@ function measure(
  * that has to be measured: it is whatever distance the box ended up at.
  */
 function usedInset(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 	property: string,
 	computed: string,
 	rect: DOMRect,
@@ -6455,7 +6469,7 @@ function usedInset(
  * this one flows in.
  */
 function containingBlockBox(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 	position: string,
 ): DOMRect | null {
 	if (position === "fixed") {
@@ -6493,7 +6507,7 @@ function containingBlockBox(
 
 /** An ancestor's padding box, or its content box, in the same coordinates as a rect. */
 function boxOf(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 	element: Element,
 	content: boolean,
 ): DOMRect | null {
@@ -6524,7 +6538,7 @@ function boxOf(
 
 /** The initial containing block: the grid itself. */
 function viewportBox(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 ): DOMRect | null {
 	const viewport = self[kManager]!.viewportSize();
 	if (!viewport) {
@@ -6580,7 +6594,7 @@ function resolvedMinSize(
 
 /** One edge length in cells, for the arithmetic above. */
 function edge(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 	property: string,
 ): number {
 	return parseFloat(self.getPropertyValue(property)) || 0;
@@ -6588,7 +6602,7 @@ function edge(
 
 /** The space an `auto` margin actually took, measured off the two boxes. */
 function autoMargin(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 	property: string,
 	rect: DOMRect,
 ): number {
@@ -6627,7 +6641,7 @@ function autoMargin(
 
 /** The width a percentage on this element resolves against. */
 function containingWidth(
-	self: ComputedStyleDeclaration,
+	self: MeasuredDeclaration,
 ): number | null {
 	const parent = flatParentElement<Element>(self[kElement]);
 	if (!parent) {
@@ -7007,6 +7021,8 @@ const kPseudoDeclarations = Symbol("pseudo declarations");
 const kPseudoElement = Symbol("pseudoElement");
 const kNodeResolved = Symbol("nodeResolved");
 const kNodeStyle = Symbol("nodeStyle");
+const kBoxView = Symbol("boxView");
+const kBoxViewOf = Symbol("boxViewOf");
 
 /**
  * A pseudo-element's computed style: a flat declaration set -- the matched
@@ -7049,6 +7065,7 @@ class PseudoStyleDeclaration extends CSSStyleProperties {
 		this[kSeenEpoch] = 0;
 		this[kNodeStyle] = null;
 		this[kNodeResolved] = new Map<string, string>();
+		this[kBoxView] = null;
 		this[kPseudoDeclarations] = declarations;
 		this[kElement] = element ?? null;
 		this[kPseudoElement] = pseudoElement;
@@ -7142,6 +7159,7 @@ class PseudoStyleDeclaration extends CSSStyleProperties {
 
 	declare [kNodeStyle]: ComputedStyle | null;
 	declare [kNodeResolved]: Map<string, string>;
+	declare [kBoxView]: MeasuredDeclaration | null;
 
 	override getPropertyValue(property: string): string {
 		this[kManager]?.flushStyle();
@@ -7158,14 +7176,30 @@ class PseudoStyleDeclaration extends CSSStyleProperties {
 	 * A pseudo-element's resolved value, measured behind the same flush an
 	 * element's is.
 	 *
-	 * A pseudo-element box hangs in the content box of the element it
-	 * originates from, which is what its percentages resolve against -- the
-	 * one measurement the layout it was composed into can answer for it. A
-	 * pseudo that generates no box (`display: none`, `display: contents`, an
-	 * originating element with no box of its own) keeps its computed value,
-	 * exactly as an element with no box does.
+	 * A pseudo-element's box belongs to the node the composition pass gave it,
+	 * so its metrics are measured off that node's rect through the same
+	 * arithmetic an element's are: a stretched block pseudo answers its used
+	 * width, an inline one the union of its fragments. A pseudo the
+	 * composition never gave a node -- one whose selector generates no
+	 * content, or a ::selection -- keeps the percentage resolution below,
+	 * against the box it would hang in.
 	 */
 	[kUsedValue](property: string, computed: string): string {
+		const originating = this[kElement];
+		const manager = this[kManager];
+		if (originating && manager) {
+			// The flush before the node lookup: the composition pass that runs
+			// under it is what creates a pseudo-element's node, so a lookup
+			// taken first would answer "no box" for a box one render away.
+			manager.usedRect(originating);
+			const node = pseudoElement<Element>(
+				originating,
+				this[kPseudoElement],
+			);
+			if (node) {
+				return measure(this[kBoxViewOf](node), property, computed);
+			}
+		}
 		if (!computed.endsWith("%")) {
 			return computed;
 		}
@@ -7193,6 +7227,30 @@ class PseudoStyleDeclaration extends CSSStyleProperties {
 			property === "height" || property === "top" || property === "bottom";
 		const basis = vertical ? box.height : box.width;
 		return usedLength((parseFloat(computed) / 100) * basis);
+	}
+
+	/**
+	 * This declaration as the measurement arithmetic reads it: the same
+	 * cascade answers, with the pseudo-element's own node standing where the
+	 * element stands -- its rect is the box being measured, and its flat-tree
+	 * parent is the originating element percentages resolve against. One view
+	 * per node: composition may retire a node and make another, and a view
+	 * naming the old one would measure a rect no layout holds.
+	 */
+	[kBoxViewOf](node: Element): MeasuredDeclaration {
+		let view = this[kBoxView];
+		if (!view || view[kElement] !== node) {
+			view = {
+				[kElement]: node,
+				[kManager]: this[kManager],
+				computedValueOf: (property: string): string =>
+					this.nodeStyle.computedValueOf(property),
+				getPropertyValue: (property: string): string =>
+					this.getPropertyValue(property),
+			};
+			this[kBoxView] = view;
+		}
+		return view;
 	}
 
 	override setProperty(): void {

--- a/tests/pseudo-element.test.ts
+++ b/tests/pseudo-element.test.ts
@@ -363,3 +363,104 @@ test.todo(
 		expect(output).toContain("BEFORE MIDDLE AFTER");
 	},
 );
+
+test("a block pseudo-element's resolved width and height are its used box", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 24});
+	const termdom = new TermDOM({transport: terminal.transport});
+	const {document} = termdom;
+
+	const style = document.createElement("style");
+	style.textContent = `
+		span.block::before { content: "BB"; display: block }
+		span.sized::before { content: "BB"; display: block; width: 10px }
+	`;
+	document.head.appendChild(style);
+	document.body.innerHTML =
+		"<div><span class=\"block\">hello</span></div>" +
+		"<div><span class=\"sized\">hello</span></div>";
+	await nextFrame(termdom);
+	const {window} = termdom;
+
+	// A block box stretches to its containing block, and the resolved value
+	// reports that used width -- not the computed "auto".
+	const block = window.getComputedStyle(
+		document.querySelector(".block")!,
+		"::before",
+	);
+	expect(block.getPropertyValue("width")).toBe("40px");
+	expect(block.getPropertyValue("height")).toBe("1px");
+
+	// A declared width is the used width.
+	const sized = window.getComputedStyle(
+		document.querySelector(".sized")!,
+		"::before",
+	);
+	expect(sized.getPropertyValue("width")).toBe("10px");
+	expect(sized.getPropertyValue("height")).toBe("1px");
+});
+
+test("an inline pseudo-element measures as an element's inline box does", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 24});
+	const termdom = new TermDOM({transport: terminal.transport});
+	const {document} = termdom;
+
+	const style = document.createElement("style");
+	style.textContent = "span.inline::before { content: \"II\" }";
+	document.head.appendChild(style);
+	document.body.innerHTML =
+		"<div><span class=\"inline\">yo</span><span class=\"bare\">yo</span></div>";
+	await nextFrame(termdom);
+	const {window} = termdom;
+
+	// An inline box's resolved width is the union of its fragments, for a
+	// pseudo-element exactly as for an element: the pseudo's two cells, the
+	// bare span's two.
+	const pseudo = window.getComputedStyle(
+		document.querySelector(".inline")!,
+		"::before",
+	);
+	const element = window.getComputedStyle(document.querySelector(".bare")!);
+	expect(element.getPropertyValue("width")).toBe("2px");
+	expect(pseudo.getPropertyValue("width")).toBe("2px");
+	expect(pseudo.getPropertyValue("height")).toBe("1px");
+});
+
+test("a pseudo-element that generates no box keeps its computed value", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 24});
+	const termdom = new TermDOM({transport: terminal.transport});
+	const {document} = termdom;
+
+	const style = document.createElement("style");
+	style.textContent =
+		"span.none::before { content: \"NN\"; display: none; width: 10px }";
+	document.head.appendChild(style);
+	document.body.innerHTML = "<div><span class=\"none\">zz</span></div>";
+	await nextFrame(termdom);
+
+	const none = termdom.window.getComputedStyle(
+		document.querySelector(".none")!,
+		"::before",
+	);
+	expect(none.getPropertyValue("width")).toBe("10px");
+	expect(none.getPropertyValue("height")).toBe("auto");
+});
+
+test("a pseudo-element's used box answers the read that asked for the layout", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 24});
+	const termdom = new TermDOM({transport: terminal.transport});
+	const {document} = termdom;
+
+	const style = document.createElement("style");
+	style.textContent = "span.block::before { content: \"BB\"; display: block }";
+	document.head.appendChild(style);
+	document.body.innerHTML = "<div><span class=\"block\">hello</span></div>";
+
+	// No frame yet: the resolved read takes the same flush a rect read does,
+	// so the box it measures is the one this DOM lays out.
+	const cs = termdom.window.getComputedStyle(
+		document.querySelector(".block")!,
+		"::before",
+	);
+	expect(cs.getPropertyValue("width")).toBe("40px");
+	expect(cs.getPropertyValue("height")).toBe("1px");
+});


### PR DESCRIPTION
`getComputedStyle(el, "::before")` now reports used values for box metrics (width, height, margins, paddings, border widths, insets) measured from the pseudo-element's own layout box, the same way elements already do. A block pseudo reports its stretched or declared width and its line height; an inline pseudo measures as an element's inline box does; a pseudo that generates no box keeps its computed value. The measurement arithmetic is shared with the element path through a view keyed to the pseudo-element's node, whose rect the layout engine already answers.

Fixes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
