### PR TITLE
Scroll elements with overflow auto and scroll

### DIFF
--- a/docs/guides/02-layout.md
+++ b/docs/guides/02-layout.md
@@ -46,7 +46,9 @@ Text wraps at the box's width; `white-space`, `word-break`, and
 ## Positioning
 
 `position: relative`, `absolute`, and `fixed`, with `z-index` and stacking
-contexts. `overflow: hidden` clips to the box.
+contexts. `overflow: hidden` clips to the box. `overflow: auto` and `scroll`
+clip the same way and make the box scrollable: `scrollTop`, `scrollTo`,
+`scrollIntoView`, and the mouse wheel move its content by whole rows.
 
 ## Not implemented
 

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -18443,18 +18443,18 @@ Object.defineProperties(Element.prototype, {
 		enumerable: true,
 		writable: true,
 	},
-	// How far a box is scrolled from its content's origin. The number is the
-	// box's own; what it means for what the box shows is the environment's.
-	// These accessors are the bare storage: an environment that can lay out
-	// and paint (the terminal engine) replaces them with accessors that
-	// clamp against the content's laid-out extent and schedule the repaint,
-	// recording the result through setScrollOffset into that store.
+	// How far a box is scrolled from its content's origin. These accessors
+	// are the storage an engineless document answers with: writes land and
+	// read back, and nothing moves. An environment that can lay out and
+	// paint (the terminal engine) replaces them wholesale -- accessor and
+	// storage both -- with ones that clamp against the content's laid-out
+	// extent and schedule the repaint.
 	scrollLeft: {
 		get(this: Element): number {
 			return scrollOffsets.get(this)?.left ?? 0;
 		},
 		set(this: Element, value: number) {
-			setScrollOffset(this, "left", toDouble(value));
+			writeScrollOffset(this, "left", toDouble(value));
 		},
 		configurable: true,
 		enumerable: true,
@@ -18464,7 +18464,7 @@ Object.defineProperties(Element.prototype, {
 			return scrollOffsets.get(this)?.top ?? 0;
 		},
 		set(this: Element, value: number) {
-			setScrollOffset(this, "top", toDouble(value));
+			writeScrollOffset(this, "top", toDouble(value));
 		},
 		configurable: true,
 		enumerable: true,
@@ -18474,28 +18474,7 @@ Object.defineProperties(Element.prototype, {
 /** The scroll offsets of the boxes that have been scrolled at all. */
 const scrollOffsets = new WeakMap<object, {left: number; top: number}>();
 
-/**
- * Where a box is scrolled to, in cells. The renderer asks: paint,
- * hit-testing and the camera all measure against it, and a box nothing has
- * scrolled reads zero without being recorded.
- */
-export function scrollOffsetOf(element: object): {
-	readonly left: number;
-	readonly top: number;
-} {
-	const offsets = scrollOffsets.get(element);
-	if (offsets === undefined) {
-		return {left: 0, top: 0};
-	}
-	return {left: offsets.left, top: offsets.top};
-}
-
-/**
- * Scroll a box along one axis, in cells. The caller has already worked out
- * what the offset may be -- the extent it clamps against is layout's answer
- * and not the DOM's -- and this records it.
- */
-export function setScrollOffset(
+function writeScrollOffset(
 	element: object,
 	axis: "left" | "top",
 	value: number,

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -18444,8 +18444,11 @@ Object.defineProperties(Element.prototype, {
 		writable: true,
 	},
 	// How far a box is scrolled from its content's origin. The number is the
-	// box's own; what it means for what the box shows is the environment's,
-	// which is why writing one scrolls nothing here.
+	// box's own; what it means for what the box shows is the environment's.
+	// These accessors are the bare storage: an environment that can lay out
+	// and paint (the terminal engine) replaces them with accessors that
+	// clamp against the content's laid-out extent and schedule the repaint,
+	// writing through scrollOffsetsOf into the same store.
 	scrollLeft: {
 		get(this: Element): number {
 			return scrollOffsets.get(this)?.left ?? 0;
@@ -18471,7 +18474,7 @@ Object.defineProperties(Element.prototype, {
 /** The scroll offsets of the boxes that have been scrolled at all. */
 const scrollOffsets = new WeakMap<Element, {left: number; top: number}>();
 
-function scrollOffsetsOf(element: Element): {left: number; top: number} {
+export function scrollOffsetsOf(element: Element): {left: number; top: number} {
 	let offsets = scrollOffsets.get(element);
 	if (offsets === undefined) {
 		offsets = {left: 0, top: 0};

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -18448,13 +18448,13 @@ Object.defineProperties(Element.prototype, {
 	// These accessors are the bare storage: an environment that can lay out
 	// and paint (the terminal engine) replaces them with accessors that
 	// clamp against the content's laid-out extent and schedule the repaint,
-	// writing through scrollOffsetsOf into the same store.
+	// recording the result through setScrollOffset into that store.
 	scrollLeft: {
 		get(this: Element): number {
 			return scrollOffsets.get(this)?.left ?? 0;
 		},
 		set(this: Element, value: number) {
-			scrollOffsetsOf(this).left = toDouble(value);
+			setScrollOffset(this, "left", toDouble(value));
 		},
 		configurable: true,
 		enumerable: true,
@@ -18464,7 +18464,7 @@ Object.defineProperties(Element.prototype, {
 			return scrollOffsets.get(this)?.top ?? 0;
 		},
 		set(this: Element, value: number) {
-			scrollOffsetsOf(this).top = toDouble(value);
+			setScrollOffset(this, "top", toDouble(value));
 		},
 		configurable: true,
 		enumerable: true,
@@ -18472,15 +18472,40 @@ Object.defineProperties(Element.prototype, {
 });
 
 /** The scroll offsets of the boxes that have been scrolled at all. */
-const scrollOffsets = new WeakMap<Element, {left: number; top: number}>();
+const scrollOffsets = new WeakMap<object, {left: number; top: number}>();
 
-export function scrollOffsetsOf(element: Element): {left: number; top: number} {
+/**
+ * Where a box is scrolled to, in cells. The renderer asks: paint,
+ * hit-testing and the camera all measure against it, and a box nothing has
+ * scrolled reads zero without being recorded.
+ */
+export function scrollOffsetOf(element: object): {
+	readonly left: number;
+	readonly top: number;
+} {
+	const offsets = scrollOffsets.get(element);
+	if (offsets === undefined) {
+		return {left: 0, top: 0};
+	}
+	return {left: offsets.left, top: offsets.top};
+}
+
+/**
+ * Scroll a box along one axis, in cells. The caller has already worked out
+ * what the offset may be -- the extent it clamps against is layout's answer
+ * and not the DOM's -- and this records it.
+ */
+export function setScrollOffset(
+	element: object,
+	axis: "left" | "top",
+	value: number,
+): void {
 	let offsets = scrollOffsets.get(element);
 	if (offsets === undefined) {
 		offsets = {left: 0, top: 0};
 		scrollOffsets.set(element, offsets);
 	}
-	return offsets;
+	offsets[axis] = value;
 }
 
 /** The spec's "insert adjacent" algorithm, shared by element and text. */

--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -1714,6 +1714,109 @@ export class LayoutEngine {
 		);
 	}
 
+	/**
+	 * The laid-out extent of a box's content -- what scrollWidth/scrollHeight
+	 * report and scroll offsets clamp against: the farthest right/bottom edge
+	 * any child box reaches, measured from the padding-box origin, plus the
+	 * padding on that end, floored at the client size. Children keep their
+	 * natural heights when they overflow a fixed box, so the vertical extent
+	 * is readable off the layout tree directly; a measured inline run's leaf
+	 * takes the width it was offered, so once one is present the horizontal
+	 * extent is unknowable and reported null -- callers must not clamp
+	 * against an answer that does not exist. Null overall for an element the
+	 * tree does not decompose into child boxes at all (an inline, a run
+	 * member, a leaf of its own).
+	 */
+	scrollExtentOf(
+		element: Element,
+	): {width: number | null; height: number} | null {
+		const flexNode = this.nodeMap.get(element);
+		if (!flexNode || flexNode.measureFunc !== null) {
+			return null;
+		}
+		const box = getBoxModel(element);
+		let right: number | null = 0;
+		let bottom = 0;
+		for (const child of flexNode.children) {
+			// A display:none placeholder holds its slot with a stale layout.
+			if (child.getDisplay() === Flex.DISPLAY_NONE) {
+				continue;
+			}
+			if (right !== null) {
+				right =
+					child.measureFunc !== null ?
+						null :
+							Math.max(
+								right,
+								child.getComputedLeft() + child.getComputedWidth(),
+							);
+			}
+			bottom = Math.max(
+				bottom,
+				child.getComputedTop() + child.getComputedHeight(),
+			);
+		}
+		const clientWidth =
+			flexNode.getComputedWidth() -
+			(box.borderLeftWidth || 0) -
+			(box.borderRightWidth || 0);
+		const clientHeight =
+			flexNode.getComputedHeight() -
+			(box.borderTopWidth || 0) -
+			(box.borderBottomWidth || 0);
+		return {
+			width:
+				right === null ?
+					null :
+						Math.round(
+							Math.max(
+								clientWidth,
+								right - (box.borderLeftWidth || 0) + (box.paddingRight || 0),
+							),
+						),
+			height: Math.round(
+				Math.max(
+					clientHeight,
+					bottom - (box.borderTopWidth || 0) + (box.paddingBottom || 0),
+				),
+			),
+		};
+	}
+
+	/**
+	 * The rows an element's painted position is shifted up by its scrolled
+	 * ancestors -- the same walk absolutePosition subtracts, minus the
+	 * element's own box. Paint extents are cached in unscrolled layout rows,
+	 * so band culling of a scrolled subtree compares against the band moved
+	 * by this amount rather than recomputing extents per scroll.
+	 */
+	scrolledAncestorRows(element: Element): number {
+		const flexNode = this.nodeMap.get(element) ?? runFlexNode(this, element);
+		if (!flexNode) {
+			return 0;
+		}
+		const document = this.window.document;
+		const root = document.documentElement;
+		const body = document.body;
+		let rows = 0;
+		for (
+			let current = flexNode.getParent();
+			current;
+			current = current.getParent()
+		) {
+			const node = this[kDOMNodeByFlexNode].get(current);
+			if (
+				node &&
+				node.nodeType === node.ELEMENT_NODE &&
+				node !== root &&
+				node !== body
+			) {
+				rows += (node as Element).scrollTop || 0;
+			}
+		}
+		return rows;
+	}
+
 	getRect(element: Element): DOMRect | null {
 		const display = getPropertyValue(element, "display");
 

--- a/src/internal/painter.ts
+++ b/src/internal/painter.ts
@@ -7,7 +7,11 @@ import {isTextField, selectionRangeOf} from "./dom.js";
 import type {EngineWindow} from "./termdom.js";
 import {type LayoutEngine, flowWalker, isPositioned} from "./layout.js";
 import type {Viewport} from "./viewport.js";
-import {type StyleManager, resolveBorderSides} from "./styles.js";
+import {
+	type StyleManager,
+	getBoxModel,
+	resolveBorderSides,
+} from "./styles.js";
 import {cssColorToNumber, isTransparentColor} from "./color.js";
 import {renderTextFragment} from "./text.js";
 import {flatIsConnected, flatParentElement, shadowRootOf} from "./dom.js";
@@ -41,17 +45,28 @@ function hasLineThrough(style: ComputedStyle): boolean {
 	return style.computedValueOf("text-decoration-line").includes("line-through");
 }
 
+/** Whether an overflow value clips its axis: everything but visible does. */
+function overflowClips(value: string): boolean {
+	return (
+		value === "hidden" ||
+		value === "clip" ||
+		value === "auto" ||
+		value === "scroll"
+	);
+}
+
 /**
- * The clip an overflow:hidden (or overflow-x/-y:hidden) element imposes on its
- * own children, intersected with whatever clip was already active from an
- * ancestor. overflow:auto/scroll/visible impose no clip on that axis -- there
- * are no scrollable containers, only the document camera, so "auto/scroll"
- * degrades to "visible" rather than clipping content nobody can scroll to see.
- * An axis that isn't hidden stays unbounded (+-Infinity), not just "this
- * element's own edge", so overflow-x:hidden;overflow-y:visible only bounds
- * columns, matching CSS's independent per-axis overflow.
+ * The clip a non-visible overflow (hidden/clip, and auto/scroll -- a scroll
+ * container clips what is scrolled out of it) imposes on the element's own
+ * children, intersected with whatever clip was already active from an
+ * ancestor. The clip is the PADDING box: content scrolled past the edge must
+ * not paint over the border glyphs, so each clipping axis is inset by that
+ * side's border. An axis that stays visible is unbounded (+-Infinity), not
+ * just "this element's own edge", so overflow-x:hidden;overflow-y:visible
+ * only bounds columns, matching CSS's independent per-axis overflow.
  */
 function overflowClipRect(
+	element: Element,
 	rect: {left: number; top: number; width: number; height: number} | null,
 	overflowX: string,
 	overflowY: string,
@@ -60,16 +75,19 @@ function overflowClipRect(
 	if (!rect) {
 		return parent;
 	}
-	const hiddenX = overflowX === "hidden";
-	const hiddenY = overflowY === "hidden";
-	if (!hiddenX && !hiddenY) {
+	const clipsX = overflowClips(overflowX);
+	const clipsY = overflowClips(overflowY);
+	if (!clipsX && !clipsY) {
 		return parent;
 	}
 
-	const left = hiddenX ? rect.left : -Infinity;
-	const right = hiddenX ? rect.left + rect.width : Infinity;
-	const top = hiddenY ? rect.top : -Infinity;
-	const bottom = hiddenY ? rect.top + rect.height : Infinity;
+	const box = getBoxModel(element);
+	const left = clipsX ? rect.left + (box.borderLeftWidth || 0) : -Infinity;
+	const right =
+		clipsX ? rect.left + rect.width - (box.borderRightWidth || 0) : Infinity;
+	const top = clipsY ? rect.top + (box.borderTopWidth || 0) : -Infinity;
+	const bottom =
+		clipsY ? rect.top + rect.height - (box.borderBottomWidth || 0) : Infinity;
 
 	if (!parent) {
 		return {left, top, right, bottom};
@@ -246,6 +264,7 @@ const kStyleManager = Symbol("styleManager");
 const kViewport = Symbol("viewport");
 const kTopLayer = Symbol("topLayer");
 const kRenderedOutsideMarkers = Symbol("renderedOutsideMarkers");
+const kScrolledRows = Symbol("scrolledRows");
 
 /**
  * The paint walk: the pure transformation of a laid-out DOM tree into terminal
@@ -275,6 +294,11 @@ export class Painter {
 	declare [kTopLayer]: Set<Element>;
 	// List markers already painted this frame; each renders at most once.
 	declare [kRenderedOutsideMarkers]: WeakSet<Element>;
+	// The rows the walk's ancestor scroll boxes have scrolled so far. Paint
+	// extents are cached in unscrolled layout rows while a scrolled subtree
+	// paints that many rows higher, so every band-culling comparison moves
+	// the band by this amount instead of the extents.
+	declare [kScrolledRows]: number;
 
 	constructor(deps: {
 		window: EngineWindow;
@@ -285,6 +309,7 @@ export class Painter {
 		topLayer: Set<Element>;
 	}) {
 		this[kRenderedOutsideMarkers] = new WeakSet<Element>();
+		this[kScrolledRows] = 0;
 		this[kWindow] = deps.window;
 		this[kDocument] = deps.document;
 		this[kLayout] = deps.layout;
@@ -296,6 +321,7 @@ export class Painter {
 	/** The whole document: the root stacking context, then the top layer. */
 	paint(ctx: CellContext): void {
 		this[kRenderedOutsideMarkers] = new WeakSet<Element>();
+		this[kScrolledRows] = 0;
 		const layers = this[kLayout].collectStackingLayers(this[kTopLayer]);
 		renderStackingContext(this, this[kDocument].body, ctx, layers);
 		for (const element of this[kTopLayer]) {
@@ -307,11 +333,15 @@ export class Painter {
 			}
 			const previousClip = ctx.clipRect;
 			ctx.clipRect = null;
+			// A top-layer element enters the walk from outside its ancestor
+			// chain; seed the culling shift its scrolled ancestors impose.
+			this[kScrolledRows] = this[kLayout].scrolledAncestorRows(element);
 			try {
 				renderBackdrop(this, element, ctx);
 				renderStackingContext(this, element, ctx, layers);
 			} finally {
 				ctx.clipRect = previousClip;
+				this[kScrolledRows] = 0;
 			}
 		}
 	}
@@ -355,7 +385,10 @@ function renderElement(
 	// The enclosing band, for the child-enumeration queries below; the
 	// per-band check culls precisely on recursion, and the context's cell
 	// mask makes any overshoot harmless.
-	let bandTop = -ctx.viewportOffset;
+	// Extents are cached in unscrolled layout rows; a subtree inside scrolled
+	// boxes paints that many rows higher, so the band moves down instead.
+	const scrolledRows = self[kScrolledRows];
+	let bandTop = -ctx.viewportOffset + scrolledRows;
 	let bandBottom = bandTop + ctx.rows;
 	if (ctx.paintBands) {
 		// Skip any subtree outside every band.
@@ -363,15 +396,11 @@ function renderElement(
 		bandTop = Infinity;
 		bandBottom = -Infinity;
 		for (const [start, end] of ctx.paintBands) {
-			bandTop = Math.min(bandTop, start - ctx.viewportOffset);
-			bandBottom = Math.max(bandBottom, end - ctx.viewportOffset);
-			if (
-				!self[kLayout].isSubtreeOutsideBand(
-					element,
-					start - ctx.viewportOffset,
-					end - ctx.viewportOffset,
-				)
-			) {
+			const top = start - ctx.viewportOffset + scrolledRows;
+			const bottom = end - ctx.viewportOffset + scrolledRows;
+			bandTop = Math.min(bandTop, top);
+			bandBottom = Math.max(bandBottom, bottom);
+			if (!self[kLayout].isSubtreeOutsideBand(element, top, bottom)) {
 				inside = true;
 			}
 		}
@@ -612,6 +641,19 @@ function renderElement(
 	// kRenderStackingContext). The old per-sibling z sort could never
 	// let a deep overlay escape its parent's siblings; hoisting is what
 	// makes a modal or dropdown paint over unrelated subtrees.
+	// The element's own scroll shifts its children, not itself: the child
+	// walk below culls against the band moved by that much more, and the
+	// walk state carries the accumulated shift to every descendant. The
+	// document roots' scrollTop is the camera, applied at ctx.viewportOffset,
+	// never here.
+	const ownScrolledRows =
+		element === self[kDocument].body ||
+		element === self[kDocument].documentElement ?
+			0 :
+			element.scrollTop || 0;
+	bandTop += ownScrolledRows;
+	bandBottom += ownScrolledRows;
+
 	const children: Node[] = [];
 
 	// Fast path: for a plain vertically-stacked container (no position:
@@ -668,16 +710,21 @@ function renderElement(
 		}
 	}
 
-	// overflow:hidden clips *descendants* to this element's own box -- never
-	// the element's own border/background painted above, which is why this is
-	// scoped to just the children, not the whole function.
-	const overflow = computedStyleOf(element).computedValueOf("overflow");
-	const overflowX =
-		computedStyleOf(element).computedValueOf("overflow-x") || overflow;
-	const overflowY =
-		computedStyleOf(element).computedValueOf("overflow-y") || overflow;
+	// A non-visible overflow clips *descendants* to this element's own box --
+	// never the element's own border/background painted above, which is why
+	// this is scoped to just the children, not the whole function.
+	const overflow = computed.computedValueOf("overflow");
+	const overflowX = computed.computedValueOf("overflow-x") || overflow;
+	const overflowY = computed.computedValueOf("overflow-y") || overflow;
 	const previousClip = ctx.clipRect;
-	ctx.clipRect = overflowClipRect(rect, overflowX, overflowY, previousClip);
+	ctx.clipRect = overflowClipRect(
+		element,
+		rect,
+		overflowX,
+		overflowY,
+		previousClip,
+	);
+	self[kScrolledRows] = scrolledRows + ownScrolledRows;
 
 	try {
 		for (const childNode of children) {
@@ -693,6 +740,7 @@ function renderElement(
 		}
 	} finally {
 		ctx.clipRect = previousClip;
+		self[kScrolledRows] = scrolledRows;
 	}
 
 	// A focused textarea's own selection now paints inline while the child
@@ -785,10 +833,10 @@ function positionedClipFor(
 		const overflow = style.computedValueOf("overflow");
 		const overflowX = style.computedValueOf("overflow-x") || overflow;
 		const overflowY = style.computedValueOf("overflow-y") || overflow;
-		if (overflowX === "hidden" || overflowY === "hidden") {
+		if (overflowClips(overflowX) || overflowClips(overflowY)) {
 			const rect = self[kLayout].getRect(ancestor);
 			if (rect) {
-				clip = overflowClipRect(rect, overflowX, overflowY, clip);
+				clip = overflowClipRect(ancestor, rect, overflowX, overflowY, clip);
 			}
 		}
 	}
@@ -821,10 +869,15 @@ function renderStackingContext(
 	const paintMember = (element: Element) => {
 		const previousClip = ctx.clipRect;
 		const previousOffset = ctx.viewportOffset;
+		const previousScrolled = self[kScrolledRows];
 		// Clips apply along the CONTAINING BLOCK chain only: an overflow
 		// ancestor that isn't a positioned ancestor doesn't clip a
 		// deferred box, but its own containing blocks' overflow does.
 		ctx.clipRect = positionedClipFor(self, element, root, contextClip);
+		// A hoisted box enters the walk from its stacking context, not its
+		// ancestor chain: re-derive the culling shift its own scrolled
+		// ancestors impose rather than inheriting the context root's.
+		self[kScrolledRows] = self[kLayout].scrolledAncestorRows(element);
 		// position:fixed anchors to the VIEWPORT: cancel the camera by
 		// undoing the scroll offset for the whole subtree. Fixed-space is
 		// a property of the containing-block CHAIN: an absolute box inside
@@ -842,6 +895,7 @@ function renderStackingContext(
 		} finally {
 			ctx.clipRect = previousClip;
 			ctx.viewportOffset = previousOffset;
+			self[kScrolledRows] = previousScrolled;
 		}
 	};
 	renderElement(self, root, ctx, () => {

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -10,6 +10,8 @@ import {
 	caretRangeOf,
 	fieldValueText,
 	flatIsConnected,
+	flatParentElement,
+	scrollOffsetsOf,
 	closePopover,
 	hidePopoversUntil,
 	installUAEngine,
@@ -524,6 +526,7 @@ function createEngineWindow(document: DOM.Document): EngineWindow {
 }
 
 const kFrameDamage = Symbol("frameDamage");
+const kScrolledElements = Symbol("scrolledElements");
 const kTransport = Symbol("transport");
 const kInteractive = Symbol("interactive");
 const kWidth = Symbol("width");
@@ -676,6 +679,11 @@ export class TermDOM {
 	// BEFORE relayout. Null once the set overflowed; cleared per frame.
 	declare [kFrameDamage]: Map<Element, DOMRect | null> | null;
 
+	// Boxes holding a nonzero scroll offset. Layout changes can shrink a
+	// box's content out from under its offset; each layout flush pulls
+	// these back into range (see clampScrolledOffsets).
+	declare [kScrolledElements]: Set<Element>;
+
 	// Bumped on every SIGWINCH. The re-anchor waits on an async cursor query;
 	// if another resize lands while it is in flight, the stale response must not
 	// trigger a redraw at coordinates that no longer mean anything.
@@ -778,6 +786,7 @@ export class TermDOM {
 		this[kLastFrameStructuralGeneration] = -1;
 		this[kLastFrameSelectionLive] = false;
 		this[kFrameDamage] = new Map();
+		this[kScrolledElements] = new Set();
 		this[kResizeEpoch] = 0;
 		this[kMouseReportingEnabled] = false;
 		this[kMouseCaptureYielded] = false;
@@ -1181,35 +1190,184 @@ export class TermDOM {
 		// html/body-only instance properties defined above (which still win: an
 		// own-property shadows a prototype getter, so document.body's viewport-
 		// height special case is untouched).
-		//
-		// scroll* is set equal to client* here rather than the element's true
-		// unclamped content size, matching the same limitation the paint-extent
-		// culling above already documents for the same reason: nothing in the
-		// layout engine measures a subtree's natural size separately from
-		// whatever box it was actually constrained into. That makes scroll* exact
-		// for the common case (auto-sized boxes, no overflow) and an honest
-		// under-report for a box with both an explicit size *and* overflowing
-		// normal-flow content -- the one case a real browser's scrollWidth/Height
-		// would exceed clientWidth/Height.
-		for (const prop of ["clientWidth", "scrollWidth"] as const) {
-			Object.defineProperty(window.HTMLElement.prototype, prop, {
-				get(this: Element) {
-					return Math.round(contentBoxOf(this)?.width ?? 0);
+		Object.defineProperty(window.HTMLElement.prototype, "clientWidth", {
+			get(this: Element) {
+				return Math.round(contentBoxOf(this)?.width ?? 0);
+			},
+			configurable: true,
+			enumerable: true,
+		});
+
+		Object.defineProperty(window.HTMLElement.prototype, "clientHeight", {
+			get(this: Element) {
+				return Math.round(contentBoxOf(this)?.height ?? 0);
+			},
+			configurable: true,
+			enumerable: true,
+		});
+
+		// scroll* is the content's laid-out extent -- how far the box could
+		// scroll, and what its offsets clamp against -- read off the layout
+		// tree, whose children keep their natural sizes when they overflow a
+		// fixed box. A box whose content the tree does not decompose into
+		// child boxes (an inline, a run member) has no readable extent and
+		// falls back to its client size, exact for the no-overflow case.
+		const scrollExtentOf = (
+			element: Element,
+		): {width: number | null; height: number} | null => {
+			if (!element.isConnected) {
+				return null;
+			}
+			const termDOM = engineOf(element);
+			processPendingMutationsAndRender(termDOM);
+			return termDOM[kLayoutEngine].scrollExtentOf(element);
+		};
+
+		Object.defineProperty(window.HTMLElement.prototype, "scrollWidth", {
+			get(this: Element) {
+				return (
+					scrollExtentOf(this)?.width ??
+					Math.round(contentBoxOf(this)?.width ?? 0)
+				);
+			},
+			configurable: true,
+			enumerable: true,
+		});
+
+		Object.defineProperty(window.HTMLElement.prototype, "scrollHeight", {
+			get(this: Element) {
+				return (
+					scrollExtentOf(this)?.height ??
+					Math.round(contentBoxOf(this)?.height ?? 0)
+				);
+			},
+			configurable: true,
+			enumerable: true,
+		});
+
+		// scrollTop/scrollLeft writes take effect here, where layout and the
+		// frame loop live: a write rounds to whole cells (everything paints
+		// on the cell grid, like the document camera), clamps into the
+		// scrollable range, and schedules the repaint that shows it. The
+		// value lands in the DOM's own store (scrollOffsetsOf), which is what
+		// the layout's geometry funnel already reads -- so getters stay the
+		// DOM's. An axis whose overflow is visible is not scrollable and
+		// pins to 0; hidden scrolls programmatically, as in a browser. A box
+		// whose extent the layout cannot name (a field's value span, whose
+		// content is an opaque measured run) stores the write unclamped --
+		// the caret-reveal machinery owns those offsets and keeps them sane.
+		const setScrollOffset = (
+			element: Element,
+			axis: "left" | "top",
+			value: number,
+		): void => {
+			const numeric = Number(value);
+			let next =
+				Number.isFinite(numeric) ? Math.max(0, Math.round(numeric)) : 0;
+			const termDOM = engines.get(element.ownerDocument);
+			if (termDOM && element.isConnected) {
+				processPendingMutationsAndRender(termDOM);
+				const engine = termDOM[kLayoutEngine];
+				const extent = engine.scrollExtentOf(element);
+				const port = engine.contentRect(element);
+				const size =
+					extent === null ?
+						null :
+						axis === "top" ?
+							extent.height :
+							extent.width;
+				if (size !== null && port) {
+					const style = computedStyleOf(element);
+					const overflow =
+						style.computedValueOf(`overflow-${axis === "top" ? "y" : "x"}`) ||
+						style.computedValueOf("overflow");
+					const scrollable =
+						overflow === "auto" ||
+						overflow === "scroll" ||
+						overflow === "hidden";
+					const room =
+						size -
+						Math.round(axis === "top" ? port.height : port.width);
+					next = Math.min(next, scrollable ? Math.max(0, room) : 0);
+				}
+			}
+			const offsets = scrollOffsetsOf(element as never);
+			if (offsets[axis] === next) {
+				return;
+			}
+			offsets[axis] = next;
+			if (termDOM) {
+				if (next !== 0) {
+					termDOM[kScrolledElements].add(element);
+				}
+				// A scroll offset is frame state no MutationObserver sees --
+				// the same footing as input: the generation bump keeps the
+				// "nothing observable moved" gate from skipping the paint,
+				// and the damage keeps that paint banded to the box's rows.
+				termDOM[kInputGeneration]++;
+				addFrameDamage(termDOM, element);
+				void render(termDOM);
+			}
+		};
+
+		for (const axis of ["left", "top"] as const) {
+			const property = axis === "left" ? "scrollLeft" : "scrollTop";
+			const stored = Object.getOwnPropertyDescriptor(
+				Element.prototype,
+				property,
+			);
+			Object.defineProperty(Element.prototype, property, {
+				get: stored?.get,
+				set(this: Element, value: number) {
+					setScrollOffset(this, axis, value);
 				},
 				configurable: true,
 				enumerable: true,
 			});
 		}
 
-		for (const prop of ["clientHeight", "scrollHeight"] as const) {
-			Object.defineProperty(window.HTMLElement.prototype, prop, {
-				get(this: Element) {
-					return Math.round(contentBoxOf(this)?.height ?? 0);
-				},
-				configurable: true,
-				enumerable: true,
-			});
-		}
+		// scrollTo/scroll/scrollBy, in both their forms; assignment through
+		// the accessors above is what rounds, clamps and repaints. html and
+		// body's own scrollTop accessors map to the camera, so scrolling
+		// them scrolls the document, as everywhere else.
+		const scrollTargetOf = (
+			xOrOptions?: number | ScrollToOptions,
+			y?: number,
+		): {left?: number; top?: number} => {
+			if (typeof xOrOptions === "object" && xOrOptions !== null) {
+				return {left: xOrOptions.left, top: xOrOptions.top};
+			}
+			return {left: xOrOptions, top: y};
+		};
+
+		const scrollElementTo = function (
+			this: Element,
+			xOrOptions?: number | ScrollToOptions,
+			y?: number,
+		): void {
+			const target = scrollTargetOf(xOrOptions, y);
+			if (target.left !== undefined) {
+				this.scrollLeft = target.left;
+			}
+			if (target.top !== undefined) {
+				this.scrollTop = target.top;
+			}
+		};
+		Element.prototype.scrollTo = scrollElementTo as Element["scrollTo"];
+		Element.prototype.scroll = scrollElementTo as Element["scroll"];
+		Element.prototype.scrollBy = function (
+			this: Element,
+			xOrOptions?: number | ScrollToOptions,
+			y?: number,
+		): void {
+			const target = scrollTargetOf(xOrOptions, y);
+			if (target.left) {
+				this.scrollLeft = this.scrollLeft + target.left;
+			}
+			if (target.top) {
+				this.scrollTop = this.scrollTop + target.top;
+			}
+		} as Element["scrollBy"];
 
 		// The document-rooted MutationObserver never sees inside a shadow
 		// root -- per spec, shadow trees are separate observation scopes. Each
@@ -1413,7 +1571,11 @@ export class TermDOM {
 			}
 		};
 
-		// Override scrollIntoView to adjust scroll offset
+		// scrollIntoView: every scroll box between the element and the
+		// document reveals it within its own port, innermost first -- each
+		// scroll moves the element in every outer port's coordinates, so the
+		// rect is re-read per level -- and the camera reveals what remains.
+		// All moves are the minimal ones: block "nearest".
 		HTMLElement.prototype.scrollIntoView = function (
 			this: HTMLElement,
 			_arg?: boolean | ScrollIntoViewOptions,
@@ -1423,11 +1585,58 @@ export class TermDOM {
 			}
 			const termDOM = engineOf(this);
 			processPendingMutationsAndRender(termDOM);
+			const engine = termDOM[kLayoutEngine];
+
+			const revealIn = (scroller: Element): void => {
+				// Document-relative rects on both sides: the element wherever
+				// its current offsets put it, against the scroller's padding
+				// box -- what the scroller actually shows.
+				const rect = engine.getRect(this);
+				const scrollerRect = engine.getRect(scroller);
+				if (!rect || !scrollerRect) {
+					return;
+				}
+				const box = getBoxModel(scroller);
+				const portTop = scrollerRect.top + (box.borderTopWidth || 0);
+				const portBottom =
+					scrollerRect.bottom - (box.borderBottomWidth || 0);
+				const portLeft = scrollerRect.left + (box.borderLeftWidth || 0);
+				const portRight = scrollerRect.right - (box.borderRightWidth || 0);
+				if (rect.top < portTop) {
+					scroller.scrollTop -= Math.round(portTop - rect.top);
+				} else if (rect.bottom > portBottom) {
+					scroller.scrollTop += Math.round(rect.bottom - portBottom);
+				}
+				if (rect.left < portLeft) {
+					scroller.scrollLeft -= Math.round(portLeft - rect.left);
+				} else if (rect.right > portRight) {
+					scroller.scrollLeft += Math.round(rect.right - portRight);
+				}
+			};
+
+			for (
+				let ancestor = flatParentElement<Element>(this);
+				ancestor &&
+				ancestor !== termDOM.document.body &&
+				ancestor !== termDOM.document.documentElement;
+				ancestor = flatParentElement<Element>(ancestor)
+			) {
+				const style = computedStyleOf(ancestor);
+				const overflow = style.computedValueOf("overflow");
+				const scrollable = (value: string) =>
+					value === "auto" || value === "scroll" || value === "hidden";
+				if (
+					scrollable(style.computedValueOf("overflow-y") || overflow) ||
+					scrollable(style.computedValueOf("overflow-x") || overflow)
+				) {
+					revealIn(ancestor);
+				}
+			}
 
 			// Document-relative, not getBoundingClientRect's viewport-relative --
 			// this compares directly against the camera's scrollTop below, so it needs
 			// the same coordinate space getRect() already provides.
-			const rect = termDOM[kLayoutEngine].getRect(this);
+			const rect = engine.getRect(this);
 			if (!rect) {
 				return;
 			}
@@ -2634,7 +2843,55 @@ function processPendingMutationsAndRender(
 		void render(self);
 	}
 	self[kLayoutEngine].calculateLayout();
+	clampScrolledOffsets(self);
 	return hadMutations;
+}
+
+/**
+ * Pull every held scroll offset back into its box's scrollable range
+ * against fresh layout: a mutation that shrinks a box's content must not
+ * leave the box scrolled past what remains. Offsets are written to the
+ * store directly -- the accessor's own clamp would re-enter this flush --
+ * and a change repaints the box's rows like any other scroll.
+ */
+function clampScrolledOffsets(
+	self: TermDOM,
+): void {
+	let changed = false;
+	for (const element of self[kScrolledElements]) {
+		const offsets = scrollOffsetsOf(element as never);
+		if (offsets.left === 0 && offsets.top === 0) {
+			self[kScrolledElements].delete(element);
+			continue;
+		}
+		if (!element.isConnected) {
+			continue;
+		}
+		const engine = self[kLayoutEngine];
+		const extent = engine.scrollExtentOf(element);
+		const port = engine.contentRect(element);
+		if (!extent || !port) {
+			continue;
+		}
+		// An unknowable horizontal extent leaves that axis unclamped.
+		const maxLeft =
+			extent.width === null ?
+				offsets.left :
+					Math.max(0, extent.width - Math.round(port.width));
+		const maxTop = Math.max(0, extent.height - Math.round(port.height));
+		if (offsets.left <= maxLeft && offsets.top <= maxTop) {
+			continue;
+		}
+		offsets.left = Math.min(offsets.left, maxLeft);
+		offsets.top = Math.min(offsets.top, maxTop);
+		addFrameDamage(self, element);
+		changed = true;
+	}
+	if (changed) {
+		// See setScrollOffset: offsets are frame state no observer sees.
+		self[kInputGeneration]++;
+		void render(self);
+	}
 }
 
 /**
@@ -2955,6 +3212,51 @@ function documentPointToTextPosition(
 }
 
 /**
+ * The scroll box a wheel tick over `target` belongs to: the nearest flat-tree
+ * ancestor (the target included) whose overflow-y makes it a scroll
+ * container -- auto or scroll; hidden and visible don't take the wheel, as
+ * in a browser -- and that can still move in the tick's direction. None
+ * means the tick chains past every element scroller to the document camera.
+ */
+function wheelScrollerFor(
+	self: TermDOM,
+	target: Element,
+	deltaY: number,
+): Element | null {
+	const body = self.document.body;
+	const root = self.document.documentElement;
+	const engine = self[kLayoutEngine];
+	for (
+		let element: Element | null = target;
+		element && element !== body && element !== root;
+		element = flatParentElement<Element>(element)
+	) {
+		const style = computedStyleOf(element);
+		const overflowY =
+			style.computedValueOf("overflow-y") ||
+			style.computedValueOf("overflow");
+		if (overflowY !== "auto" && overflowY !== "scroll") {
+			continue;
+		}
+		if (deltaY < 0) {
+			if (element.scrollTop > 0) {
+				return element;
+			}
+			continue;
+		}
+		const extent = engine.scrollExtentOf(element);
+		const port = engine.contentRect(element);
+		if (!extent || !port) {
+			continue;
+		}
+		if (element.scrollTop < extent.height - Math.round(port.height)) {
+			return element;
+		}
+	}
+	return null;
+}
+
+/**
  * A mouse report from the terminal (SGR encoding: `CSI < code ; col ; row M/m`).
  * These only arrive while capture is on -- see updateMouseReporting.
  *
@@ -3009,6 +3311,15 @@ function handleMouseReport(
 			}),
 		);
 		if (notCanceled) {
+			// The innermost scroll box under the pointer that can still move
+			// in the wheel's direction consumes the tick; an exhausted one
+			// chains outward -- ultimately to the camera and the terminal's
+			// own scrollback below, the browser's scroll chaining.
+			const scroller = wheelScrollerFor(self, target as Element, wheelDeltaY);
+			if (scroller) {
+				scroller.scrollTop += wheelDeltaY;
+				return;
+			}
 			if (
 				wheelDeltaY < 0 &&
 				self[kViewport].scrollTop === 0 &&
@@ -3656,6 +3967,7 @@ async function renderInteractive(
 	}
 
 	self[kLayoutEngine].calculateLayout();
+	clampScrolledOffsets(self);
 
 	// The caret reveal an edit queued runs here, against the layout this
 	// frame just flushed -- one camera decision per frame, however many

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -11,8 +11,6 @@ import {
 	fieldValueText,
 	flatIsConnected,
 	flatParentElement,
-	scrollOffsetOf,
-	setScrollOffset,
 	closePopover,
 	hidePopoversUntil,
 	installUAEngine,
@@ -1250,9 +1248,9 @@ export class TermDOM {
 		// frame loop live: a write rounds to whole cells (everything paints
 		// on the cell grid, like the document camera), clamps into the
 		// scrollable range, and schedules the repaint that shows it. The
-		// value lands in the DOM's store (setScrollOffset), which is what
-		// the layout's geometry funnel already reads -- so getters stay the
-		// DOM's. An axis whose overflow is visible is not scrollable and
+		// value lands in the engine's store, which the getter installed
+		// below and the layout's geometry funnel (element.scrollTop) both
+		// read. An axis whose overflow is visible is not scrollable and
 		// pins to 0; hidden scrolls programmatically, as in a browser. A box
 		// whose extent the layout cannot name (a field's value span, whose
 		// content is an opaque measured run) stores the write unclamped --
@@ -1292,10 +1290,10 @@ export class TermDOM {
 					next = Math.min(next, scrollable ? Math.max(0, room) : 0);
 				}
 			}
-			if (scrollOffsetOf(element)[axis] === next) {
+			if ((elementScrollOffsets.get(element)?.[axis] ?? 0) === next) {
 				return;
 			}
-			setScrollOffset(element, axis, next);
+			writeElementScroll(element, axis, next);
 			if (termDOM) {
 				if (next !== 0) {
 					termDOM[kScrolledElements].add(element);
@@ -1312,12 +1310,10 @@ export class TermDOM {
 
 		for (const axis of ["left", "top"] as const) {
 			const property = axis === "left" ? "scrollLeft" : "scrollTop";
-			const stored = Object.getOwnPropertyDescriptor(
-				Element.prototype,
-				property,
-			);
 			Object.defineProperty(Element.prototype, property, {
-				get: stored?.get,
+				get(this: Element): number {
+					return elementScrollOffsets.get(this)?.[axis] ?? 0;
+				},
 				set(this: Element, value: number) {
 					scrollAxisTo(this, axis, value);
 				},
@@ -2848,6 +2844,30 @@ function processPendingMutationsAndRender(
 }
 
 /**
+ * The engine's element scroll offsets, in cells. Replacing the DOM's
+ * accessors replaces the storage under them too, so the DOM module keeps no
+ * seam for the engine to reach through; a box nothing scrolled is absent
+ * and reads zero.
+ */
+const elementScrollOffsets = new WeakMap<
+	Element,
+	{left: number; top: number}
+>();
+
+function writeElementScroll(
+	element: Element,
+	axis: "left" | "top",
+	value: number,
+): void {
+	let offsets = elementScrollOffsets.get(element);
+	if (offsets === undefined) {
+		offsets = {left: 0, top: 0};
+		elementScrollOffsets.set(element, offsets);
+	}
+	offsets[axis] = value;
+}
+
+/**
  * Pull every held scroll offset back into its box's scrollable range
  * against fresh layout: a mutation that shrinks a box's content must not
  * leave the box scrolled past what remains. Offsets are written to the
@@ -2859,7 +2879,7 @@ function clampScrolledOffsets(
 ): void {
 	let changed = false;
 	for (const element of self[kScrolledElements]) {
-		const offsets = scrollOffsetOf(element);
+		const offsets = elementScrollOffsets.get(element) ?? {left: 0, top: 0};
 		if (offsets.left === 0 && offsets.top === 0) {
 			self[kScrolledElements].delete(element);
 			continue;
@@ -2882,8 +2902,8 @@ function clampScrolledOffsets(
 		if (offsets.left <= maxLeft && offsets.top <= maxTop) {
 			continue;
 		}
-		setScrollOffset(element, "left", Math.min(offsets.left, maxLeft));
-		setScrollOffset(element, "top", Math.min(offsets.top, maxTop));
+		writeElementScroll(element, "left", Math.min(offsets.left, maxLeft));
+		writeElementScroll(element, "top", Math.min(offsets.top, maxTop));
 		addFrameDamage(self, element);
 		changed = true;
 	}

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -11,7 +11,8 @@ import {
 	fieldValueText,
 	flatIsConnected,
 	flatParentElement,
-	scrollOffsetsOf,
+	scrollOffsetOf,
+	setScrollOffset,
 	closePopover,
 	hidePopoversUntil,
 	installUAEngine,
@@ -1249,14 +1250,14 @@ export class TermDOM {
 		// frame loop live: a write rounds to whole cells (everything paints
 		// on the cell grid, like the document camera), clamps into the
 		// scrollable range, and schedules the repaint that shows it. The
-		// value lands in the DOM's own store (scrollOffsetsOf), which is what
+		// value lands in the DOM's store (setScrollOffset), which is what
 		// the layout's geometry funnel already reads -- so getters stay the
 		// DOM's. An axis whose overflow is visible is not scrollable and
 		// pins to 0; hidden scrolls programmatically, as in a browser. A box
 		// whose extent the layout cannot name (a field's value span, whose
 		// content is an opaque measured run) stores the write unclamped --
 		// the caret-reveal machinery owns those offsets and keeps them sane.
-		const setScrollOffset = (
+		const scrollAxisTo = (
 			element: Element,
 			axis: "left" | "top",
 			value: number,
@@ -1291,11 +1292,10 @@ export class TermDOM {
 					next = Math.min(next, scrollable ? Math.max(0, room) : 0);
 				}
 			}
-			const offsets = scrollOffsetsOf(element as never);
-			if (offsets[axis] === next) {
+			if (scrollOffsetOf(element)[axis] === next) {
 				return;
 			}
-			offsets[axis] = next;
+			setScrollOffset(element, axis, next);
 			if (termDOM) {
 				if (next !== 0) {
 					termDOM[kScrolledElements].add(element);
@@ -1319,7 +1319,7 @@ export class TermDOM {
 			Object.defineProperty(Element.prototype, property, {
 				get: stored?.get,
 				set(this: Element, value: number) {
-					setScrollOffset(this, axis, value);
+					scrollAxisTo(this, axis, value);
 				},
 				configurable: true,
 				enumerable: true,
@@ -2859,7 +2859,7 @@ function clampScrolledOffsets(
 ): void {
 	let changed = false;
 	for (const element of self[kScrolledElements]) {
-		const offsets = scrollOffsetsOf(element as never);
+		const offsets = scrollOffsetOf(element);
 		if (offsets.left === 0 && offsets.top === 0) {
 			self[kScrolledElements].delete(element);
 			continue;
@@ -2882,13 +2882,13 @@ function clampScrolledOffsets(
 		if (offsets.left <= maxLeft && offsets.top <= maxTop) {
 			continue;
 		}
-		offsets.left = Math.min(offsets.left, maxLeft);
-		offsets.top = Math.min(offsets.top, maxTop);
+		setScrollOffset(element, "left", Math.min(offsets.left, maxLeft));
+		setScrollOffset(element, "top", Math.min(offsets.top, maxTop));
 		addFrameDamage(self, element);
 		changed = true;
 	}
 	if (changed) {
-		// See setScrollOffset: offsets are frame state no observer sees.
+		// See scrollAxisTo: offsets are frame state no observer sees.
 		self[kInputGeneration]++;
 		void render(self);
 	}

--- a/tests/overflow-scroll.test.ts
+++ b/tests/overflow-scroll.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Element scrollers: a box with overflow auto or scroll clips to its own
+ * rows and moves its content by its scrollTop/scrollLeft -- whole cells,
+ * clamped to the content's laid-out extent -- with the wheel, hit-testing
+ * and scrollIntoView all reading the same offsets.
+ */
+
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+function makeScrollerApp(options?: {
+	boxHeight?: number;
+	lines?: number;
+	rows?: number;
+}): {
+	terminal: MockProcess;
+	dom: TermDOM;
+	box: HTMLElement;
+} {
+	const {boxHeight = 3, lines = 8, rows = 10} = options ?? {};
+	const terminal = new MockProcess({cols: 20, rows});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+	const box = document.createElement("div");
+	box.id = "box";
+	box.style.height = `${boxHeight}px`;
+	box.style.overflow = "auto";
+	for (let i = 0; i < lines; i++) {
+		const line = document.createElement("div");
+		line.id = `line-${i}`;
+		line.textContent = `row ${i}`;
+		box.appendChild(line);
+	}
+	document.body.appendChild(box);
+	return {terminal, dom, box: box as HTMLElement};
+}
+
+/** Feed terminal input (a mouse report) and let the transport deliver it. */
+function send(terminal: MockProcess, data: string): Promise<void> {
+	terminal.stdin.simulateResponse(data);
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("scrollHeight reports the content's extent, clientHeight the box", async () => {
+	const {dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+	expect(box.clientHeight).toBe(3);
+	expect(box.scrollHeight).toBe(8);
+	dom.dispose();
+});
+
+test("a box whose content fits reports its client size as the extent", async () => {
+	const {dom, box} = makeScrollerApp({boxHeight: 8, lines: 4});
+	await nextFrame(dom);
+	expect(box.clientHeight).toBe(8);
+	expect(box.scrollHeight).toBe(8);
+	dom.dispose();
+});
+
+test("scrollWidth reports child boxes wider than the scroller", async () => {
+	const terminal = new MockProcess({cols: 20, rows: 10});
+	const dom = new TermDOM({transport: terminal.transport});
+	const box = dom.document.createElement("div");
+	box.style.width = "6ch";
+	box.style.overflow = "auto";
+	const wide = dom.document.createElement("div");
+	wide.style.width = "15ch";
+	wide.style.height = "1px";
+	box.appendChild(wide);
+	dom.document.body.appendChild(box);
+	await nextFrame(dom);
+	expect(box.clientWidth).toBe(6);
+	expect(box.scrollWidth).toBe(15);
+	dom.dispose();
+});
+
+test("scrollTop writes round to whole rows and clamp to the extent", async () => {
+	const {dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+
+	box.scrollTop = 2.6;
+	expect(box.scrollTop).toBe(3);
+
+	box.scrollTop = -4;
+	expect(box.scrollTop).toBe(0);
+
+	// 8 rows of content in a 3-row box: 5 rows of room.
+	box.scrollTop = 99;
+	expect(box.scrollTop).toBe(5);
+	dom.dispose();
+});
+
+test("scrollTop pins to 0 on a box whose overflow is visible", async () => {
+	const terminal = new MockProcess({cols: 20, rows: 10});
+	const dom = new TermDOM({transport: terminal.transport});
+	const box = dom.document.createElement("div");
+	box.style.height = "2px";
+	for (let i = 0; i < 5; i++) {
+		const line = dom.document.createElement("div");
+		line.textContent = `row ${i}`;
+		box.appendChild(line);
+	}
+	dom.document.body.appendChild(box);
+	await nextFrame(dom);
+	box.scrollTop = 2;
+	expect(box.scrollTop).toBe(0);
+	dom.dispose();
+});
+
+test("a mutation that shrinks the content pulls the offset back", async () => {
+	const {dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+
+	box.scrollTop = 5;
+	expect(box.scrollTop).toBe(5);
+
+	// Down to 4 rows of content in a 3-row box: 1 row of room.
+	while (box.children.length > 4) {
+		box.removeChild(box.lastChild!);
+	}
+	await nextFrame(dom);
+	expect(box.scrollTop).toBe(1);
+	dom.dispose();
+});
+
+test("painted rows shift by scrollTop, clipped to the box", async () => {
+	const {terminal, dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toBe("row 0\nrow 1\nrow 2\n");
+
+	box.scrollTop = 4;
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toBe("row 4\nrow 5\nrow 6\n");
+	dom.dispose();
+});
+
+test("painted columns shift by scrollLeft", async () => {
+	const terminal = new MockProcess({cols: 20, rows: 10});
+	const dom = new TermDOM({transport: terminal.transport});
+	const box = dom.document.createElement("div");
+	box.style.width = "4ch";
+	box.style.overflow = "auto";
+	const wide = dom.document.createElement("div");
+	wide.style.width = "8ch";
+	wide.textContent = "abcdefgh";
+	box.appendChild(wide);
+	dom.document.body.appendChild(box);
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toBe("abcd\n");
+
+	box.scrollLeft = 3;
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toBe("defg\n");
+	dom.dispose();
+});
+
+test("elementFromPoint sees the row the scroll put there", async () => {
+	const {dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+	expect(dom.document.elementFromPoint(1, 1)?.id).toBe("line-1");
+
+	box.scrollTop = 4;
+	await nextFrame(dom);
+	expect(dom.document.elementFromPoint(1, 1)?.id).toBe("line-5");
+	dom.dispose();
+});
+
+test("a click after scrolling lands on the element shown there", async () => {
+	const {terminal, dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+	box.scrollTop = 4;
+	await nextFrame(dom);
+
+	let clicked: string | null = null;
+	dom.document.addEventListener("click", (event) => {
+		clicked = (event.target as Element).id;
+	});
+	// Press and release on the box's second visual row (screen row 2).
+	await send(terminal, "\x1b[<0;2;2M");
+	await send(terminal, "\x1b[<0;2;2m");
+	expect(clicked).toBe("line-5");
+	dom.dispose();
+});
+
+test("wheel scrolls the innermost scroller, then chains to the camera", async () => {
+	// 8 scroller rows over enough document lines to give the camera room.
+	const {terminal, dom, box} = makeScrollerApp({rows: 5, lines: 5});
+	const {document} = dom;
+	for (let i = 0; i < 10; i++) {
+		const div = document.createElement("div");
+		div.textContent = `below ${i}`;
+		document.body.appendChild(div);
+	}
+	await nextFrame(dom);
+
+	// A wheel tick is 3 rows. The scroller has 2 rows of room (5 lines in
+	// 3), so the first tick exhausts it -- and the camera doesn't move.
+	await send(terminal, "\x1b[<65;2;2M");
+	expect(box.scrollTop).toBe(2);
+	expect(dom.window.scrollY).toBe(0);
+
+	// The next tick chains outward to the camera.
+	await send(terminal, "\x1b[<65;2;2M");
+	await nextFrame(dom);
+	expect(box.scrollTop).toBe(2);
+	expect(dom.window.scrollY).toBe(3);
+
+	// The camera has scrolled the box off screen, so wheel up belongs to
+	// the camera; once the box is back under the pointer, the wheel is its.
+	await send(terminal, "\x1b[<64;2;1M");
+	await nextFrame(dom);
+	expect(dom.window.scrollY).toBe(0);
+	await send(terminal, "\x1b[<64;2;2M");
+	expect(box.scrollTop).toBe(0);
+	expect(dom.window.scrollY).toBe(0);
+	dom.dispose();
+});
+
+test("preventDefault on wheel keeps a scroller still", async () => {
+	const {terminal, dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+	dom.document.addEventListener(
+		"wheel",
+		(event) => event.preventDefault(),
+		{passive: false},
+	);
+	await send(terminal, "\x1b[<65;2;2M");
+	expect(box.scrollTop).toBe(0);
+	dom.dispose();
+});
+
+test("scrollTo/scroll/scrollBy move a scroller in both their forms", async () => {
+	const {dom, box} = makeScrollerApp();
+	await nextFrame(dom);
+
+	box.scrollTo(0, 2);
+	expect(box.scrollTop).toBe(2);
+
+	box.scrollTo({top: 1});
+	expect(box.scrollTop).toBe(1);
+
+	box.scroll(0, 3);
+	expect(box.scrollTop).toBe(3);
+
+	box.scrollBy(0, 1);
+	expect(box.scrollTop).toBe(4);
+
+	box.scrollBy({top: -2});
+	expect(box.scrollTop).toBe(2);
+	dom.dispose();
+});
+
+test("scrollIntoView scrolls ancestor scrollers, then the camera", async () => {
+	const terminal = new MockProcess({cols: 20, rows: 4});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+	// Padding above pushes the outer scroller past the first screen.
+	for (let i = 0; i < 6; i++) {
+		const div = document.createElement("div");
+		div.textContent = `above ${i}`;
+		document.body.appendChild(div);
+	}
+	const outer = document.createElement("div");
+	outer.style.height = "3px";
+	outer.style.overflow = "auto";
+	const inner = document.createElement("div");
+	inner.style.height = "2px";
+	inner.style.overflow = "auto";
+	let target: HTMLElement | null = null;
+	for (let i = 0; i < 6; i++) {
+		const line = document.createElement("div");
+		line.id = `deep-${i}`;
+		line.textContent = `deep ${i}`;
+		inner.appendChild(line);
+		if (i === 5) {
+			target = line as HTMLElement;
+		}
+	}
+	outer.appendChild(inner);
+	const tail = document.createElement("div");
+	tail.textContent = "tail";
+	outer.appendChild(tail);
+	document.body.appendChild(outer);
+	await nextFrame(dom);
+
+	target!.scrollIntoView();
+	await nextFrame(dom);
+	// The inner scroller reveals its last row, the outer reveals the
+	// inner's bottom, and the camera reveals the outer's rows.
+	expect(inner.scrollTop).toBe(4);
+	expect(outer.scrollTop).toBe(0);
+	const rect = target!.getBoundingClientRect();
+	expect(rect.top).toBeGreaterThanOrEqual(0);
+	expect(rect.bottom).toBeLessThanOrEqual(4);
+	expect(terminal.getPlainText()).toContain("deep 5");
+	dom.dispose();
+});


### PR DESCRIPTION
Elements with `overflow: auto` or `overflow: scroll` now scroll. `scrollHeight`/`scrollWidth` report the content's laid-out extent, `scrollTop`/`scrollLeft` writes take effect and repaint, `scrollTo`/`scrollBy`/`scroll` work in both forms, `scrollIntoView` scrolls ancestor scrollers before the document camera, and hit-testing sees whatever the scroll put under the pointer. A mutation that shrinks a box's content pulls its offset back into range.

**Chaining:** a wheel tick scrolls the innermost scroll container under the pointer that can still move in that direction; an exhausted one chains outward, ultimately to the document camera and the terminal's own scrollback exactly as before. `preventDefault` on the wheel event opts out, as it already did for the document.

**Whole cells:** everything paints on the cell grid, so offsets are whole rows and columns — writes round and clamp to `[0, extent − client]`, the way the document camera does.

**No scrollbar chrome:** terminals get none. `auto` and `scroll` behave identically apart from `auto` being a scroll container only when its content overflows.

Fixes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
