### PR TITLE
Implement aspect-ratio: the ratio counts cells

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,7 +7,7 @@ properties. Every row is a probe -- the feature applied to a real
 document and rendered, with the row recording whether the output
 changed.
 
-170 features supported, 54 probed and unsupported,
+171 features supported, 53 probed and unsupported,
 157 CSS properties not applicable to a character grid,
 129 applicable and not implemented,
 4 not yet probed.
@@ -125,6 +125,7 @@ changed.
 | `border-bottom-right-radius` | yes |
 | `border-bottom-left-radius` | yes |
 | `box-sizing` | no (no effect) |
+| `aspect-ratio` | yes |
 | `outline` | yes |
 | `outline-style` | yes |
 | `outline-width` | yes |
@@ -227,7 +228,6 @@ changed.
 | `animation` | no (no effect) |
 | `box-shadow` | no (no effect) |
 | `filter` | no (no effect) |
-| `aspect-ratio` | no (no effect) |
 | `cursor` | no (no effect) |
 
 ## Logical properties

--- a/scripts/support-matrix.ts
+++ b/scripts/support-matrix.ts
@@ -115,6 +115,7 @@ const FEATURES: Record<string, Feature> = {
 		value: "border-box",
 		setup: "#probe { width: 12ch; padding: 0 2ch; border: 1px solid; }",
 	},
+	"aspect-ratio": {value: "1 / 1", setup: NARROW},
 	"outline": {value: "1px solid red"},
 	"outline-style": {value: "solid", setup: "#probe { outline-width: 1px; }"},
 	// The painted outline is present or absent; a zero width is the only width
@@ -316,7 +317,6 @@ const FEATURES: Record<string, Feature> = {
 	"animation": {value: "spin 1s"},
 	"box-shadow": {value: "1px 1px red"},
 	"filter": {value: "blur(1px)"},
-	"aspect-ratio": {value: "1 / 1", setup: NARROW},
 	"cursor": {value: "pointer"},
 };
 
@@ -1016,6 +1016,7 @@ const CATEGORIES: Array<[string, string[]]> = [
 			"border-bottom-right-radius",
 			"border-bottom-left-radius",
 			"box-sizing",
+			"aspect-ratio",
 			"outline",
 			"outline-style",
 			"outline-width",
@@ -1118,7 +1119,6 @@ const CATEGORIES: Array<[string, string[]]> = [
 			"animation",
 			"box-shadow",
 			"filter",
-			"aspect-ratio",
 			"cursor",
 		],
 	],

--- a/src/internal/flex.ts
+++ b/src/internal/flex.ts
@@ -8,8 +8,8 @@
  *
  * Omitted, because the engine resolves them elsewhere or a cell grid has no
  * use for them: writing modes and the direction property -- bidi is resolved
- * when text is shaped, not when boxes are placed -- aspect-ratio, scrollable
- * overflow sizing, and sub-cell scaling, the grid being integer cells, so
+ * when text is shaped, not when boxes are placed -- scrollable overflow
+ * sizing, and sub-cell scaling, the grid being integer cells, so
  * pointScaleFactor is always 1.
  *
  * Undefined values are represented as NaN throughout, matching the convention
@@ -292,6 +292,13 @@ interface Style {
 	minHeight: Value;
 	maxWidth: Value;
 	maxHeight: Value;
+
+	/**
+	 * width / height, counted in CELLS on both axes: one cell is one cell,
+	 * vertical or horizontal, so a ratio of 1 on a box 10 cells wide makes it
+	 * 10 rows tall. NaN means auto.
+	 */
+	aspectRatio: number;
 }
 
 interface LayoutResult {
@@ -380,6 +387,7 @@ function createStyle(): Style {
 		minHeight: UNDEFINED_VALUE,
 		maxWidth: UNDEFINED_VALUE,
 		maxHeight: UNDEFINED_VALUE,
+		aspectRatio: NaN,
 	};
 }
 
@@ -850,6 +858,17 @@ export class Node {
 
 	setHeightAuto(): void {
 		this.style.height = AUTO_VALUE;
+		this.markDirty();
+	}
+
+	/**
+	 * width / height. The ratio counts cells -- one cell is one cell on either
+	 * axis -- so 1 makes a 10-cell-wide box 10 rows tall. A non-finite,
+	 * zero or negative value means auto.
+	 */
+	setAspectRatio(v: number | undefined): void {
+		this.style.aspectRatio =
+			v !== undefined && Number.isFinite(v) && v > 0 ? v : NaN;
 		this.markDirty();
 	}
 
@@ -3526,6 +3545,25 @@ function layoutBlockChild(
 				contentWidth,
 			) + marginRow;
 		childWidth.mode = MEASURE_MODE_EXACTLY;
+	} else if (
+		isDefined(child.style.aspectRatio) &&
+		child.style.aspectRatio > 0 &&
+		styleDimIsDefined(child, FLEX_DIRECTION_COLUMN, ownerHeight)
+	) {
+		// A definite height transfers through the box's aspect ratio, and the
+		// transferred width beats fill: the box is as wide as its ratio says,
+		// not as wide as the container (css-sizing-4 §5).
+		const transferred =
+			resolveValue(child.style.height, ownerHeight) *
+			child.style.aspectRatio;
+		childWidth.value =
+			boundAxisWithinMinMax(
+				child,
+				FLEX_DIRECTION_ROW,
+				transferred,
+				contentWidth,
+			) + marginRow;
+		childWidth.mode = MEASURE_MODE_EXACTLY;
 	} else if (isDefined(contentWidth)) {
 		childWidth.value = contentWidth;
 		childWidth.mode = fill ? MEASURE_MODE_EXACTLY : MEASURE_MODE_AT_MOST;
@@ -3832,6 +3870,38 @@ function layoutNode(
 	ownerHeight: number,
 	performLayout: boolean,
 ): void {
+	// css-sizing-4 §5: an aspect ratio takes a box's one settled axis to the
+	// other. An axis offered EXACTLY is settled -- by a definite size or by
+	// stretch-fit -- and the open axis follows it through the ratio; when both
+	// axes are settled the ratio yields. Margins sit outside the box, so they
+	// come off the settled offer and go back onto the derived one. Min/max on
+	// the derived axis still clamp, in setMeasuredDimensions. The ratio counts
+	// cells: one cell is one cell, vertical or horizontal.
+	const ratio = node.style.aspectRatio;
+	if (isDefined(ratio) && ratio > 0) {
+		const marginRow = marginForAxis(node, FLEX_DIRECTION_ROW, ownerWidth);
+		const marginColumn = marginForAxis(
+			node,
+			FLEX_DIRECTION_COLUMN,
+			ownerWidth,
+		);
+		if (
+			widthMode === MEASURE_MODE_EXACTLY &&
+			heightMode !== MEASURE_MODE_EXACTLY &&
+			isDefined(availableWidth)
+		) {
+			availableHeight = (availableWidth - marginRow) / ratio + marginColumn;
+			heightMode = MEASURE_MODE_EXACTLY;
+		} else if (
+			heightMode === MEASURE_MODE_EXACTLY &&
+			widthMode !== MEASURE_MODE_EXACTLY &&
+			isDefined(availableHeight)
+		) {
+			availableWidth = (availableHeight - marginColumn) * ratio + marginRow;
+			widthMode = MEASURE_MODE_EXACTLY;
+		}
+	}
+
 	// A clean node under constraints it has already answered: restore the size
 	// and skip the whole subtree. Child geometry is parent-relative and was left
 	// exactly as the cached pass computed it, so nothing below needs touching.

--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -394,6 +394,36 @@ function applyInsets(
 	}
 }
 
+/**
+ * `aspect-ratio`, computed to the width/height quotient the engine works in.
+ *
+ * The ratio counts cells: one cell is one cell, vertical or horizontal.
+ * `1px` and `1ch` are both one cell in this engine, so `aspect-ratio: 1` on a
+ * box 10 cells wide makes it 10 rows tall -- there is no compensation for a
+ * glyph being visually taller than it is wide. `auto`, a value with an `auto`
+ * component, and a zero or negative component all behave as auto.
+ */
+function parseAspectRatio(value: string): number | undefined {
+	if (!value || value.includes("auto")) {
+		return undefined;
+	}
+	const parts = value.split("/");
+	if (parts.length > 2) {
+		return undefined;
+	}
+	const width = parseFloat(parts[0]);
+	const height = parts.length === 2 ? parseFloat(parts[1]) : 1;
+	if (
+		!Number.isFinite(width) ||
+		!Number.isFinite(height) ||
+		width <= 0 ||
+		height <= 0
+	) {
+		return undefined;
+	}
+	return width / height;
+}
+
 function styleFlexNode(
 	element: Element,
 	flexNode: FlexTypes.Node,
@@ -451,6 +481,16 @@ function styleFlexNode(
 		}
 
 		applyMinMax(flexNode, computedStyle);
+	}
+
+	// An aspect ratio sizes a box, which an inline box is not; everything
+	// else carries it to the engine.
+	if (display === "inline" && !parentIsFlex) {
+		flexNode.setAspectRatio(undefined);
+	} else {
+		flexNode.setAspectRatio(
+			parseAspectRatio(computedStyle.computedValueOf("aspect-ratio")),
+		);
 	}
 
 	// Box model properties: clear for inline elements, apply for block/

--- a/tests/aspect-ratio.test.ts
+++ b/tests/aspect-ratio.test.ts
@@ -1,0 +1,242 @@
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+// The ratio counts cells: one cell is one cell, vertical or horizontal, so
+// `aspect-ratio: 1` on a box 10 cells wide makes it 10 rows tall.
+
+test("a definite width derives the height through the ratio", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.width = "12ch";
+	box.style.setProperty("aspect-ratio", "3");
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(12);
+	expect(rect.height).toBe(4);
+
+	dom.dispose();
+});
+
+test("aspect-ratio: 1 makes a 10-cell-wide box 10 rows tall", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.width = "10ch";
+	box.style.setProperty("aspect-ratio", "1");
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(10);
+	expect(rect.height).toBe(10);
+
+	dom.dispose();
+});
+
+test("a definite height derives the width through the ratio", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.height = "4px";
+	box.style.setProperty("aspect-ratio", "2 / 1");
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.height).toBe(4);
+	expect(rect.width).toBe(8);
+
+	dom.dispose();
+});
+
+test("both axes definite: the ratio is ignored", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.width = "12ch";
+	box.style.height = "3px";
+	box.style.setProperty("aspect-ratio", "1");
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(12);
+	expect(rect.height).toBe(3);
+
+	dom.dispose();
+});
+
+test("min-height overrides the derived height", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.width = "6ch";
+	box.style.setProperty("aspect-ratio", "1 / 2");
+	box.style.minHeight = "20px";
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(6);
+	expect(rect.height).toBe(20);
+
+	dom.dispose();
+});
+
+test("max-height clamps the derived height", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.width = "10ch";
+	box.style.setProperty("aspect-ratio", "1");
+	box.style.maxHeight = "5px";
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(10);
+	expect(rect.height).toBe(5);
+
+	dom.dispose();
+});
+
+test("a flex item transfers its definite cross size to the main axis", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const row = document.createElement("div");
+	row.style.display = "flex";
+	row.style.flexDirection = "row";
+	document.body.appendChild(row);
+
+	const item = document.createElement("div");
+	item.style.height = "4px";
+	item.style.setProperty("aspect-ratio", "3 / 1");
+	row.appendChild(item);
+
+	const sibling = document.createElement("div");
+	sibling.textContent = "x";
+	row.appendChild(sibling);
+
+	await nextFrame(dom);
+
+	const rect = item.getBoundingClientRect();
+	expect(rect.height).toBe(4);
+	expect(rect.width).toBe(12);
+
+	const siblingRect = sibling.getBoundingClientRect();
+	expect(siblingRect.left).toBe(12);
+
+	dom.dispose();
+});
+
+test("a flex item with a definite main size derives its cross size", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const row = document.createElement("div");
+	row.style.display = "flex";
+	row.style.flexDirection = "row";
+	row.style.alignItems = "flex-start";
+	document.body.appendChild(row);
+
+	const item = document.createElement("div");
+	item.style.width = "8ch";
+	item.style.setProperty("aspect-ratio", "2 / 1");
+	row.appendChild(item);
+
+	await nextFrame(dom);
+
+	const rect = item.getBoundingClientRect();
+	expect(rect.width).toBe(8);
+	expect(rect.height).toBe(4);
+
+	dom.dispose();
+});
+
+test("aspect-ratio: auto leaves the box content-sized", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.width = "12ch";
+	box.style.setProperty("aspect-ratio", "auto");
+	box.textContent = "hello";
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(12);
+	expect(rect.height).toBe(1);
+
+	dom.dispose();
+});
+
+test("a zero or negative component behaves as auto", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 20});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const zero = document.createElement("div");
+	zero.style.width = "12ch";
+	zero.style.setProperty("aspect-ratio", "0");
+	zero.textContent = "a";
+	document.body.appendChild(zero);
+
+	const negative = document.createElement("div");
+	negative.style.width = "12ch";
+	negative.style.setProperty("aspect-ratio", "3 / -1");
+	negative.textContent = "b";
+	document.body.appendChild(negative);
+
+	await nextFrame(dom);
+
+	expect(zero.getBoundingClientRect().height).toBe(1);
+	expect(negative.getBoundingClientRect().height).toBe(1);
+
+	dom.dispose();
+});
+
+test("an auto-width block fills its container and derives its height", async () => {
+	const terminal = new MockProcess({cols: 20, rows: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+
+	const box = document.createElement("div");
+	box.style.setProperty("aspect-ratio", "4 / 1");
+	document.body.appendChild(box);
+
+	await nextFrame(dom);
+
+	const rect = box.getBoundingClientRect();
+	expect(rect.width).toBe(20);
+	expect(rect.height).toBe(5);
+
+	dom.dispose();
+});


### PR DESCRIPTION
The ratio counts cells: one cell is one cell, vertical or horizontal, so `aspect-ratio: 1` on a 10-cell-wide box is 10 rows tall — no compensation for glyphs being visually taller than wide. The ruling is stated in the property's doc comments.

A box offered one definite axis derives the other through the ratio (margins stripped and re-added; min/max still clamp). A definite height transfers to width in block layout, beating fill. Flex transferred sizes fall out of the same interception. Both axes definite ignores the ratio; zero, negative, or `auto`-bearing values behave as `auto`.

Consciously left out: absolutely positioned boxes do not derive through the ratio, and `auto && <ratio>` is treated as plain `auto`. The compatibility matrix regenerates with the probe now passing.

Fixes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
