### PR TITLE
Implement Selection.modify(), honest isTrusted, and the clipboard

### DIFF
--- a/docs/dom-conformance.md
+++ b/docs/dom-conformance.md
@@ -431,7 +431,7 @@ Range.getClientRects() and Range.getBoundingClientRect() are not implemented. Th
 
 ### selection/modify.tentative.html, bidi/modify-*.html, contenteditable/modify*.html, move-by-word-*.html
 
-Selection.modify() is not implemented. Its "character" and "word" granularities could be answered from the tree. Its "line", "lineboundary", "paragraph" and remaining granularities are positions only layout knows.
+Selection.modify() implements the "character", "word", "line", "lineboundary" and document-boundary granularities. "sentence" and "paragraph" do nothing. A line is a laid-out line rather than a property of the string, so the line granularities need a document mounted in a terminal; on the bare DOM this suite runs against, they do nothing.
 
 ### selection/getSelection.html (excluded), and the defaultView sanity checks in it
 

--- a/docs/guides/03-events-and-input.md
+++ b/docs/guides/03-events-and-input.md
@@ -123,6 +123,30 @@ reaching for the clipboard is already too late. Most terminals refuse clipboard 
 when one does not answer. The terminal's own select-to-copy remains
 available as Shift+drag, which bypasses mouse reporting.
 
+`navigator.clipboard` is a `Clipboard`, and `write()` and `read()` work over
+`ClipboardItem` under the same gate. OSC 52 carries one payload a terminal
+treats as text, so `text/plain` is the type it sends and answers with, and
+`ClipboardItem.supports()` says so. `navigator.permissions.query({name:
+"clipboard-read"})` and `"clipboard-write"` report `granted` while a gesture
+is being dispatched and `prompt` outside one.
+
+A paste from the terminal arrives as a cancelable `paste` event at the
+focused element, or at `document.body` when nothing is focused, with the text
+on `event.clipboardData`. A paste nobody cancels goes on to insert into a
+focused text field:
+
+```ts
+document.addEventListener("paste", (event) => {
+	console.log(event.clipboardData.getData("text/plain"));
+	event.preventDefault();
+});
+```
+
+`ClipboardEvent` and `DataTransfer` are here, and `copy` and `cut` listeners
+attach and receive what an application dispatches, but nothing fires them for
+the user: the terminal keeps the copy gesture -- Cmd+C, Shift+drag -- and
+never reports it, and Ctrl+C is the interrupt.
+
 ## Scrolling and the camera
 
 Output starts at the command line and flows down. When the document

--- a/docs/guides/03-events-and-input.md
+++ b/docs/guides/03-events-and-input.md
@@ -3,7 +3,10 @@ title: Events and Input
 description: Keyboard, mouse, focus, form controls, and selection.
 ---
 
-Input arrives as DOM events, through `addEventListener`.
+Input arrives as DOM events, through `addEventListener`. An event the engine
+fires -- decoded input, a resize, a focus move -- reads `isTrusted` true; an
+event an application constructs and dispatches itself reads false, so a
+listener can tell the two apart.
 
 ## Keyboard
 
@@ -103,11 +106,22 @@ value.
 ## Selection and the clipboard
 
 Drag to select, in the document or inside a field. Selection is styled
-through `::selection`. Copying is explicit:
-`navigator.clipboard.writeText(text)` carries the text to the system
-clipboard over OSC 52, which travels in-band and works across SSH. The
-terminal's own select-to-copy remains available as Shift+drag, which
-bypasses mouse reporting.
+through `::selection`. `getSelection().modify(alter, direction,
+granularity)` moves the caret or drags the focus by character, word, line
+or line boundary -- the line granularities read the laid-out lines, so a
+soft wrap counts as a line.
+
+Copying is explicit: `navigator.clipboard.writeText(text)` carries the text
+to the system clipboard over OSC 52, which travels in-band and works across
+SSH, and `readText()` asks the terminal for the clipboard the same way.
+Both are reachable only from inside the dispatch of a trusted event the user
+caused -- a keystroke, a mouse press or release, a click, a paste -- and
+reject with a `NotAllowedError` otherwise; `navigator.userActivation` reports
+the same state. This is stricter than a browser, whose activation window is a
+span of time and survives an `await`: here a handler that awaits before
+reaching for the clipboard is already too late. Most terminals refuse clipboard reads, and `readText()` rejects
+when one does not answer. The terminal's own select-to-copy remains
+available as Shift+drag, which bypasses mouse reporting.
 
 ## Scrolling and the camera
 

--- a/docs/guides/04-api.md
+++ b/docs/guides/04-api.md
@@ -36,9 +36,11 @@ these members are wired to the terminal:
 - `matchMedia()` — live `MediaQueryList`s, re-evaluated on resize
 - `resize` — fired at the window when the terminal size changes, before the
   `MediaQueryList` `change` events for the same resize; `onresize` works too
-- `getSelection()` — the document selection
-- `navigator.clipboard.writeText()` — the system clipboard, over OSC 52;
-  `readText()` rejects, since terminals do not answer clipboard reads
+- `getSelection()` — the document selection, `modify()` included
+- `navigator.clipboard.writeText()` / `readText()` — the system clipboard,
+  over OSC 52, and only from inside the dispatch of a trusted user event;
+  `readText()` rejects if the terminal does not answer the query
+- `navigator.userActivation` — `hasBeenActive` and `isActive`
 - `MutationObserver`, `ResizeObserver`, `IntersectionObserver` — entries
   are delivered per rendered frame
 - `close()` — ends the session (detailed below)

--- a/scripts/wpt-dom.ts
+++ b/scripts/wpt-dom.ts
@@ -789,7 +789,7 @@ const DEVIATIONS: Array<[string, string]> = [
 	],
 	[
 		"selection/modify.tentative.html, bidi/modify-*.html, contenteditable/modify*.html, move-by-word-*.html",
-		'Selection.modify() is not implemented. Its "character" and "word" granularities could be answered from the tree. Its "line", "lineboundary", "paragraph" and remaining granularities are positions only layout knows.',
+		'Selection.modify() implements the "character", "word", "line", "lineboundary" and document-boundary granularities. "sentence" and "paragraph" do nothing. A line is a laid-out line rather than a property of the string, so the line granularities need a document mounted in a terminal; on the bare DOM this suite runs against, they do nothing.',
 	],
 	[
 		"selection/getSelection.html (excluded), and the defaultView sanity checks in it",

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -1673,7 +1673,7 @@ export class DataTransfer {
 	declare [kTransferEntries]: Map<string, string>;
 	declare [kTransferItems]: DataTransferItemList;
 	declare [kTransferFiles]: FileList;
-	declare [kTransferMode]: "readwrite" | "readonly";
+	declare [kTransferMode]: "readwrite" | "readonly" | "protected";
 	declare [kDropEffect]: string;
 	declare [kEffectAllowed]: string;
 
@@ -1713,6 +1713,9 @@ export class DataTransfer {
 	}
 
 	get types(): readonly string[] {
+		if (this[kTransferMode] === "protected") {
+			return Object.freeze([]);
+		}
 		return Object.freeze(Array.from(this[kTransferEntries].keys()));
 	}
 
@@ -1723,6 +1726,9 @@ export class DataTransfer {
 	setDragImage(_image: unknown, _x: unknown, _y: unknown): void {}
 
 	getData(format: unknown): string {
+		if (this[kTransferMode] === "protected") {
+			return "";
+		}
 		return this[kTransferEntries].get(normalizeTransferFormat(format)) ?? "";
 	}
 
@@ -1759,6 +1765,25 @@ Object.defineProperty(DataTransfer.prototype, Symbol.toStringTag, {
  */
 export function lockDataTransfer(transfer: DataTransfer): void {
 	transfer[kTransferMode] = "readonly";
+}
+
+/**
+ * Empty a transfer when the dispatch it belonged to ends: a clipboard
+ * event's payload is the listener's to read while the event runs and
+ * nothing afterward, which is what a browser hands back.
+ *
+ * This is conformance and not a boundary. An app holding a stale transfer
+ * has lost nothing it could not ask for again through
+ * `navigator.clipboard`, and it wrote the listener the payload arrived in.
+ */
+function protectClipboardData(event: Event): void {
+	if (!(event instanceof ClipboardEvent)) {
+		return;
+	}
+	const transfer = event.clipboardData;
+	if (transfer !== null) {
+		transfer[kTransferMode] = "protected";
+	}
 }
 
 export interface ClipboardEventInit extends EventInit {
@@ -2913,6 +2938,7 @@ function dispatch(
 			legacyCanceledActivationBehavior(activationTarget);
 		}
 	}
+	protectClipboardData(event);
 	return !state.canceled;
 }
 

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -68,7 +68,14 @@ export interface UAEngine {
 		invalidate(node: object): void;
 		calculateLayout(): void;
 		getRect(element: object): UARect | null;
-		lineFragments(text: object): TextareaVisualLine[];
+		lineFragments(text: object): UALineFragment[];
+		getRangeRects(range: object): UARect[];
+		caretPositionFromPoint(
+			x: number,
+			y: number,
+			root: object,
+			clampToNearestLine?: boolean,
+		): {node: UAText; offset: number} | null;
 	};
 	styles: {registerShadowRoot(root: object): void};
 	/**
@@ -97,6 +104,19 @@ type UAText = globalThis.Text;
 type UARange = globalThis.Range;
 type UARect = globalThis.DOMRect;
 type UADocument = globalThis.Document;
+
+/**
+ * One laid-out line of a text node: where it sits, and the range of the
+ * node's raw data it renders. A line is a property of the layout and not of
+ * the string, so this is the only thing that can answer "what line is this
+ * offset on" -- for a textarea's vertical motion and for the document
+ * selection's alike.
+ */
+interface UALineFragment {
+	rect: UARect;
+	startOffset: number;
+	endOffset: number;
+}
 
 const kUAEngine = Symbol("the engine a document's UA widgets render through");
 
@@ -11822,6 +11842,18 @@ function wordStartBefore(value: string, caret: number): number {
 	return at;
 }
 
+/** The mirror of wordStartBefore: where a word-wise forward move lands. */
+function wordEndAfter(value: string, caret: number): number {
+	let at = caret;
+	while (at < value.length && /\s/.test(value[at])) {
+		at++;
+	}
+	while (at < value.length && !/\s/.test(value[at])) {
+		at++;
+	}
+	return at;
+}
+
 /** An edit result whose selection is a caret collapsed at `pos`. */
 function collapsedEdit(value: string, pos: number): FieldEditResult {
 	const clamped = Math.max(0, Math.min(pos, value.length));
@@ -11921,9 +11953,13 @@ function uaStyleElement(host: Element, styles: string): UAElement {
 	return style;
 }
 
-/** The engine a document's controls render through, if it has been installed. */
+/**
+ * The engine a document's controls render through, if it has been installed.
+ * A document has no ownerDocument, so it stands for itself: the selection
+ * asks about a whole document where a control asks about a node.
+ */
 function uaEngineOf(node: object): UAEngine | undefined {
-	const document = (node as Node).ownerDocument as unknown as Record<
+	const document = ((node as Node).ownerDocument ?? node) as unknown as Record<
 		symbol,
 		UAEngine
 	> | null;
@@ -20447,10 +20483,371 @@ export class Selection {
 		);
 	}
 
+	/**
+	 * Move the caret, or drag the focus, by a unit of text -- the motion a
+	 * keyboard makes, in the one place a page can ask for it.
+	 *
+	 * `alter` is "move" (collapse where the motion lands) or "extend" (take
+	 * the focus there and leave the anchor). A "move" over a range starts
+	 * from the edge it is heading for, so a forward character move over a
+	 * selection collapses to its end without going further -- what browsers
+	 * do. "left" and "right" mean "backward" and "forward": a right-to-left
+	 * run's visual order is not followed.
+	 *
+	 * "character" and "word" are answerable from the text. "line" and
+	 * "lineboundary" are laid-out lines rather than a property of the string,
+	 * so they need a document mounted in a terminal and do nothing without
+	 * one; a line's ends are its first and last text in tree order, which is
+	 * its visual order only where the text runs left to right. "sentence",
+	 * "paragraph" and their boundaries are not implemented. Anything
+	 * unrecognized does nothing, as in a browser.
+	 */
+	modify(alter?: string, direction?: string, granularity?: string): void {
+		const how = String(alter ?? "move").toLowerCase();
+		const where = String(direction ?? "forward").toLowerCase();
+		const unit = String(granularity ?? "character").toLowerCase();
+		if (how !== "move" && how !== "extend") {
+			return;
+		}
+		const forward = where === "forward" || where === "right";
+		if (!forward && where !== "backward" && where !== "left") {
+			return;
+		}
+		const range = documentRange(this);
+		if (range === null) {
+			return;
+		}
+		const extending = how === "extend";
+		const from =
+			extending ?
+					(focusPoint(this) as [Node, number]) :
+				forward ?
+						([range[kEndNode], range[kEndOffset]] as [Node, number]) :
+						([range[kStartNode], range[kStartOffset]] as [Node, number]);
+		// Collapsing a range by a character is the whole motion: the caret
+		// lands on the edge the direction points at, not one character past it.
+		const to =
+			!extending && !range.collapsed && unit === "character" ?
+				from :
+					modifiedPoint(this, from, forward, unit);
+		if (to === null) {
+			return;
+		}
+		if (extending) {
+			this.extend(to[0], to[1]);
+			return;
+		}
+		this.setBaseAndExtent(to[0], to[1], to[0], to[1]);
+	}
+
 	toString(): string {
 		const range = this[kRange];
 		return range === null ? "" : range.toString();
 	}
+}
+
+/**
+ * The text a document paints, as one string with the text node each stretch
+ * of it came from. Character and word motion are string questions, and a
+ * caret crosses from one text node into the next without noticing, so both
+ * are asked of this rather than of a node at a time.
+ *
+ * Built per call: a selection moves at the speed of a keystroke, and a cache
+ * of the document's text would have every mutation to invalidate it.
+ */
+interface SelectionText {
+	text: string;
+	parts: Array<{node: Text; start: number}>;
+}
+
+/** One laid-out line, as offsets into the flattened text. */
+interface SelectionLine {
+	y: number;
+	start: number;
+	end: number;
+}
+
+/** Whether a text node puts anything on the screen. */
+function paintsText(
+	node: Text,
+	layout: UAEngine["layout"] | null,
+): boolean {
+	if (node[kData].length === 0) {
+		return false;
+	}
+	if (layout === null) {
+		return true;
+	}
+	for (const fragment of layout.lineFragments(node)) {
+		if (fragment.endOffset > fragment.startOffset) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/** The painted text nodes of a document, in tree order. */
+function selectionTextNodes(
+	document: Document,
+	layout: UAEngine["layout"] | null,
+): Text[] {
+	const nodes: Text[] = [];
+	const collect = (node: Node): void => {
+		for (let child = node[kFirstChild]; child !== null; child = child[kNext]) {
+			if (child.nodeType === TEXT_NODE) {
+				if (paintsText(child as Text, layout)) {
+					nodes.push(child as Text);
+				}
+			} else if (child.nodeType === ELEMENT_NODE) {
+				const name = (child as Element).localName;
+				if (name !== "script" && name !== "style" && name !== "template") {
+					collect(child);
+				}
+			}
+		}
+	};
+	const root = document.body ?? document.documentElement;
+	if (root !== null) {
+		collect(root as unknown as Node);
+	}
+	return nodes;
+}
+
+function flattenSelectionText(nodes: Text[]): SelectionText {
+	let text = "";
+	const parts: Array<{node: Text; start: number}> = [];
+	for (const node of nodes) {
+		parts.push({node, start: text.length});
+		text += node[kData];
+	}
+	return {text, parts};
+}
+
+/**
+ * Where a boundary point sits in the flattened text, or null for a point in
+ * nothing painted. An element boundary point sits before the child at its
+ * offset, so it lands on the first painted text at or after that child --
+ * and past the last child, at the end of the element's own text.
+ */
+function selectionIndexOf(
+	run: SelectionText,
+	node: Node,
+	offset: number,
+): number | null {
+	if (node.nodeType === TEXT_NODE) {
+		for (const part of run.parts) {
+			if (part.node === node) {
+				return part.start + Math.min(offset, part.node[kData].length);
+			}
+		}
+		return null;
+	}
+	let child = node[kFirstChild];
+	for (let i = 0; child !== null && i < offset; i++) {
+		child = child[kNext];
+	}
+	if (child !== null) {
+		for (const part of run.parts) {
+			if (isInclusiveAncestor(child, part.node)) {
+				return part.start;
+			}
+		}
+	}
+	let last: number | null = null;
+	for (const part of run.parts) {
+		if (isInclusiveAncestor(node, part.node)) {
+			last = part.start + part.node[kData].length;
+		}
+	}
+	return last;
+}
+
+/**
+ * The boundary point an offset into the flattened text names. An offset on
+ * the seam between two nodes belongs to the earlier one's end, which is the
+ * same position as the later one's start.
+ */
+function selectionPointAt(
+	run: SelectionText,
+	index: number,
+): [Node, number] | null {
+	const at = Math.max(0, Math.min(index, run.text.length));
+	for (const part of run.parts) {
+		if (at <= part.start + part.node[kData].length) {
+			return [part.node, at - part.start];
+		}
+	}
+	const last = run.parts[run.parts.length - 1];
+	return last === undefined ? null : [last.node, last.node[kData].length];
+}
+
+/**
+ * The document's laid-out lines, as stretches of the flattened text. Two
+ * fragments on the same row are the same line however many nodes they came
+ * from, so a row is keyed by where it sits.
+ */
+function selectionLines(
+	run: SelectionText,
+	layout: UAEngine["layout"],
+): SelectionLine[] {
+	const rows = new Map<number, SelectionLine>();
+	for (const part of run.parts) {
+		for (const fragment of layout.lineFragments(part.node)) {
+			if (fragment.endOffset <= fragment.startOffset) {
+				continue;
+			}
+			const y = Math.round(fragment.rect.y);
+			const start = part.start + fragment.startOffset;
+			const end = part.start + fragment.endOffset;
+			const row = rows.get(y);
+			if (row === undefined) {
+				rows.set(y, {y, start, end});
+			} else {
+				row.start = Math.min(row.start, start);
+				row.end = Math.max(row.end, end);
+			}
+		}
+	}
+	return [...rows.values()].sort((a, b) => a.y - b.y);
+}
+
+/**
+ * The line an offset sits on. A caret exactly at a soft wrap belongs to the
+ * next line's start -- both lines claim the offset, and the later one wins,
+ * the same rule the textarea's vertical motion follows.
+ */
+function selectionLineAt(lines: SelectionLine[], index: number): number {
+	for (let i = 0; i < lines.length; i++) {
+		if (index <= lines[i].end) {
+			const next = lines[i + 1];
+			if (next !== undefined && next.start <= index) {
+				continue;
+			}
+			return i;
+		}
+	}
+	return lines.length - 1;
+}
+
+/** The column a caret paints at, asked of the layout. */
+function caretColumnOf(
+	document: Document,
+	layout: UAEngine["layout"],
+	point: [Node, number],
+): number | null {
+	const range = document.createRange();
+	range.setStart(point[0], point[1]);
+	range.setEnd(point[0], point[1]);
+	const rect = layout.getRangeRects(range)[0];
+	return rect === undefined ? null : rect.x;
+}
+
+/**
+ * The point one laid-out line up or down, keeping the column the caret is at
+ * now. Past the first or last line the motion spends itself on that line's
+ * own end, as a browser's arrow key does.
+ *
+ * The column is a screen column and the target is a screen row, so the
+ * landing offset is the layout's own hit test -- the same answer a click
+ * there would give.
+ */
+function selectionLineMove(
+	document: Document,
+	run: SelectionText,
+	layout: UAEngine["layout"],
+	index: number,
+	forward: boolean,
+): [Node, number] | null {
+	const lines = selectionLines(run, layout);
+	if (lines.length === 0) {
+		return null;
+	}
+	const at = selectionLineAt(lines, index);
+	const target = at + (forward ? 1 : -1);
+	if (target < 0) {
+		return selectionPointAt(run, lines[0].start);
+	}
+	if (target >= lines.length) {
+		return selectionPointAt(run, lines[lines.length - 1].end);
+	}
+	const here = selectionPointAt(run, index);
+	const column = here === null ? null : caretColumnOf(document, layout, here);
+	const root = document.body ?? document.documentElement;
+	const found =
+		column === null || root === null ?
+			null :
+				layout.caretPositionFromPoint(
+					column,
+					lines[target].y,
+					root as unknown as object,
+					true,
+				);
+	if (found === null) {
+		return selectionPointAt(run, lines[target].start);
+	}
+	return [found.node as unknown as Node, found.offset];
+}
+
+/** The point the motion lands on, or null where there is nothing to do. */
+function modifiedPoint(
+	self: Selection,
+	from: [Node, number],
+	forward: boolean,
+	granularity: string,
+): [Node, number] | null {
+	const document = self[kDocument];
+	const layout = uaEngineOf(document)?.layout ?? null;
+	if (layout === null) {
+		if (granularity === "line" || granularity === "lineboundary") {
+			return null;
+		}
+	} else {
+		// Lines are read back off the layout in the same turn, so whatever the
+		// page just mutated has to be laid out before they are asked for.
+		layout.calculateLayout();
+	}
+	const run = flattenSelectionText(selectionTextNodes(document, layout));
+	if (run.parts.length === 0) {
+		return null;
+	}
+	const index = selectionIndexOf(run, from[0], from[1]);
+	if (index === null) {
+		return null;
+	}
+	if (granularity === "character") {
+		return selectionPointAt(
+			run,
+			forward ?
+					nextGraphemeBoundary(run.text, index) :
+					prevGraphemeBoundary(run.text, index),
+		);
+	}
+	if (granularity === "word") {
+		return selectionPointAt(
+			run,
+			forward ?
+					wordEndAfter(run.text, index) :
+					wordStartBefore(run.text, index),
+		);
+	}
+	if (granularity === "documentboundary") {
+		return selectionPointAt(run, forward ? run.text.length : 0);
+	}
+	if (layout === null) {
+		return null;
+	}
+	if (granularity === "lineboundary") {
+		const lines = selectionLines(run, layout);
+		if (lines.length === 0) {
+			return null;
+		}
+		const line = lines[selectionLineAt(lines, index)];
+		return selectionPointAt(run, forward ? line.end : line.start);
+	}
+	if (granularity === "line") {
+		return selectionLineMove(document, run, layout, index, forward);
+	}
+	return null;
 }
 
 /** Whether a node is in the selection's document, shadow trees included. */

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -523,18 +523,22 @@ const isTrustedProperty: PropertyDescriptor = {
 };
 
 /**
- * Whether the platform's event constructor installs isTrusted itself, as an
- * own property no one can redefine. Where it does, that property is the one
- * every event carries and it reads false; where it does not, the constructor
- * here installs the accessor above.
+ * The base this DOM's events extend.
+ *
+ * Its prototype chain reaches the platform's Event, so an event here is an
+ * instance of the global one and platform code accepts it -- but the platform
+ * constructor never runs on it. Some platforms install isTrusted as an
+ * unforgeable own property that always reads false, which an event this DOM
+ * dispatches as the user agent must be able to answer true, so the accessor
+ * an event carries has to be this DOM's. Every member the platform's base
+ * would have provided is provided below.
  */
-const hostInstallsIsTrusted = ((): boolean => {
-	const descriptor = Object.getOwnPropertyDescriptor(
-		new HostEvent("x"),
-		"isTrusted",
-	);
-	return descriptor !== undefined && !descriptor.configurable;
-})();
+const EventBase = function EventBase(): void {} as unknown as {
+	new (): HostEventInstance;
+	prototype: HostEventInstance;
+};
+
+EventBase.prototype = Object.create(HostEvent.prototype) as HostEventInstance;
 
 const kBubbles = Symbol("bubbles");
 const kCancelable = Symbol("cancelable");
@@ -545,7 +549,7 @@ const kIsMouseEvent = Symbol("is a mouse event");
 const kType = Symbol("document type");
 
 /** An event, and the flags a listener sets on it while it is dispatched. */
-export class Event extends HostEvent {
+export class Event extends EventBase {
 	declare [kType]: string;
 	declare [kBubbles]: boolean;
 	declare [kCancelable]: boolean;
@@ -562,15 +566,14 @@ export class Event extends HostEvent {
 		if (arguments.length < 1) {
 			throw new TypeError("Event constructor needs a type");
 		}
-		// The dictionary is converted once, here, and the platform base is
-		// handed the converted members: a member that is an accessor is read
-		// the one time the conversion reads it.
+		// The dictionary is converted once, here: a member that is an accessor
+		// is read the one time the conversion reads it.
 		const name = String(type);
 		const init = toDictionary<EventInit>(eventInitDict, "An event init");
 		const bubbles = Boolean(init.bubbles);
 		const cancelable = Boolean(init.cancelable);
 		const composed = Boolean(init.composed);
-		super(name, {bubbles, cancelable, composed});
+		super();
 		this[kState] = {
 			target: null,
 			relatedTarget: null,
@@ -592,9 +595,7 @@ export class Event extends HostEvent {
 		this[kComposed] = composed;
 		this[kTimeStamp] = performance.now();
 		this[kState].initialized = true;
-		if (!hostInstallsIsTrusted) {
-			Object.defineProperty(this, "isTrusted", isTrustedProperty);
-		}
+		Object.defineProperty(this, "isTrusted", isTrustedProperty);
 	}
 
 	get [kDispatchState](): DispatchState {
@@ -671,7 +672,6 @@ export class Event extends HostEvent {
 	override set cancelBubble(value: boolean) {
 		if (value) {
 			this[kState].stopPropagation = true;
-			super.stopPropagation();
 		}
 	}
 
@@ -681,13 +681,11 @@ export class Event extends HostEvent {
 
 	override stopPropagation(): void {
 		this[kState].stopPropagation = true;
-		super.stopPropagation();
 	}
 
 	override stopImmediatePropagation(): void {
 		this[kState].stopPropagation = true;
 		this[kState].stopImmediate = true;
-		super.stopImmediatePropagation();
 	}
 
 	override preventDefault(): void {
@@ -734,7 +732,11 @@ function setCanceledFlag(event: Event): void {
 	const state = event[kDispatchState];
 	if (event.cancelable && !state.inPassiveListener) {
 		state.canceled = true;
-		HostEvent.prototype.preventDefault.call(event);
+		// A platform event keeps its canceled flag on the platform half, which
+		// is where whoever handed it over will read it back.
+		if (state.foreign) {
+			HostEvent.prototype.preventDefault.call(event);
+		}
 	}
 }
 
@@ -1995,21 +1997,7 @@ export class EventTarget {
 	}
 
 	dispatchEvent(event: Event): boolean {
-		if (!(event instanceof HostEvent)) {
-			throw new TypeError("dispatchEvent needs an Event");
-		}
-		if (!(event instanceof Event)) {
-			adoptForeignEvent(event);
-		}
-		const state = event[kDispatchState];
-		if (state.dispatch || !state.initialized) {
-			throw domError(
-				"InvalidStateError",
-				"That event is already being dispatched",
-			);
-		}
-		state.trusted = false;
-		return dispatch(this, event);
+		return dispatchFromOutside(this, event, false);
 	}
 
 	/**
@@ -2418,6 +2406,50 @@ function syncForeignFlags(event: Event, state: DispatchState): void {
 }
 
 /**
+ * Dispatch an event handed in from outside this module, and say whose it is.
+ *
+ * This is the one place an event's provenance is decided. Script reaches it
+ * through dispatchEvent(), whose events are never trusted; the engine reaches
+ * it through dispatchAsUserAgent(), whose events always are. Everything the
+ * module fires itself goes through dispatch() below, which is the spec's
+ * "fire an event" and therefore trusted as well.
+ */
+function dispatchFromOutside(
+	target: EventTarget,
+	event: Event,
+	trusted: boolean,
+): boolean {
+	if (!(event instanceof HostEvent)) {
+		throw new TypeError("dispatchEvent needs an Event");
+	}
+	if (!(event instanceof Event)) {
+		adoptForeignEvent(event);
+	}
+	const state = event[kDispatchState];
+	if (state.dispatch || !state.initialized) {
+		throw domError(
+			"InvalidStateError",
+			"That event is already being dispatched",
+		);
+	}
+	return dispatch(target, event, trusted);
+}
+
+/**
+ * Dispatch an event as the user agent: the event is trusted.
+ *
+ * The engine calls this where decoded terminal input, a viewport change or a
+ * focus move becomes a DOM event -- everything a user or the terminal itself
+ * caused, as opposed to what an application constructs and dispatches.
+ */
+export function dispatchAsUserAgent(
+	target: EventTarget,
+	event: Event,
+): boolean {
+	return dispatchFromOutside(target, event, true);
+}
+
+/**
  * Dispatch an event at a target.
  *
  * The path is built once, from the target outward, and then walked twice: in
@@ -2427,9 +2459,18 @@ function syncForeignFlags(event: Event, state: DispatchState): void {
  *
  * The spec threads a legacy target override flag through here for HTML's load
  * event, which retargets to a Window; there is no Window in this DOM.
+ *
+ * Firing an event is the user agent's act, so an event dispatched here is
+ * trusted unless the caller says otherwise -- click() says otherwise, since
+ * HTML fires a synthetic, untrusted pointer event there.
  */
-function dispatch(target: EventTarget, event: Event): boolean {
+function dispatch(
+	target: EventTarget,
+	event: Event,
+	trusted = true,
+): boolean {
 	const state = event[kDispatchState];
+	state.trusted = trusted;
 	state.dispatch = true;
 	let activationTarget: EventTarget | null = null;
 	let relatedTarget = retarget(state.relatedTarget, target);
@@ -7388,7 +7429,7 @@ export class HTMLElement extends Element {
 				cancelable: true,
 				composed: true,
 			});
-			dispatch(this, event);
+			dispatch(this, event, false);
 		} finally {
 			this[kClickInProgress] = false;
 		}

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -1475,6 +1475,324 @@ Object.defineProperty(InputEvent.prototype, Symbol.toStringTag, {
 	configurable: true,
 });
 
+// A transfer here carries text under format names and nothing else. There is
+// no drag and drop in a terminal and no file to hand over, so `dropEffect`,
+// `effectAllowed`, `setDragImage()` and `files` are present, answer what the
+// interface says they answer, and do nothing.
+
+/**
+ * A transfer format name, normalized.
+ *
+ * The two shorthands the platform keeps are folded into the media types they
+ * stand for, and what is left is lowercased with the surrounding whitespace
+ * dropped, so `"TEXT/Plain "` and `"text"` name one entry.
+ */
+function normalizeTransferFormat(format: unknown): string {
+	const name = String(format).trim().toLowerCase();
+	if (name === "text") {
+		return "text/plain";
+	}
+	if (name === "url") {
+		return "text/uri-list";
+	}
+	return name;
+}
+
+/** The brand an interface with no constructor is built through internally. */
+const kInternalConstruction = Symbol("internal construction");
+
+/** A list of files, empty here because nothing in a terminal produces one. */
+export class FileList {
+	get length(): number {
+		return 0;
+	}
+
+	item(_index: number): null {
+		return null;
+	}
+
+	* [Symbol.iterator](): Generator<never, void, unknown> {}
+}
+
+Object.defineProperty(FileList.prototype, Symbol.toStringTag, {
+	value: "FileList",
+	configurable: true,
+});
+
+const kTransferEntries = Symbol("entries");
+const kTransferItems = Symbol("items");
+const kTransferFiles = Symbol("files");
+const kTransferMode = Symbol("mode");
+const kDropEffect = Symbol("dropEffect");
+const kEffectAllowed = Symbol("effectAllowed");
+
+const kItemType = Symbol("type");
+const kItemData = Symbol("data");
+
+/** One entry of a transfer: a string under a format name. */
+export class DataTransferItem {
+	declare [kItemType]: string;
+	declare [kItemData]: string;
+
+	constructor(brand?: unknown, type?: string, data?: string) {
+		if (brand !== kInternalConstruction) {
+			throw new TypeError("Illegal constructor");
+		}
+		this[kItemType] = String(type);
+		this[kItemData] = String(data);
+	}
+
+	get kind(): string {
+		return "string";
+	}
+
+	get type(): string {
+		return this[kItemType];
+	}
+
+	getAsString(callback: unknown): void {
+		if (callback === null || callback === undefined) {
+			return;
+		}
+		if (typeof callback !== "function") {
+			throw new TypeError("getAsString needs a function");
+		}
+		const data = this[kItemData];
+		queueMicrotask(() => {
+			(callback as (data: string) => void)(data);
+		});
+	}
+
+	getAsFile(): null {
+		return null;
+	}
+}
+
+Object.defineProperty(DataTransferItem.prototype, Symbol.toStringTag, {
+	value: "DataTransferItem",
+	configurable: true,
+});
+
+const kListOwner = Symbol("owner");
+const kListIndices = Symbol("indices");
+
+/** The entries of a transfer, as a list that indexes and mutates them. */
+export class DataTransferItemList {
+	declare [kListOwner]: DataTransfer;
+	declare [kListIndices]: number;
+
+	constructor(brand?: unknown, owner?: DataTransfer) {
+		if (brand !== kInternalConstruction) {
+			throw new TypeError("Illegal constructor");
+		}
+		this[kListOwner] = owner as DataTransfer;
+		this[kListIndices] = 0;
+	}
+
+	get length(): number {
+		return this[kListOwner][kTransferEntries].size;
+	}
+
+	add(data: unknown, type?: unknown): DataTransferItem | null {
+		const owner = this[kListOwner];
+		if (owner[kTransferMode] !== "readwrite") {
+			return null;
+		}
+		if (type === undefined) {
+			throw new TypeError("Adding a string entry needs a format");
+		}
+		const format = normalizeTransferFormat(type);
+		if (owner[kTransferEntries].has(format)) {
+			throw domError(
+				"NotSupportedError",
+				`The transfer already carries a ${format} entry`,
+			);
+		}
+		owner[kTransferEntries].set(format, String(data));
+		syncTransferItems(owner);
+		return (this as unknown as Record<number, DataTransferItem>)[
+			owner[kTransferEntries].size - 1
+		];
+	}
+
+	remove(index: number): void {
+		const owner = this[kListOwner];
+		if (owner[kTransferMode] !== "readwrite") {
+			throw domError(
+				"InvalidStateError",
+				"That transfer cannot be modified",
+			);
+		}
+		const formats = Array.from(owner[kTransferEntries].keys());
+		const at = toLong(index);
+		if (at < 0 || at >= formats.length) {
+			return;
+		}
+		owner[kTransferEntries].delete(formats[at]);
+		syncTransferItems(owner);
+	}
+
+	clear(): void {
+		const owner = this[kListOwner];
+		if (owner[kTransferMode] !== "readwrite") {
+			return;
+		}
+		owner[kTransferEntries].clear();
+		syncTransferItems(owner);
+	}
+}
+
+Object.defineProperty(DataTransferItemList.prototype, Symbol.toStringTag, {
+	value: "DataTransferItemList",
+	configurable: true,
+});
+
+/** Bring a list's indexed properties back in line with the entries behind it. */
+function syncTransferItems(transfer: DataTransfer): void {
+	const list = transfer[kTransferItems] as unknown as Record<number, unknown>;
+	const formats = Array.from(transfer[kTransferEntries].keys());
+	for (let i = 0; i < transfer[kTransferItems][kListIndices]; i++) {
+		delete list[i];
+	}
+	for (let i = 0; i < formats.length; i++) {
+		Object.defineProperty(list, i, {
+			value: new DataTransferItem(
+				kInternalConstruction,
+				formats[i],
+				transfer[kTransferEntries].get(formats[i]),
+			),
+			configurable: true,
+			enumerable: true,
+		});
+	}
+	transfer[kTransferItems][kListIndices] = formats.length;
+}
+
+/** The payload a clipboard event carries: text under format names. */
+export class DataTransfer {
+	declare [kTransferEntries]: Map<string, string>;
+	declare [kTransferItems]: DataTransferItemList;
+	declare [kTransferFiles]: FileList;
+	declare [kTransferMode]: "readwrite" | "readonly";
+	declare [kDropEffect]: string;
+	declare [kEffectAllowed]: string;
+
+	constructor() {
+		this[kTransferEntries] = new Map();
+		this[kTransferItems] = new DataTransferItemList(
+			kInternalConstruction,
+			this,
+		);
+		this[kTransferFiles] = new FileList();
+		this[kTransferMode] = "readwrite";
+		this[kDropEffect] = "none";
+		this[kEffectAllowed] = "uninitialized";
+	}
+
+	get dropEffect(): string {
+		return this[kDropEffect];
+	}
+
+	set dropEffect(value: string) {
+		const effect = String(value);
+		if (["none", "copy", "link", "move"].includes(effect)) {
+			this[kDropEffect] = effect;
+		}
+	}
+
+	get effectAllowed(): string {
+		return this[kEffectAllowed];
+	}
+
+	set effectAllowed(value: string) {
+		this[kEffectAllowed] = String(value);
+	}
+
+	get items(): DataTransferItemList {
+		return this[kTransferItems];
+	}
+
+	get types(): readonly string[] {
+		return Object.freeze(Array.from(this[kTransferEntries].keys()));
+	}
+
+	get files(): FileList {
+		return this[kTransferFiles];
+	}
+
+	setDragImage(_image: unknown, _x: unknown, _y: unknown): void {}
+
+	getData(format: unknown): string {
+		return this[kTransferEntries].get(normalizeTransferFormat(format)) ?? "";
+	}
+
+	setData(format: unknown, data: unknown): void {
+		if (this[kTransferMode] !== "readwrite") {
+			return;
+		}
+		this[kTransferEntries].set(normalizeTransferFormat(format), String(data));
+		syncTransferItems(this);
+	}
+
+	clearData(format?: unknown): void {
+		if (this[kTransferMode] !== "readwrite") {
+			return;
+		}
+		if (format === undefined) {
+			this[kTransferEntries].clear();
+		} else {
+			this[kTransferEntries].delete(normalizeTransferFormat(format));
+		}
+		syncTransferItems(this);
+	}
+}
+
+Object.defineProperty(DataTransfer.prototype, Symbol.toStringTag, {
+	value: "DataTransfer",
+	configurable: true,
+});
+
+/**
+ * Put a transfer into the read-only mode a `paste` hands its listeners: the
+ * text is theirs to read, and the clipboard is not theirs to rewrite through
+ * the event.
+ */
+export function lockDataTransfer(transfer: DataTransfer): void {
+	transfer[kTransferMode] = "readonly";
+}
+
+export interface ClipboardEventInit extends EventInit {
+	clipboardData?: DataTransfer | null;
+}
+
+const kClipboardData = Symbol("clipboardData");
+
+/** An event of a clipboard gesture, carrying the payload it moves. */
+export class ClipboardEvent extends Event {
+	declare [kClipboardData]: DataTransfer | null;
+
+	constructor(type: string, eventInitDict: ClipboardEventInit = {}) {
+		super(type, eventInitDict);
+		const init = toDictionary<ClipboardEventInit>(
+			eventInitDict,
+			"An event init",
+		);
+		this[kClipboardData] =
+			init.clipboardData === undefined || init.clipboardData === null ?
+				null :
+				init.clipboardData;
+	}
+
+	get clipboardData(): DataTransfer | null {
+		return this[kClipboardData];
+	}
+}
+
+Object.defineProperty(ClipboardEvent.prototype, Symbol.toStringTag, {
+	value: "ClipboardEvent",
+	configurable: true,
+});
+
 const DOM_DELTA_PIXEL = 0x00;
 const DOM_DELTA_LINE = 0x01;
 const DOM_DELTA_PAGE = 0x02;

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -169,10 +169,11 @@ const BARE_MODIFIER_KEYS = new Set([
  * rather than something happening to them.
  *
  * These are the spec's -- a key that is neither Escape nor a bare modifier, a
- * mouse press, release or click. A resize, a focus move, pointer motion and a
- * wheel tick are the user agent's events too, and none of them is a request.
- * A paste arrives as the beforeinput its text rides in on, which is the event
- * a listener sees that gesture as.
+ * mouse press, release or click, a paste. A paste's default action carries
+ * the text on to a field as a beforeinput, which is activation-triggering
+ * too: a listener that sees the gesture only there still has the gate open.
+ * A resize, a focus move, pointer motion and a wheel tick are the user
+ * agent's events too, and none of them is a request.
  */
 function isActivationTriggering(event: DOM.Event): boolean {
 	switch (event.type) {
@@ -184,6 +185,7 @@ function isActivationTriggering(event: DOM.Event): boolean {
 		case "mouseup":
 		case "click":
 		case "pointerup":
+		case "paste":
 			return true;
 		case "beforeinput":
 			return (event as DOM.InputEvent).inputType === "insertFromPaste";
@@ -501,6 +503,15 @@ export interface EngineWindow
 	KeyboardEvent: typeof globalThis.KeyboardEvent;
 	FocusEvent: typeof globalThis.FocusEvent;
 	InputEvent: typeof globalThis.InputEvent;
+	ClipboardEvent: typeof DOM.ClipboardEvent;
+	DataTransfer: typeof DOM.DataTransfer;
+	DataTransferItem: typeof DOM.DataTransferItem;
+	DataTransferItemList: typeof DOM.DataTransferItemList;
+	FileList: typeof DOM.FileList;
+	Clipboard: typeof Clipboard;
+	ClipboardItem: typeof ClipboardItem;
+	Permissions: typeof Permissions;
+	PermissionStatus: typeof PermissionStatus;
 	CompositionEvent: typeof globalThis.CompositionEvent;
 	BeforeUnloadEvent: typeof globalThis.BeforeUnloadEvent;
 	DOMException: typeof globalThis.DOMException;
@@ -1855,6 +1866,315 @@ function sealToScrollback(
 	self[kSealed] = true;
 }
 
+/** The brand an interface with no constructor is built through internally. */
+const kInternalConstruction = Symbol("internal construction");
+const kClipboardEngine = Symbol("engine");
+const kItemEntries = Symbol("entries");
+const kPermissionName = Symbol("name");
+const kPermissionEngine = Symbol("engine");
+
+/** Refuse a clipboard request the user has not asked for. */
+function clipboardDenied(why: string): Promise<never> {
+	return Promise.reject(new globalThis.DOMException(why, "NotAllowedError"));
+}
+
+/**
+ * Whether the clipboard is reachable right now, and the refusal if it is not.
+ *
+ * The clipboard is the user's to grant, so it is reachable only from a
+ * trusted activation-triggering event while it is being dispatched -- a
+ * keystroke, a mouse press or release, a click, a paste. This is stricter
+ * than a browser on purpose: a browser's transient activation outlives the
+ * dispatch that granted it, because its window is a span of time, so a
+ * handler there may await and still write the clipboard. Here the gate is the
+ * dispatch itself, and the clipboard is reachable only synchronously within
+ * it. A timer, a microtask, a resolved fetch and an event an application
+ * dispatched itself are all outside.
+ */
+function clipboardRefusal(
+	self: TermDOM,
+	what: string,
+): Promise<never> | null {
+	if (!self[kAttached] || !self[kInteractive]) {
+		return clipboardDenied(
+			"clipboard requires an attached interactive terminal",
+		);
+	}
+	if (!isUserActive(self)) {
+		return clipboardDenied(`clipboard ${what} need a user gesture`);
+	}
+	return null;
+}
+
+/** A media type, lowercased with the surrounding whitespace dropped. */
+function normalizeMediaType(type: unknown): string {
+	return String(type).trim().toLowerCase();
+}
+
+/** The payload OSC 52 carries, which is text and only text. */
+const CLIPBOARD_TEXT_TYPE = "text/plain";
+
+/**
+ * A payload the clipboard moves, held under the media types it reads as.
+ *
+ * Blob is the platform's, which Node and Bun both have as a global. OSC 52
+ * carries one payload a terminal treats as text, so text/plain is the only
+ * type a write sends and the only type a read answers with; an item may hold
+ * others, and the clipboard passes over them.
+ */
+class ClipboardItem {
+	declare [kItemEntries]: Map<string, Promise<Blob>>;
+
+	constructor(
+		items: Record<string, string | Blob | Promise<string | Blob>>,
+		_options?: unknown,
+	) {
+		if (items === null || typeof items !== "object") {
+			throw new TypeError("A clipboard item takes a record of types");
+		}
+		const entries = new Map<string, Promise<Blob>>();
+		for (const [type, value] of Object.entries(items)) {
+			const mediaType = normalizeMediaType(type);
+			entries.set(
+				mediaType,
+				Promise.resolve(value).then((held) =>
+					held instanceof Blob ?
+						held :
+							new Blob([String(held)], {type: mediaType}),
+				),
+			);
+		}
+		if (entries.size === 0) {
+			throw new TypeError("A clipboard item carries at least one type");
+		}
+		this[kItemEntries] = entries;
+	}
+
+	get types(): readonly string[] {
+		return Object.freeze(Array.from(this[kItemEntries].keys()));
+	}
+
+	getType(type: string): Promise<Blob> {
+		const held = this[kItemEntries].get(normalizeMediaType(type));
+		if (held === undefined) {
+			return Promise.reject(
+				new globalThis.DOMException(
+					`That item carries no ${normalizeMediaType(type)}`,
+					"NotFoundError",
+				),
+			);
+		}
+		return held;
+	}
+
+	static supports(type: string): boolean {
+		return normalizeMediaType(type) === CLIPBOARD_TEXT_TYPE;
+	}
+}
+
+Object.defineProperty(ClipboardItem.prototype, Symbol.toStringTag, {
+	value: "ClipboardItem",
+	configurable: true,
+});
+
+/**
+ * The clipboard, as navigator.clipboard.
+ *
+ * writeText() carries the text to the system clipboard over OSC 52, which
+ * travels in-band -- across SSH too. Terminals without OSC 52 ignore it;
+ * there is no way to know, so the promise resolves when the transport has the
+ * bytes. readText() asks for the clipboard the same way (OSC 52 with `?` for
+ * the payload) and resolves with what comes back. write() and read() are the
+ * same two round trips over a ClipboardItem.
+ *
+ * It is an EventTarget because the interface says so; the user agent fires
+ * nothing at it.
+ */
+class Clipboard extends DOM.EventTarget {
+	declare [kClipboardEngine]: TermDOM;
+
+	constructor(brand?: unknown, engine?: TermDOM) {
+		super();
+		if (brand !== kInternalConstruction) {
+			throw new TypeError("Illegal constructor");
+		}
+		this[kClipboardEngine] = engine as TermDOM;
+	}
+
+	writeText(text: string): Promise<void> {
+		const engine = this[kClipboardEngine];
+		const refusal = clipboardRefusal(engine, "writes");
+		if (refusal !== null) {
+			return refusal;
+		}
+		return engine[kSession].write(
+			`\x1b]52;c;${base64OfText(String(text))}\x07`,
+		);
+	}
+
+	async readText(): Promise<string> {
+		const engine = this[kClipboardEngine];
+		const refusal = clipboardRefusal(engine, "reads");
+		if (refusal !== null) {
+			return refusal;
+		}
+		const payload = await engine[kSession].queryClipboard();
+		if (payload === null) {
+			// Silence is a refusal: most terminals gate clipboard reads on
+			// their own configuration and answer nothing when they are off.
+			return clipboardDenied("the terminal did not answer the clipboard query");
+		}
+		return textOfBase64(payload);
+	}
+
+	async write(items: Iterable<ClipboardItem>): Promise<void> {
+		const engine = this[kClipboardEngine];
+		const refusal = clipboardRefusal(engine, "writes");
+		if (refusal !== null) {
+			return refusal;
+		}
+		let carrier: ClipboardItem | null = null;
+		for (const item of items) {
+			if (item.types.includes(CLIPBOARD_TEXT_TYPE)) {
+				carrier = item;
+				break;
+			}
+		}
+		if (carrier === null) {
+			return clipboardDenied(
+				`a clipboard write needs a ${CLIPBOARD_TEXT_TYPE} entry`,
+			);
+		}
+		const text = await (await carrier.getType(CLIPBOARD_TEXT_TYPE)).text();
+		return engine[kSession].write(`\x1b]52;c;${base64OfText(text)}\x07`);
+	}
+
+	async read(): Promise<ClipboardItem[]> {
+		const text = await this.readText();
+		return [new ClipboardItem({[CLIPBOARD_TEXT_TYPE]: text})];
+	}
+}
+
+Object.defineProperty(Clipboard.prototype, Symbol.toStringTag, {
+	value: "Clipboard",
+	configurable: true,
+});
+
+// The permission names the clipboard here answers for, and the ones the
+// Permissions API defines that a terminal has nothing behind: no camera, no
+// microphone, no location, no notification surface, so the answer is denied
+// rather than a prompt nobody could ever answer.
+const CLIPBOARD_PERMISSIONS = new Set(["clipboard-read", "clipboard-write"]);
+const UNBACKED_PERMISSIONS = new Set([
+	"accelerometer",
+	"ambient-light-sensor",
+	"background-sync",
+	"bluetooth",
+	"camera",
+	"display-capture",
+	"geolocation",
+	"gyroscope",
+	"idle-detection",
+	"local-fonts",
+	"magnetometer",
+	"microphone",
+	"midi",
+	"notifications",
+	"payment-handler",
+	"periodic-background-sync",
+	"persistent-storage",
+	"push",
+	"screen-wake-lock",
+	"speaker-selection",
+	"storage-access",
+	"window-management",
+	"xr-spatial-tracking",
+]);
+
+/**
+ * The standing of one permission.
+ *
+ * `state` is read at the moment it is asked, and for the clipboard that
+ * answer is granted while a gesture is being dispatched and prompt outside
+ * one. Nothing fires `change`: the gesture opens and closes inside a single
+ * dispatch, and a listener would be told about a state that had already
+ * passed.
+ */
+class PermissionStatus extends DOM.EventTarget {
+	declare [kPermissionName]: string;
+	declare [kPermissionEngine]: TermDOM | null;
+
+	constructor(brand?: unknown, name?: string, engine?: TermDOM) {
+		super();
+		if (brand !== kInternalConstruction) {
+			throw new TypeError("Illegal constructor");
+		}
+		this[kPermissionName] = String(name);
+		this[kPermissionEngine] = engine ?? null;
+	}
+
+	get name(): string {
+		return this[kPermissionName];
+	}
+
+	get state(): string {
+		const engine = this[kPermissionEngine];
+		if (engine === null || !CLIPBOARD_PERMISSIONS.has(this[kPermissionName])) {
+			return "denied";
+		}
+		if (!engine[kAttached] || !engine[kInteractive]) {
+			return "denied";
+		}
+		return isUserActive(engine) ? "granted" : "prompt";
+	}
+}
+
+DOM.installEventHandlers(PermissionStatus.prototype, ["onchange"]);
+
+Object.defineProperty(PermissionStatus.prototype, Symbol.toStringTag, {
+	value: "PermissionStatus",
+	configurable: true,
+});
+
+/** navigator.permissions: what the gate above answers, asked by name. */
+class Permissions extends DOM.EventTarget {
+	declare [kPermissionEngine]: TermDOM;
+
+	constructor(brand?: unknown, engine?: TermDOM) {
+		super();
+		if (brand !== kInternalConstruction) {
+			throw new TypeError("Illegal constructor");
+		}
+		this[kPermissionEngine] = engine as TermDOM;
+	}
+
+	query(descriptor: {name?: string}): Promise<PermissionStatus> {
+		if (descriptor === null || typeof descriptor !== "object") {
+			return Promise.reject(
+				new TypeError("A permission query takes a descriptor"),
+			);
+		}
+		const name = String(descriptor.name);
+		if (!CLIPBOARD_PERMISSIONS.has(name) && !UNBACKED_PERMISSIONS.has(name)) {
+			return Promise.reject(
+				new TypeError(`"${name}" is not a permission name`),
+			);
+		}
+		return Promise.resolve(
+			new PermissionStatus(
+				kInternalConstruction,
+				name,
+				this[kPermissionEngine],
+			),
+		);
+	}
+}
+
+Object.defineProperty(Permissions.prototype, Symbol.toStringTag, {
+	value: "Permissions",
+	configurable: true,
+});
+
 function installWindowExtensions(
 	self: TermDOM,
 ): void {
@@ -2104,61 +2424,27 @@ function installWindowExtensions(
 		});
 	}
 
-	// navigator.clipboard: writeText() carries the text to the system
-	// clipboard over OSC 52, which travels in-band -- across SSH too.
-	// Terminals without OSC 52 ignore it; there is no way to know, so the
-	// promise resolves when the transport has the bytes. readText() asks for
-	// the clipboard the same way (OSC 52 with `?` for the payload) and
-	// resolves with what comes back.
+	// The clipboard and the permission it stands behind, which the classes
+	// above implement over OSC 52.
 	//
-	// Both are the user's to grant, so both are reachable only from a trusted
-	// activation-triggering event while it is being dispatched -- a keystroke,
-	// a mouse press or release, a click, a paste. This is stricter than a
-	// browser on purpose: a browser's transient activation outlives the
-	// dispatch that granted it, because its window is a span of time, so a
-	// handler there may await and still write the clipboard. Here the gate is
-	// the dispatch itself, and the clipboard is reachable only synchronously
-	// within it. A timer, a microtask, a resolved fetch and an event an
-	// application dispatched itself are all outside.
-	const clipboardDenied = (why: string): Promise<never> =>
-		Promise.reject(
-			new (window as any).DOMException(why, "NotAllowedError"),
-		);
+	// `copy` and `cut` are here as interfaces and event types, so a listener
+	// attaches and an application can build one and dispatch it, and the user
+	// agent fires neither. The terminal keeps the copy gesture for itself --
+	// Cmd+C, Shift+drag -- and does not report it, and Ctrl+C is the
+	// interrupt. A document learns of a copy the terminal made only by
+	// writing the clipboard itself.
+	Object.assign(window as unknown as Record<string, unknown>, {
+		Clipboard,
+		ClipboardItem,
+		Permissions,
+		PermissionStatus,
+	});
 	Object.defineProperty(window.navigator, "clipboard", {
-		value: {
-			writeText: (text: string): Promise<void> => {
-				if (!termDOM[kAttached] || !termDOM[kInteractive]) {
-					return clipboardDenied(
-						"clipboard requires an attached interactive terminal",
-					);
-				}
-				if (!isUserActive(termDOM)) {
-					return clipboardDenied("clipboard writes need a user gesture");
-				}
-				return termDOM[kSession].write(
-					`\x1b]52;c;${base64OfText(String(text))}\x07`,
-				);
-			},
-			readText: async (): Promise<string> => {
-				if (!termDOM[kAttached] || !termDOM[kInteractive]) {
-					return clipboardDenied(
-						"clipboard requires an attached interactive terminal",
-					);
-				}
-				if (!isUserActive(termDOM)) {
-					return clipboardDenied("clipboard reads need a user gesture");
-				}
-				const payload = await termDOM[kSession].queryClipboard();
-				if (payload === null) {
-					// Silence is a refusal: most terminals gate clipboard reads on
-					// their own configuration and answer nothing when they are off.
-					return clipboardDenied(
-						"the terminal did not answer the clipboard query",
-					);
-				}
-				return textOfBase64(payload);
-			},
-		},
+		value: new Clipboard(kInternalConstruction, termDOM),
+		configurable: true,
+	});
+	Object.defineProperty(window.navigator, "permissions", {
+		value: new Permissions(kInternalConstruction, termDOM),
 		configurable: true,
 	});
 
@@ -3457,8 +3743,12 @@ function handleMouseReport(
 }
 
 /**
- * Deliver a paste to the focused control as an `insertFromPaste` beforeinput;
- * its own listener does the edit. Dropped if nothing editable is focused.
+ * Deliver a paste as a `paste` event carrying the text, at the focused
+ * element or at the body when nothing is focused. A paste nobody cancels
+ * runs its default action: into a text field, an `insertFromPaste`
+ * beforeinput whose listener does the edit. Anywhere else the event is the
+ * whole of it, and an application that wants the text reads it off
+ * `clipboardData`.
  */
 function dispatchPaste(
 	self: TermDOM,
@@ -3470,19 +3760,32 @@ function dispatchPaste(
 	// boundary, so a multi-line paste into a textarea is multi-line and
 	// a field's own handlers never see a bare CR.
 	text = text.replace(/\r\n?/g, "\n");
-	const target = self.document.activeElement;
-	if (!target || target === self.document.body) {
-		return;
-	}
-	fireAsUserAgent(
+	const focused = self.document.activeElement;
+	const target =
+		focused && focused !== self.document.body ? focused : self.document.body;
+	const clipboardData = new DOM.DataTransfer();
+	clipboardData.setData("text/plain", text);
+	DOM.lockDataTransfer(clipboardData);
+	const proceed = fireAsUserAgent(
 		target,
-		new self.window.InputEvent("beforeinput", {
-			inputType: "insertFromPaste",
-			data: text,
+		new self.window.ClipboardEvent("paste", {
+			clipboardData,
 			bubbles: true,
 			cancelable: true,
 		}),
 	);
+	const tag = target.tagName;
+	if (proceed && (tag === "INPUT" || tag === "TEXTAREA")) {
+		fireAsUserAgent(
+			target,
+			new self.window.InputEvent("beforeinput", {
+				inputType: "insertFromPaste",
+				data: text,
+				bubbles: true,
+				cancelable: true,
+			}),
+		);
+	}
 	void render(self);
 }
 

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -76,6 +76,24 @@ function base64OfText(text: string): string {
 	return out;
 }
 
+/** The inverse: what OSC 52 answers a clipboard query with, as text. */
+function textOfBase64(payload: string): string {
+	const digits = payload.replace(/[^A-Za-z0-9+/]/g, "");
+	const bytes = new Uint8Array((digits.length * 3) >> 2);
+	let at = 0;
+	let bits = 0;
+	let held = 0;
+	for (const digit of digits) {
+		held = (held << 6) | BASE64_ALPHABET.indexOf(digit);
+		bits += 6;
+		if (bits >= 8) {
+			bits -= 8;
+			bytes[at++] = (held >> bits) & 0xff;
+		}
+	}
+	return new TextDecoder().decode(bytes.subarray(0, at));
+}
+
 // The built-in tags that upgrade to a UA widget on connect.
 const UPGRADEABLE_CONTROLS = new Set([
 	"DETAILS",
@@ -114,6 +132,66 @@ function upgradeControlsIn(root: Element): void {
 // closing over one.
 const engines = new WeakMap<object, TermDOM>();
 
+/** The engine an event target belongs to, if it is mounted in one. */
+function engineOfTarget(target: unknown): TermDOM | undefined {
+	const node = target as Node | null;
+	if (!node || typeof node.nodeType !== "number") {
+		return undefined;
+	}
+	const document =
+		node.nodeType === node.DOCUMENT_NODE ? node : node.ownerDocument;
+	return document === null ? undefined : engines.get(document);
+}
+
+/**
+ * The keys that are a modifier and nothing else, which a user pressing them
+ * has not yet asked for anything with.
+ */
+const BARE_MODIFIER_KEYS = new Set([
+	"Alt",
+	"AltGraph",
+	"CapsLock",
+	"Control",
+	"Fn",
+	"FnLock",
+	"Hyper",
+	"Meta",
+	"NumLock",
+	"ScrollLock",
+	"Shift",
+	"Super",
+	"Symbol",
+	"SymbolLock",
+]);
+
+/**
+ * Whether an event is activation-triggering: the user asking for something,
+ * rather than something happening to them.
+ *
+ * These are the spec's -- a key that is neither Escape nor a bare modifier, a
+ * mouse press, release or click. A resize, a focus move, pointer motion and a
+ * wheel tick are the user agent's events too, and none of them is a request.
+ * A paste arrives as the beforeinput its text rides in on, which is the event
+ * a listener sees that gesture as.
+ */
+function isActivationTriggering(event: DOM.Event): boolean {
+	switch (event.type) {
+		case "keydown": {
+			const key = (event as DOM.KeyboardEvent).key;
+			return key !== "Escape" && !BARE_MODIFIER_KEYS.has(key);
+		}
+		case "mousedown":
+		case "mouseup":
+		case "click":
+		case "pointerup":
+			return true;
+		case "beforeinput":
+			return (event as DOM.InputEvent).inputType === "insertFromPaste";
+		default:
+			return false;
+	}
+}
+
 /**
  * Fire an event as the user agent.
  *
@@ -122,12 +200,33 @@ const engines = new WeakMap<object, TermDOM>();
  * made -- so it is the user agent's, and reads isTrusted true. Provenance is
  * decided here, once, for all of them: an event an application constructs and
  * hands to dispatchEvent() is script's, and is never trusted.
+ *
+ * An activation-triggering event also holds user activation open for as long
+ * as its dispatch runs, which is what the clipboard asks about.
  */
 function fireAsUserAgent(target: unknown, event: unknown): boolean {
-	return DOM.dispatchAsUserAgent(
-		target as DOM.EventTarget,
-		event as DOM.Event,
-	);
+	const self = engineOfTarget(target);
+	if (self === undefined || !isActivationTriggering(event as DOM.Event)) {
+		return DOM.dispatchAsUserAgent(
+			target as DOM.EventTarget,
+			event as DOM.Event,
+		);
+	}
+	self[kActivationDepth]++;
+	self[kEverActivated] = true;
+	try {
+		return DOM.dispatchAsUserAgent(
+			target as DOM.EventTarget,
+			event as DOM.Event,
+		);
+	} finally {
+		self[kActivationDepth]--;
+	}
+}
+
+/** Whether an activation-triggering event is being dispatched right now. */
+function isUserActive(self: TermDOM): boolean {
+	return self[kActivationDepth] > 0;
 }
 
 export {
@@ -569,6 +668,8 @@ const kPrototypesInstalled = Symbol("prototypesInstalled");
 const kScreenSwitching = Symbol("screenSwitching");
 const kRenderInFlight = Symbol("renderInFlight");
 const kInputGeneration = Symbol("inputGeneration");
+const kActivationDepth = Symbol("activationDepth");
+const kEverActivated = Symbol("everActivated");
 const kMouseCaptureYielded = Symbol("mouseCaptureYielded");
 const kAttachBeginning = Symbol("attachBeginning");
 const kAttachBegun = Symbol("attachBegun");
@@ -685,6 +786,13 @@ export class TermDOM {
 	// change without mutations; repaint-and-diff is what detects them, so
 	// every input path bumps this and the clean-frame skip compares it.
 	declare [kInputGeneration]: number;
+	/**
+	 * How many activation-triggering events are being dispatched right now,
+	 * and whether one ever has been. What only a user may ask for is asked of
+	 * these, and nothing else writes them.
+	 */
+	declare [kActivationDepth]: number;
+	declare [kEverActivated]: boolean;
 	declare [kLastFrameInputGeneration]: number;
 	declare [kLastFrameActiveElement]: Element | null;
 	declare [kLastFrameStructuralGeneration]: number;
@@ -791,6 +899,8 @@ export class TermDOM {
 		this[kLastFrameScrollTop] = null;
 		this[kLastFrameEpoch] = -1;
 		this[kInputGeneration] = 0;
+		this[kActivationDepth] = 0;
+		this[kEverActivated] = false;
 		this[kLastFrameInputGeneration] = -1;
 		this[kLastFrameActiveElement] = null;
 		this[kLastFrameStructuralGeneration] = -1;
@@ -1997,31 +2107,71 @@ function installWindowExtensions(
 	// navigator.clipboard: writeText() carries the text to the system
 	// clipboard over OSC 52, which travels in-band -- across SSH too.
 	// Terminals without OSC 52 ignore it; there is no way to know, so the
-	// promise resolves when the transport has the bytes. readText()
-	// rejects: terminals do not answer clipboard queries to untrusted
-	// programs, and pretending otherwise would hang.
+	// promise resolves when the transport has the bytes. readText() asks for
+	// the clipboard the same way (OSC 52 with `?` for the payload) and
+	// resolves with what comes back.
+	//
+	// Both are the user's to grant, so both are reachable only from a trusted
+	// activation-triggering event while it is being dispatched -- a keystroke,
+	// a mouse press or release, a click, a paste. This is stricter than a
+	// browser on purpose: a browser's transient activation outlives the
+	// dispatch that granted it, because its window is a span of time, so a
+	// handler there may await and still write the clipboard. Here the gate is
+	// the dispatch itself, and the clipboard is reachable only synchronously
+	// within it. A timer, a microtask, a resolved fetch and an event an
+	// application dispatched itself are all outside.
+	const clipboardDenied = (why: string): Promise<never> =>
+		Promise.reject(
+			new (window as any).DOMException(why, "NotAllowedError"),
+		);
 	Object.defineProperty(window.navigator, "clipboard", {
 		value: {
 			writeText: (text: string): Promise<void> => {
 				if (!termDOM[kAttached] || !termDOM[kInteractive]) {
-					return Promise.reject(
-						new (window as any).DOMException(
-							"clipboard requires an attached interactive terminal",
-							"NotAllowedError",
-						),
+					return clipboardDenied(
+						"clipboard requires an attached interactive terminal",
 					);
+				}
+				if (!isUserActive(termDOM)) {
+					return clipboardDenied("clipboard writes need a user gesture");
 				}
 				return termDOM[kSession].write(
 					`\x1b]52;c;${base64OfText(String(text))}\x07`,
 				);
 			},
-			readText: (): Promise<string> =>
-				Promise.reject(
-					new (window as any).DOMException(
-						"the terminal does not expose clipboard reads",
-						"NotAllowedError",
-					),
-				),
+			readText: async (): Promise<string> => {
+				if (!termDOM[kAttached] || !termDOM[kInteractive]) {
+					return clipboardDenied(
+						"clipboard requires an attached interactive terminal",
+					);
+				}
+				if (!isUserActive(termDOM)) {
+					return clipboardDenied("clipboard reads need a user gesture");
+				}
+				const payload = await termDOM[kSession].queryClipboard();
+				if (payload === null) {
+					// Silence is a refusal: most terminals gate clipboard reads on
+					// their own configuration and answer nothing when they are off.
+					return clipboardDenied(
+						"the terminal did not answer the clipboard query",
+					);
+				}
+				return textOfBase64(payload);
+			},
+		},
+		configurable: true,
+	});
+
+	// navigator.userActivation: the same two questions the gate above asks,
+	// as the page can ask them.
+	Object.defineProperty(window.navigator, "userActivation", {
+		value: {
+			get hasBeenActive(): boolean {
+				return termDOM[kEverActivated];
+			},
+			get isActive(): boolean {
+				return isUserActive(termDOM);
+			},
 		},
 		configurable: true,
 	});
@@ -3489,10 +3639,19 @@ function dispatchGlobalKeyboardEvent(
 				(keyName === "Enter" && activation.enter) ||
 				(key === " " && activation.space)
 			) {
-				// click() rather than a synthesized event: it runs the element's
-				// full activation behavior, so a submit button submits its form
-				// and a link follows its href, exactly as a mouse click would.
-				(targetElement as HTMLElement).click();
+				// The user agent's own click, not click()'s synthetic one: it
+				// is trusted, as the click a browser generates for keyboard
+				// activation is, and dispatching it runs the element's full
+				// activation behavior, so a submit button submits its form and
+				// a link follows its href, exactly as a mouse click would.
+				fireAsUserAgent(
+					targetElement,
+					new self.window.PointerEvent("click", {
+						bubbles: true,
+						cancelable: true,
+						composed: true,
+					}),
+				);
 				render(self);
 			}
 		}

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -114,6 +114,22 @@ function upgradeControlsIn(root: Element): void {
 // closing over one.
 const engines = new WeakMap<object, TermDOM>();
 
+/**
+ * Fire an event as the user agent.
+ *
+ * Every event this file dispatches comes from outside the document -- decoded
+ * terminal input, a terminal that resized, a focus move the engine itself
+ * made -- so it is the user agent's, and reads isTrusted true. Provenance is
+ * decided here, once, for all of them: an event an application constructs and
+ * hands to dispatchEvent() is script's, and is never trusted.
+ */
+function fireAsUserAgent(target: unknown, event: unknown): boolean {
+	return DOM.dispatchAsUserAgent(
+		target as DOM.EventTarget,
+		event as DOM.Event,
+	);
+}
+
 export {
 	transportFromProcess,
 	type TerminalTransport,
@@ -280,7 +296,7 @@ function fireFullscreenChangeEvent(
 	// Per spec: fired on the element, and it BUBBLES -- document listeners
 	// hear it through the bubble; dispatching on the document as well
 	// delivered every transition twice.
-	element.dispatchEvent(event);
+	fireAsUserAgent(element, event);
 }
 
 function fireFullscreenErrorEvent(
@@ -300,8 +316,10 @@ function fireFullscreenErrorEvent(
 	});
 
 	// Fire on both element and document
-	element.dispatchEvent(event);
-	element.ownerDocument?.dispatchEvent(event);
+	fireAsUserAgent(element, event);
+	if (element.ownerDocument) {
+		fireAsUserAgent(element.ownerDocument, event);
+	}
 }
 
 function getWindow(
@@ -1363,26 +1381,30 @@ export class TermDOM {
 				termDOM[kStyleManager].handleFocusChange(prev, this);
 				void render(termDOM);
 				if (prev && prev !== document.body) {
-					prev.dispatchEvent(
+					fireAsUserAgent(
+						prev,
 						new window.FocusEvent("blur", {
 							relatedTarget: this,
 							bubbles: false,
 						}),
 					);
-					prev.dispatchEvent(
+					fireAsUserAgent(
+						prev,
 						new window.FocusEvent("focusout", {
 							relatedTarget: this,
 							bubbles: true,
 						}),
 					);
 				}
-				this.dispatchEvent(
+				fireAsUserAgent(
+					this,
 					new window.FocusEvent("focus", {
 						relatedTarget: prev,
 						bubbles: false,
 					}),
 				);
-				this.dispatchEvent(
+				fireAsUserAgent(
+					this,
 					new window.FocusEvent("focusin", {
 						relatedTarget: prev,
 						bubbles: true,
@@ -1398,13 +1420,15 @@ export class TermDOM {
 			if (wasFocused) {
 				termDOM[kStyleManager].handleFocusChange(this);
 				void render(termDOM);
-				this.dispatchEvent(
+				fireAsUserAgent(
+					this,
 					new window.FocusEvent("blur", {
 						relatedTarget: null,
 						bubbles: false,
 					}),
 				);
-				this.dispatchEvent(
+				fireAsUserAgent(
+					this,
 					new window.FocusEvent("focusout", {
 						relatedTarget: null,
 						bubbles: true,
@@ -1907,7 +1931,7 @@ function installWindowExtensions(
 				matches: {value: now, enumerable: true},
 				media: {value: media, enumerable: true},
 			});
-			mql.dispatchEvent(event);
+			fireAsUserAgent(mql, event);
 		});
 		return mql as MediaQueryList;
 	}) as typeof window.matchMedia;
@@ -1924,7 +1948,7 @@ function installWindowExtensions(
 		// user says yes. Every close asks: the event carries nothing from
 		// the last one.
 		const unloadEvent = DOM.createBeforeUnloadEvent();
-		(window as unknown as DOM.EventTarget).dispatchEvent(unloadEvent);
+		fireAsUserAgent(window, unloadEvent);
 		if (unloadEvent.defaultPrevented || unloadEvent.returnValue !== "") {
 			return;
 		}
@@ -2274,7 +2298,7 @@ function applyTerminalSize(
 	// Per the rendering steps, resize fires before media query "change"
 	// events, and everything a listener reads already has the new size.
 	if (sizeChanged) {
-		self.window.dispatchEvent(new self.window.Event("resize"));
+		fireAsUserAgent(self.window, new self.window.Event("resize"));
 	}
 	for (const update of self[kMediaQueryUpdaters]) {
 		update();
@@ -2995,7 +3019,8 @@ function handleMouseReport(
 		(point && findElementAtDocumentPoint(self, x, y)) || self.document.body;
 
 	if (wheelDeltaY !== null) {
-		const notCanceled = target.dispatchEvent(
+		const notCanceled = fireAsUserAgent(
+			target,
 			new self.window.WheelEvent("wheel", {
 				deltaY: wheelDeltaY,
 				deltaMode: 1, // DOM_DELTA_LINE
@@ -3058,7 +3083,10 @@ function handleMouseReport(
 	};
 
 	if (isMotion) {
-		target.dispatchEvent(new self.window.MouseEvent("mousemove", eventInit));
+		fireAsUserAgent(
+			target,
+			new self.window.MouseEvent("mousemove", eventInit),
+		);
 		// A field drag extends the field's own selection to the offset
 		// under the pointer -- clamped into the field, whichever element
 		// the pointer is over now (the field holds the capture).
@@ -3110,7 +3138,8 @@ function handleMouseReport(
 			self[kStyleManager].handleFocusChange(self.document.activeElement);
 			void render(self);
 		}
-		const notCanceled = target.dispatchEvent(
+		const notCanceled = fireAsUserAgent(
+			target,
 			new self.window.MouseEvent("mousedown", eventInit),
 		);
 		// Default action: mousedown moves focus, exactly as in a browser --
@@ -3187,7 +3216,7 @@ function handleMouseReport(
 		return;
 	}
 
-	target.dispatchEvent(new self.window.MouseEvent("mouseup", eventInit));
+	fireAsUserAgent(target, new self.window.MouseEvent("mouseup", eventInit));
 	// LIGHT DISMISS: a release closes every auto popover the released
 	// point is not inside of and did not open -- the invoker of a popover
 	// counts as part of it, so the click that follows toggles rather than
@@ -3224,7 +3253,8 @@ function handleMouseReport(
 		return;
 	}
 	if (self[kMouseDownTarget] === target) {
-		target.dispatchEvent(
+		fireAsUserAgent(
+			target,
 			new self.window.MouseEvent("click", {...eventInit, buttons: 0}),
 		);
 		// A checkbox/radio's .checked already flipped -- the activation behavior's
@@ -3262,7 +3292,8 @@ function handleMouseReport(
 			self[kLastClickTarget] === target &&
 			now - self[kLastClickTime] <= TermDOM[kDBLCLICK_INTERVAL_MS]
 		) {
-			target.dispatchEvent(
+			fireAsUserAgent(
+				target,
 				new self.window.MouseEvent("dblclick", {...eventInit, buttons: 0}),
 			);
 			self[kLastClickTarget] = null;
@@ -3293,7 +3324,8 @@ function dispatchPaste(
 	if (!target || target === self.document.body) {
 		return;
 	}
-	target.dispatchEvent(
+	fireAsUserAgent(
+		target,
 		new self.window.InputEvent("beforeinput", {
 			inputType: "insertFromPaste",
 			data: text,
@@ -3322,7 +3354,8 @@ function dispatchInsertText(
 	if (tag !== "INPUT" && tag !== "TEXTAREA") {
 		return;
 	}
-	target.dispatchEvent(
+	fireAsUserAgent(
+		target,
 		new self.window.InputEvent("beforeinput", {
 			inputType: "insertText",
 			data: text,
@@ -3410,7 +3443,7 @@ function dispatchGlobalKeyboardEvent(
 		cancelable: true,
 	});
 
-	const notCanceled = targetElement.dispatchEvent(keydownEvent);
+	const notCanceled = fireAsUserAgent(targetElement, keydownEvent);
 
 	// Escape is a CLOSE REQUEST on whatever is on top of the top layer and
 	// answers one: a modal dialog fires cancel and closes unless a
@@ -3487,7 +3520,7 @@ function dispatchGlobalKeyboardEvent(
 			bubbles: true,
 			cancelable: true,
 		});
-		if (targetElement.dispatchEvent(keypressEvent)) {
+		if (fireAsUserAgent(targetElement, keypressEvent)) {
 			dispatchInsertText(self, targetElement, key);
 		}
 	}
@@ -3506,7 +3539,7 @@ function dispatchGlobalKeyboardEvent(
 		bubbles: true,
 		cancelable: true,
 	});
-	targetElement.dispatchEvent(keyupEvent);
+	fireAsUserAgent(targetElement, keyupEvent);
 }
 
 /**

--- a/src/internal/terminalsession.ts
+++ b/src/internal/terminalsession.ts
@@ -434,6 +434,11 @@ const kCursorDetectionPromise = Symbol("cursorDetectionPromise");
 const kModeProbeTimers = Symbol("modeProbeTimers");
 const kPriorBidiMode = Symbol("priorBidiMode");
 const kCursorDetectionTimer = Symbol("cursorDetectionTimer");
+const kClipboardHandler = Symbol("clipboardHandler");
+const kClipboardTimer = Symbol("clipboardTimer");
+const kClipboardBuffer = Symbol("clipboardBuffer");
+const kClipboardQueryTimeout = Symbol("clipboardQueryTimeout");
+const kClipboardReplyLimit = Symbol("clipboardReplyLimit");
 
 export class TerminalSession {
 	declare [kTransport]: TerminalTransport;
@@ -480,6 +485,18 @@ export class TerminalSession {
 	 */
 	declare [kModeProbeHandlers]: Map<string, (value: number) => void>;
 	declare [kModeProbeTimers]: Set<ReturnType<typeof setTimeout>>;
+	/**
+	 * The outstanding OSC 52 clipboard query: the handler its reply resolves,
+	 * the timeout that gives up on it, and the half of a reply held for the
+	 * next chunk. One query at a time -- the reply carries no sequence, so a
+	 * second would have nothing to be told apart by.
+	 *
+	 * The buffer is only ever non-null while a query is outstanding, so a
+	 * typed ESC ] is routed as keystrokes exactly as before.
+	 */
+	declare [kClipboardHandler]: ((payload: string | null) => void) | null;
+	declare [kClipboardTimer]: ReturnType<typeof setTimeout> | null;
+	declare [kClipboardBuffer]: string | null;
 	/** The BDSM state the terminal reported before we touched it, for dispose. */
 	declare [kPriorBidiMode]: number | null;
 	/** Whether the terminal agreed to grapheme-cluster widths (mode 2027). */
@@ -561,6 +578,19 @@ export class TerminalSession {
 	 * animating, typing or scrolling carries the train for free.
 	 */
 	static readonly [kWidthStarvationWait] = 500;
+	/**
+	 * How long a clipboard query waits. Short on purpose: most terminals
+	 * refuse clipboard reads and refusing is silence, so this is the delay
+	 * every navigator.clipboard.readText() pays before rejecting. A terminal
+	 * that does answer answers at typing latency.
+	 */
+	static readonly [kClipboardQueryTimeout] = 500;
+	/**
+	 * The most of a clipboard reply that is held while its terminator is
+	 * awaited. A larger payload is not a clipboard the terminal is answering
+	 * with, and the query gives up rather than buffer the wire.
+	 */
+	static readonly [kClipboardReplyLimit] = 1 << 16;
 
 	declare [kWidthMeasurer]: WidthMeasurer;
 
@@ -603,6 +633,9 @@ export class TerminalSession {
 		this[kCursorDetectionPromise] = null;
 		this[kModeProbeHandlers] = new Map<string, (value: number) => void>();
 		this[kModeProbeTimers] = new Set<ReturnType<typeof setTimeout>>();
+		this[kClipboardHandler] = null;
+		this[kClipboardTimer] = null;
+		this[kClipboardBuffer] = null;
 		this[kPriorBidiMode] = null;
 		this[kGraphemeClustersNegotiated] = false;
 		this[kDsrSequence] = 0;
@@ -969,6 +1002,32 @@ export class TerminalSession {
 	}
 
 	/**
+	 * Ask the terminal for the system clipboard (OSC 52 with `?` where the
+	 * payload goes) and resolve with the base64 the reply carries -- the
+	 * bytes verbatim, since decoding them is the caller's business.
+	 *
+	 * Resolves null when the terminal says nothing before the timeout, which
+	 * is what most of them say: a clipboard read is a capability terminals
+	 * gate on their own configuration, and refusing it looks like silence.
+	 * One query at a time; a second while one is outstanding replaces it, and
+	 * the replaced one resolves null.
+	 */
+	queryClipboard(): Promise<string | null> {
+		if (!this[kInteractive] || this[kDisposed]) {
+			return Promise.resolve(null);
+		}
+		return new Promise<string | null>((resolve) => {
+			settleClipboardQuery(this, null);
+			const timer = setTimeout(() => {
+				settleClipboardQuery(this, null);
+			}, TerminalSession[kClipboardQueryTimeout]);
+			this[kClipboardTimer] = timer;
+			this[kClipboardHandler] = resolve;
+			void this.write("\x1b]52;c;?\x07");
+		});
+	}
+
+	/**
 	 * Hand the terminal back the modes we changed, release the transport, and
 	 * tear down every timer and handler that would otherwise keep the event
 	 * loop open. Only modes we actually set are restored -- reset is where the
@@ -993,6 +1052,7 @@ export class TerminalSession {
 			void this.write("\x1b[?2027l");
 			this[kGraphemeClustersNegotiated] = false;
 		}
+		settleClipboardQuery(this, null);
 		for (const timer of this[kModeProbeTimers]) {
 			clearTimeout(timer);
 		}
@@ -1253,6 +1313,19 @@ function route(
 		return;
 	}
 
+	// The clipboard reply, while one is asked for: its base64 body would not
+	// survive tokenization, and it can arrive split, so it is taken out of
+	// the chunk before anything else looks at it.
+	if (self[kClipboardHandler] !== null) {
+		const rest = routeClipboardReply(self, dataStr);
+		if (rest !== null) {
+			if (rest.length > 0) {
+				route(self, rest);
+			}
+			return;
+		}
+	}
+
 	// Replies (highest priority): the terminal's answer about a mode
 	// (DECRPM) or the cursor position (DSR). Fast typing can land in the
 	// same chunk as a report -- "jjj\x1b[12;1Rjjj" -- so hand the report to
@@ -1310,6 +1383,68 @@ function route(
 	}
 
 	self[kHandlers].onKeys(keyInput);
+}
+
+/**
+ * Answer the outstanding clipboard query and forget it. Called with the
+ * payload the terminal sent, or null wherever the query ends without one:
+ * the timeout, a replacement query, dispose.
+ */
+function settleClipboardQuery(
+	self: TerminalSession,
+	payload: string | null,
+): void {
+	const waiting = self[kClipboardHandler];
+	if (self[kClipboardTimer] !== null) {
+		clearTimeout(self[kClipboardTimer]);
+		self[kClipboardTimer] = null;
+	}
+	self[kClipboardHandler] = null;
+	self[kClipboardBuffer] = null;
+	waiting?.(payload);
+}
+
+/**
+ * Take the OSC 52 reply out of a chunk that may also hold typing, or say the
+ * chunk is not one. Returns the remainder to route on as ordinary input, or
+ * null for "no reply here, route the whole chunk yourself".
+ *
+ * An OSC carries base64 and ends in BEL or ST, and no other branch of the
+ * route table knows either, so a reply split across chunks would be shredded
+ * into keystrokes. It is held whole here instead -- only while a query is
+ * outstanding, so nothing a user types is ever held.
+ */
+function routeClipboardReply(
+	self: TerminalSession,
+	dataStr: string,
+): string | null {
+	let chunk = dataStr;
+	if (self[kClipboardBuffer] !== null) {
+		chunk = self[kClipboardBuffer] + chunk;
+		self[kClipboardBuffer] = null;
+	}
+	const start = chunk.indexOf("\x1b]52;");
+	if (start === -1) {
+		return null;
+	}
+	const before = chunk.slice(0, start);
+	const reply = chunk
+		.slice(start)
+		.match(/^\x1b\]52;[^;]*;([^\x07\x1b]*)(?:\x07|\x1b\\)/);
+	if (!reply) {
+		// The terminator has not arrived. Hold the fragment for the next chunk
+		// and let whatever preceded it through as input.
+		const held = chunk.slice(start);
+		if (held.length <= TerminalSession[kClipboardReplyLimit]) {
+			self[kClipboardBuffer] = held;
+			return before;
+		}
+		settleClipboardQuery(self, null);
+		return before;
+	}
+	const rest = before + chunk.slice(start + reply[0].length);
+	settleClipboardQuery(self, reply[1]);
+	return rest;
 }
 
 /** Route a DECRPM mode reply to whichever negotiation is waiting on it. */

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -316,3 +316,305 @@ test("Enter on a button is a gesture, through the click it generates", async () 
 	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
 	dom.dispose();
 });
+
+test("a paste fires at the focused field and inserts by default", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	document.body.innerHTML = "<input id=\"field\">";
+	await nextFrame(dom);
+	const field = document.getElementById("field") as any;
+	field.focus();
+	await nextFrame(dom);
+	const seen: Array<{target: string; text: string; trusted: boolean}> = [];
+	document.addEventListener("paste", (event: any) => {
+		seen.push({
+			target: (event.target as any).id ?? "",
+			text: event.clipboardData.getData("text/plain"),
+			trusted: event.isTrusted,
+		});
+	});
+	await proc.stdin.send("\x1b[200~hello\x1b[201~");
+	await nextFrame(dom);
+	expect(seen).toEqual([{target: "field", text: "hello", trusted: true}]);
+	expect(field.value).toBe("hello");
+	dom.dispose();
+});
+
+test("a paste with nothing focused fires at the body", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	const targets: unknown[] = [];
+	let text = "";
+	document.body.addEventListener("paste", (event: any) => {
+		targets.push(event.target);
+		text = event.clipboardData.getData("text");
+	});
+	await proc.stdin.send("\x1b[200~loose\x1b[201~");
+	await nextFrame(dom);
+	expect(targets).toEqual([document.body]);
+	expect(text).toBe("loose");
+	dom.dispose();
+});
+
+test("preventing the paste suppresses the insert", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	document.body.innerHTML = "<input id=\"field\">";
+	await nextFrame(dom);
+	const field = document.getElementById("field") as any;
+	field.focus();
+	await nextFrame(dom);
+	const inputTypes: string[] = [];
+	field.addEventListener("beforeinput", (event: any) => {
+		inputTypes.push(event.inputType);
+	});
+	document.addEventListener("paste", (event: any) => {
+		event.preventDefault();
+	});
+	await proc.stdin.send("\x1b[200~blocked\x1b[201~");
+	await nextFrame(dom);
+	expect(inputTypes).toEqual([]);
+	expect(field.value).toBe("");
+	dom.dispose();
+});
+
+test("a paste's clipboardData is the pasted text, and read-only", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	let types: readonly string[] = [];
+	let rewritten = "";
+	let items = 0;
+	let kind = "";
+	let files = -1;
+	document.body.addEventListener("paste", (event: any) => {
+		const data = event.clipboardData;
+		types = data.types;
+		items = data.items.length;
+		kind = data.items[0].kind;
+		files = data.files.length;
+		data.setData("text/plain", "rewritten");
+		rewritten = data.getData("TEXT ");
+	});
+	await proc.stdin.send("\x1b[200~held\x1b[201~");
+	await nextFrame(dom);
+	expect(Array.from(types)).toEqual(["text/plain"]);
+	expect(items).toBe(1);
+	expect(kind).toBe("string");
+	expect(files).toBe(0);
+	expect(rewritten).toBe("held");
+	dom.dispose();
+});
+
+test("a paste is a gesture: the clipboard is reachable from its listener", async () => {
+	const {proc, dom} = await mount();
+	let written: Promise<void> | null = null;
+	dom.document.body.addEventListener("paste", () => {
+		written = dom.window.navigator.clipboard.writeText("from paste");
+	});
+	await proc.stdin.send("\x1b[200~text\x1b[201~");
+	await written;
+	const payload = Buffer.from("from paste", "utf8").toString("base64");
+	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
+	dom.dispose();
+});
+
+test("a DataTransfer an app builds is writable, and normalizes its formats", () => {
+	const dom = new TermDOM({
+		transport: transportFromProcess(new MockClipboardProcess() as any),
+	});
+	const data = new (dom.window as any).DataTransfer();
+	data.setData("Text", "one");
+	data.setData("text/html", "<b>one</b>");
+	expect(data.getData("text/plain")).toBe("one");
+	expect(Array.from(data.types)).toEqual(["text/plain", "text/html"]);
+	expect(data.items.length).toBe(2);
+	expect(data.items[1].type).toBe("text/html");
+	const read = new Promise<string>((resolve) => {
+		data.items[0].getAsString(resolve);
+	});
+	data.clearData("text/html");
+	expect(Array.from(data.types)).toEqual(["text/plain"]);
+	data.items.clear();
+	expect(data.items.length).toBe(0);
+	expect(data.getData("text")).toBe("");
+	dom.dispose();
+	return read.then((value) => {
+		expect(value).toBe("one");
+	});
+});
+
+test("copy and cut exist as events an app can build and dispatch", async () => {
+	const {proc, dom} = await mount();
+	const {document, window} = dom;
+	const seen: Array<{type: string; text: string; trusted: boolean}> = [];
+	for (const type of ["copy", "cut"]) {
+		document.body.addEventListener(type, (event: any) => {
+			seen.push({
+				type: event.type,
+				text: event.clipboardData.getData("text/plain"),
+				trusted: event.isTrusted,
+			});
+		});
+	}
+	for (const type of ["copy", "cut"]) {
+		const data = new (window as any).DataTransfer();
+		data.setData("text/plain", type);
+		document.body.dispatchEvent(
+			new (window as any).ClipboardEvent(type, {clipboardData: data}),
+		);
+	}
+	expect(seen).toEqual([
+		{type: "copy", text: "copy", trusted: false},
+		{type: "cut", text: "cut", trusted: false},
+	]);
+	// The user agent fires neither: the terminal keeps the copy gesture and
+	// does not report it, so no keystroke and no drag becomes one.
+	await proc.stdin.send("c");
+	await proc.stdin.send("\x1b[<0;1;1M");
+	await proc.stdin.send("\x1b[<0;9;1m");
+	expect(seen.length).toBe(2);
+	dom.dispose();
+});
+
+test("write() carries a ClipboardItem's text over OSC 52", async () => {
+	const {proc, dom} = await mount();
+	const {ClipboardItem} = dom.window as any;
+	const clipboard = dom.window.navigator.clipboard as any;
+	let written: Promise<void> | null = null;
+	dom.document.addEventListener("keydown", () => {
+		written = clipboard.write([
+			new ClipboardItem({"text/plain": "an item"}),
+		]);
+	});
+	await proc.stdin.send("c");
+	await written;
+	const payload = Buffer.from("an item", "utf8").toString("base64");
+	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
+	dom.dispose();
+});
+
+test("write() takes a Blob, and refuses an item with no text", async () => {
+	const {proc, dom} = await mount();
+	const {ClipboardItem} = dom.window as any;
+	const clipboard = dom.window.navigator.clipboard as any;
+	let written: Promise<void> | null = null;
+	const refused: Array<Promise<any>> = [];
+	dom.document.addEventListener("keydown", () => {
+		written = clipboard.write([
+			new ClipboardItem({
+				"text/plain": new Blob(["blobbed"], {type: "text/plain"}),
+			}),
+		]);
+		refused.push(
+			rejection(
+				clipboard.write([new ClipboardItem({"text/html": "<b>no</b>"})]),
+			),
+		);
+	});
+	await proc.stdin.send("c");
+	await written;
+	const payload = Buffer.from("blobbed", "utf8").toString("base64");
+	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
+	expect((await refused[0]).name).toBe("NotAllowedError");
+	dom.dispose();
+});
+
+test("write() outside a gesture is refused", async () => {
+	const {proc, dom} = await mount();
+	const {ClipboardItem} = dom.window as any;
+	const clipboard = dom.window.navigator.clipboard as any;
+	const error = await rejection(
+		clipboard.write([new ClipboardItem({"text/plain": "late"})]),
+	);
+	expect(error.name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;");
+	dom.dispose();
+});
+
+test("read() answers with one text/plain item, and is gated", async () => {
+	const {proc, dom} = await mount();
+	const clipboard = dom.window.navigator.clipboard as any;
+	expect((await rejection(clipboard.read())).name).toBe("NotAllowedError");
+	proc.clipboard = "from the terminal";
+	let reading: Promise<any[]> | null = null;
+	dom.document.addEventListener("keydown", () => {
+		reading = clipboard.read();
+	});
+	await proc.stdin.send("v");
+	const items = (await reading) as unknown as any[];
+	expect(items.length).toBe(1);
+	expect(Array.from(items[0].types)).toEqual(["text/plain"]);
+	const blob = await items[0].getType("text/plain");
+	expect(await blob.text()).toBe("from the terminal");
+	expect((await rejection(items[0].getType("text/html"))).name).toBe(
+		"NotFoundError",
+	);
+	dom.dispose();
+});
+
+test("ClipboardItem.supports answers for text and nothing else", async () => {
+	const {dom} = await mount();
+	const {ClipboardItem} = dom.window as any;
+	expect(ClipboardItem.supports("text/plain")).toBe(true);
+	expect(ClipboardItem.supports(" TEXT/plain ")).toBe(true);
+	expect(ClipboardItem.supports("text/html")).toBe(false);
+	expect(ClipboardItem.supports("image/png")).toBe(false);
+	dom.dispose();
+});
+
+test("the clipboard interfaces are on the window, and name their instances", async () => {
+	const {dom} = await mount();
+	const window = dom.window as any;
+	expect(window.navigator.clipboard instanceof window.Clipboard).toBe(true);
+	expect(window.navigator.permissions instanceof window.Permissions).toBe(
+		true,
+	);
+	expect(new window.ClipboardItem({"text/plain": "x"})).toBeInstanceOf(
+		window.ClipboardItem,
+	);
+	const data = new window.DataTransfer();
+	expect(data).toBeInstanceOf(window.DataTransfer);
+	expect(data.items).toBeInstanceOf(window.DataTransferItemList);
+	const event = new window.ClipboardEvent("copy", {clipboardData: data});
+	expect(event).toBeInstanceOf(window.ClipboardEvent);
+	expect(event).toBeInstanceOf(window.Event);
+	expect(event.clipboardData).toBe(data);
+	expect(new window.ClipboardEvent("copy").clipboardData).toBe(null);
+	// Neither the clipboard nor a permission is an application's to build.
+	expect(() => new window.Clipboard()).toThrow(TypeError);
+	expect(() => new window.PermissionStatus()).toThrow(TypeError);
+	dom.dispose();
+});
+
+test("permissions.query reports the gesture the clipboard asks about", async () => {
+	const {proc, dom} = await mount();
+	const permissions = dom.window.navigator.permissions as any;
+	const read = await permissions.query({name: "clipboard-read"});
+	const write = await permissions.query({name: "clipboard-write"});
+	expect(read.name).toBe("clipboard-read");
+	expect(read.state).toBe("prompt");
+	expect(write.state).toBe("prompt");
+	expect(read).toBeInstanceOf((dom.window as any).PermissionStatus);
+	const duringKeydown: string[] = [];
+	dom.document.addEventListener("keydown", () => {
+		duringKeydown.push(read.state, write.state);
+	});
+	await proc.stdin.send("c");
+	expect(duringKeydown).toEqual(["granted", "granted"]);
+	expect(read.state).toBe("prompt");
+	expect(read.onchange).toBe(null);
+	dom.dispose();
+});
+
+test("permissions.query refuses a name that is not one", async () => {
+	const {dom} = await mount();
+	const permissions = dom.window.navigator.permissions as any;
+	const unknownName = await rejection(permissions.query({name: "clipboard"}));
+	expect(unknownName).toBeInstanceOf(TypeError);
+	expect(await rejection(permissions.query({}))).toBeInstanceOf(TypeError);
+	// A name the API defines that a terminal has nothing behind.
+	expect((await permissions.query({name: "geolocation"})).state).toBe(
+		"denied",
+	);
+	dom.dispose();
+});

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -405,6 +405,22 @@ test("a paste's clipboardData is the pasted text, and read-only", async () => {
 	dom.dispose();
 });
 
+test("a transfer held past its event answers with nothing", async () => {
+	const {proc, dom} = await mount();
+	let held: any = null;
+	let duringEvent = "";
+	dom.document.body.addEventListener("paste", (event: any) => {
+		held = event.clipboardData;
+		duringEvent = held.getData("text/plain");
+	});
+	await proc.stdin.send("\x1b[200~held\x1b[201~");
+	await nextFrame(dom);
+	expect(duringEvent).toBe("held");
+	expect(held.getData("text/plain")).toBe("");
+	expect(Array.from(held.types)).toEqual([]);
+	dom.dispose();
+});
+
 test("a paste is a gesture: the clipboard is reachable from its listener", async () => {
 	const {proc, dom} = await mount();
 	let written: Promise<void> | null = null;

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -1,0 +1,318 @@
+/**
+ * navigator.clipboard, gated on user activation: the clipboard belongs to the
+ * user, so it is reachable only from inside the dispatch of a trusted event
+ * the user caused.
+ *
+ * The transport here records everything written and can be fed input by hand,
+ * which is what a gesture is at this layer -- decoded stdin.
+ */
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM, transportFromProcess} from "../src/internal/termdom.js";
+import {nextFrame} from "./test-utils.js";
+import {EventEmitter} from "events";
+
+class MockTTYStream extends EventEmitter {
+	isTTY: boolean;
+
+	constructor(...args: ConstructorParameters<typeof EventEmitter>) {
+		super(...args);
+		this.isTTY = true;
+	}
+
+	setRawMode(_mode: boolean): this {
+		return this;
+	}
+
+	resume(): this {
+		return this;
+	}
+
+	pause(): this {
+		return this;
+	}
+
+	setEncoding(_encoding: string): this {
+		return this;
+	}
+
+	/** Feed bytes as the terminal would, and wait for the read side to see them. */
+	send(data: string): Promise<void> {
+		this.emit("data", Buffer.from(data));
+		return new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+class MockClipboardProcess extends EventEmitter {
+	output: string[];
+	stdin: MockTTYStream;
+	env: {TERM: string; COLORTERM: string};
+	/** Answered for the next clipboard query, if the terminal is one that does. */
+	clipboard: string | null;
+	stdout: {
+		isTTY: boolean;
+		columns: number;
+		rows: number;
+		write: (chunk: any, encoding?: any, callback?: any) => boolean;
+	};
+
+	constructor(...args: ConstructorParameters<typeof EventEmitter>) {
+		super(...args);
+		this.output = [];
+		this.stdin = new MockTTYStream();
+		this.env = {TERM: "xterm-256color", COLORTERM: "truecolor"};
+		this.clipboard = null;
+		this.stdout = {
+			isTTY: true,
+			columns: 40,
+			rows: 12,
+			write: (chunk: any, encoding?: any, callback?: any): boolean => {
+				const data = String(chunk);
+				this.output.push(data);
+				if (this.clipboard !== null && data.includes("\x1b]52;c;?\x07")) {
+					const payload = Buffer.from(this.clipboard, "utf8").toString(
+						"base64",
+					);
+					this.clipboard = null;
+					setTimeout(() => {
+						void this.stdin.send(`\x1b]52;c;${payload}\x07`);
+					}, 0);
+				}
+				if (typeof encoding === "function") {
+					encoding();
+				} else if (callback) {
+					callback();
+				}
+				return true;
+			},
+		};
+	}
+
+	exit(_code?: number): never {
+		throw new Error("Process exit");
+	}
+
+	get written(): string {
+		return this.output.join("");
+	}
+}
+
+async function mount(): Promise<{proc: MockClipboardProcess; dom: TermDOM}> {
+	const proc = new MockClipboardProcess();
+	const dom = new TermDOM({transport: transportFromProcess(proc as any)});
+	dom.document.body.textContent = "clipboard";
+	await nextFrame(dom);
+	proc.output.length = 0;
+	return {proc, dom};
+}
+
+async function rejection(promise: Promise<unknown>): Promise<any> {
+	try {
+		await promise;
+	} catch (err) {
+		return err;
+	}
+	throw new Error("the promise resolved");
+}
+
+test("writeText inside a keystroke's dispatch reaches the terminal", async () => {
+	const {proc, dom} = await mount();
+	let written: Promise<void> | null = null;
+	dom.document.addEventListener("keydown", () => {
+		written = dom.window.navigator.clipboard.writeText("hello");
+	});
+	await proc.stdin.send("c");
+	await written;
+	const payload = Buffer.from("hello", "utf8").toString("base64");
+	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
+	dom.dispose();
+});
+
+test("a mouse press is a gesture too", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	let written: Promise<void> | null = null;
+	document.body.addEventListener("mousedown", () => {
+		written = dom.window.navigator.clipboard.writeText("gesture");
+	});
+	await proc.stdin.send("\x1b[<0;1;1M");
+	await written;
+	const payload = Buffer.from("gesture", "utf8").toString("base64");
+	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
+	dom.dispose();
+});
+
+test("a keystroke's gesture is over once its dispatch is", async () => {
+	const {proc, dom} = await mount();
+	await proc.stdin.send("c");
+	const error = await rejection(
+		dom.window.navigator.clipboard.writeText("late"),
+	);
+	expect(error.name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;");
+	dom.dispose();
+});
+
+test("a handler that awaits before writing is too late", async () => {
+	const {proc, dom} = await mount();
+	const pending: Array<Promise<any>> = [];
+	dom.document.addEventListener("keydown", () => {
+		pending.push(
+			(async () => {
+				await Promise.resolve();
+				return rejection(dom.window.navigator.clipboard.writeText("awaited"));
+			})(),
+		);
+	});
+	await proc.stdin.send("c");
+	expect((await pending[0]).name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;");
+	dom.dispose();
+});
+
+test("writeText from a bare timer or microtask is refused", async () => {
+	const {proc, dom} = await mount();
+	const fromTimer = await new Promise<any>((resolve) => {
+		setTimeout(() => {
+			resolve(rejection(dom.window.navigator.clipboard.writeText("sneaky")));
+		}, 0);
+	});
+	const error = await fromTimer;
+	expect(error.name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;");
+	const fromMicrotask = await Promise.resolve().then(() =>
+		rejection(dom.window.navigator.clipboard.writeText("sneaky")),
+	);
+	expect((await fromMicrotask).name).toBe("NotAllowedError");
+	dom.dispose();
+});
+
+test("an event an app dispatches itself is not a gesture", async () => {
+	const {proc, dom} = await mount();
+	const {document, window} = dom;
+	const pending: Array<Promise<any>> = [];
+	document.body.addEventListener("keydown", () => {
+		pending.push(
+			rejection(dom.window.navigator.clipboard.writeText("forged")),
+		);
+	});
+	document.body.dispatchEvent(
+		new window.KeyboardEvent("keydown", {key: "c", bubbles: true}),
+	);
+	expect((await pending[0]).name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;");
+	dom.dispose();
+});
+
+test("readText outside a gesture is refused, and asks the terminal nothing", async () => {
+	const {proc, dom} = await mount();
+	proc.clipboard = "should not be read";
+	const error = await rejection(dom.window.navigator.clipboard.readText());
+	expect(error.name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;?");
+	const {document, window} = dom;
+	const pending: Array<Promise<any>> = [];
+	document.body.addEventListener("keydown", () => {
+		pending.push(rejection(dom.window.navigator.clipboard.readText()));
+	});
+	document.body.dispatchEvent(
+		new window.KeyboardEvent("keydown", {key: "v", bubbles: true}),
+	);
+	expect((await pending[0]).name).toBe("NotAllowedError");
+	expect(proc.written).not.toContain("\x1b]52;c;?");
+	dom.dispose();
+});
+
+test("readText queries the terminal and resolves with what it answers", async () => {
+	const {proc, dom} = await mount();
+	proc.clipboard = "pasted text";
+	let reading: Promise<string> | null = null;
+	dom.document.addEventListener("keydown", () => {
+		reading = dom.window.navigator.clipboard.readText();
+	});
+	await proc.stdin.send("v");
+	expect(proc.written).toContain("\x1b]52;c;?\x07");
+	expect(await reading).toBe("pasted text");
+	dom.dispose();
+});
+
+test("a clipboard reply survives arriving in pieces, and glued to typing", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	const keys: string[] = [];
+	let reading: Promise<string> | null = null;
+	document.addEventListener("keydown", (event: any) => {
+		keys.push(event.key);
+		if (event.key === "v") {
+			reading = dom.window.navigator.clipboard.readText();
+		}
+	});
+	await proc.stdin.send("v");
+	const payload = Buffer.from("héllo", "utf8").toString("base64");
+	await proc.stdin.send(`\x1b]52;c;${payload.slice(0, 3)}`);
+	await proc.stdin.send(`${payload.slice(3)}\x07jj`);
+	expect(await reading).toBe("héllo");
+	expect(keys.join("")).toBe("vjj");
+	dom.dispose();
+});
+
+test("readText rejects when the terminal does not answer", async () => {
+	const {proc, dom} = await mount();
+	const pending: Array<Promise<any>> = [];
+	dom.document.addEventListener("keydown", () => {
+		pending.push(rejection(dom.window.navigator.clipboard.readText()));
+	});
+	await proc.stdin.send("v");
+	expect(proc.written).toContain("\x1b]52;c;?\x07");
+	expect((await pending[0]).name).toBe("NotAllowedError");
+	dom.dispose();
+});
+
+test("navigator.userActivation reports the gate the clipboard asks about", async () => {
+	const {proc, dom} = await mount();
+	const activation = dom.window.navigator.userActivation;
+	expect(activation.hasBeenActive).toBe(false);
+	expect(activation.isActive).toBe(false);
+	const duringKeydown: boolean[] = [];
+	dom.document.addEventListener("keydown", () => {
+		duringKeydown.push(activation.isActive, activation.hasBeenActive);
+	});
+	await proc.stdin.send("x");
+	expect(duringKeydown).toEqual([true, true]);
+	// The gesture is the dispatch, and the dispatch is over.
+	expect(activation.isActive).toBe(false);
+	expect(activation.hasBeenActive).toBe(true);
+	dom.dispose();
+});
+
+test("Escape is not a gesture", async () => {
+	const {proc, dom} = await mount();
+	const active: boolean[] = [];
+	dom.document.addEventListener("keydown", () => {
+		active.push(dom.window.navigator.userActivation.isActive);
+	});
+	await proc.stdin.send("\x1b");
+	await proc.stdin.send("a");
+	expect(active).toEqual([false, true]);
+	dom.dispose();
+});
+
+test("Enter on a button is a gesture, through the click it generates", async () => {
+	const {proc, dom} = await mount();
+	const {document} = dom;
+	document.body.innerHTML = "<button id=\"copy\">copy</button>";
+	await nextFrame(dom);
+	const button = document.getElementById("copy") as any;
+	button.focus();
+	let written: Promise<void> | null = null;
+	let trusted: boolean | null = null;
+	button.addEventListener("click", (event: any) => {
+		trusted = event.isTrusted;
+		written = dom.window.navigator.clipboard.writeText("keyboard");
+	});
+	await proc.stdin.send("\r");
+	await written;
+	expect(trusted).toBe(true);
+	const payload = Buffer.from("keyboard", "utf8").toString("base64");
+	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
+	dom.dispose();
+});

--- a/tests/dom.test.ts
+++ b/tests/dom.test.ts
@@ -672,6 +672,30 @@ test("isTrusted reads false and cannot be redefined", () => {
 	expect(event.isTrusted).toBe(false);
 });
 
+test("the user agent's own events are trusted, click()'s is not", async () => {
+	const document = make();
+	const details = document.createElement("details");
+	document.body.appendChild(details);
+	let toggleTrusted: boolean | null = null;
+	details.addEventListener("toggle", (event: any) => {
+		toggleTrusted = event.isTrusted;
+	});
+	details.setAttribute("open", "");
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(toggleTrusted).toBe(true);
+
+	// click() fires a synthetic pointer event, which HTML says is untrusted:
+	// a listener can tell it from a press the user made.
+	const button = document.createElement("button");
+	document.body.appendChild(button);
+	let clickTrusted: boolean | null = null;
+	button.addEventListener("click", (event: any) => {
+		clickTrusted = event.isTrusted;
+	});
+	button.click();
+	expect(clickTrusted).toBe(false);
+});
+
 test("a platform CustomEvent dispatches through the tree", () => {
 	const document = make();
 	const outer = document.createElement("div");

--- a/tests/keyboard.test.ts
+++ b/tests/keyboard.test.ts
@@ -2506,3 +2506,63 @@ test("moving focus and opening a disclosure bring their target into view", async
 
 	dom.dispose();
 });
+
+test("a decoded keystroke is trusted; a constructed event is not", async () => {
+	const terminal = new MockKeyboardProcess();
+	const termdom = new TermDOM({
+		transport: transportFromProcess(terminal as any),
+	});
+	const {document, window} = termdom;
+	termdom.attach();
+	await new Promise((r) => setTimeout(r, 0));
+	const trust: Array<{type: string; isTrusted: boolean}> = [];
+	for (const type of ["keydown", "keypress", "keyup"]) {
+		document.body.addEventListener(type, (event: any) => {
+			trust.push({type: event.type, isTrusted: event.isTrusted});
+		});
+	}
+
+	await (terminal.stdin as any).simulateKeypress("a");
+	expect(trust).toEqual([
+		{type: "keydown", isTrusted: true},
+		{type: "keypress", isTrusted: true},
+		{type: "keyup", isTrusted: true},
+	]);
+
+	// The same event type, constructed by an app and dispatched by it: the
+	// engine never fired it, so nothing about it is the user's.
+	trust.length = 0;
+	document.body.dispatchEvent(
+		new window.KeyboardEvent("keydown", {key: "a", bubbles: true}),
+	);
+	expect(trust).toEqual([{type: "keydown", isTrusted: false}]);
+
+	termdom.dispose();
+});
+
+test("a mouse report is trusted, and so is the focus move it causes", async () => {
+	const terminal = new MockProcess({rows: 8, cols: 40});
+	const dom = new TermDOM({transport: transportFromProcess(terminal as any)});
+	const {document} = dom;
+	dom.attach();
+	await new Promise((r) => setTimeout(r, 0));
+	document.body.innerHTML = "<button id=\"b\">press</button>";
+	await nextFrame(dom);
+	const trust: Array<{type: string; isTrusted: boolean}> = [];
+	for (const type of ["mousedown", "mouseup", "click", "focus"]) {
+		document
+			.getElementById("b")!
+			.addEventListener(type, (event: any) =>
+				trust.push({type: event.type, isTrusted: event.isTrusted}),
+			);
+	}
+
+	(terminal.stdin as any).emit("data", Buffer.from("\x1b[<0;1;1M"));
+	await new Promise((r) => setTimeout(r, 0));
+	(terminal.stdin as any).emit("data", Buffer.from("\x1b[<0;1;1m"));
+	await new Promise((r) => setTimeout(r, 0));
+	expect(trust.every((entry) => entry.isTrusted)).toBe(true);
+	expect(trust.map((entry) => entry.type)).toContain("click");
+
+	dom.dispose();
+});

--- a/tests/mouse.test.ts
+++ b/tests/mouse.test.ts
@@ -428,12 +428,17 @@ test("dragging across text builds a real Selection and paints inverse, without t
 	expect(proc.written).toMatch(/\x1b\[[\d;]*7m/);
 
 	// Releasing a drag is only a selection: the clipboard is written by
-	// navigator.clipboard.writeText(), never as a side effect.
-	await proc.stdin.send("\x1b[<0;6;1m");
+	// navigator.clipboard.writeText() from the app's own release handler --
+	// which is inside the release's dispatch, where the clipboard is
+	// reachable -- and never as a side effect of the drag.
 	expect(proc.written).not.toContain("\x1b]52;");
-
+	let copied: Promise<void> | null = null;
+	document.addEventListener("mouseup", () => {
+		copied = window.navigator.clipboard.writeText(selection.toString());
+	});
+	await proc.stdin.send("\x1b[<0;6;1m");
+	await copied;
 	const payload = Buffer.from("hello", "utf8").toString("base64");
-	await window.navigator.clipboard.writeText(selection.toString());
 	expect(proc.written).toContain(`\x1b]52;c;${payload}\x07`);
 
 	termdom.dispose();

--- a/tests/selection-modify.test.ts
+++ b/tests/selection-modify.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Selection.modify(): the caret motion a keyboard makes, asked for by a page.
+ *
+ * Character and word granularity are answerable from the text, so they are
+ * tested on a bare document. A line is a laid-out line, so the line
+ * granularities are tested against text wrapped by a real terminal width.
+ */
+import {test, expect} from "@b9g/libuild/test";
+import {createHTMLDocument, setAmbientDocument} from "../src/internal/dom.js";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils.js";
+
+function withText(html: string): any {
+	const document = createHTMLDocument("") as any;
+	setAmbientDocument(document);
+	document.body.innerHTML = html;
+	return document;
+}
+
+/** A caret parked at `offset` in the paragraph's first text node. */
+function caretAt(document: any, offset: number): any {
+	const text = document.body.firstChild.firstChild;
+	const selection = document.getSelection();
+	selection.setBaseAndExtent(text, offset, text, offset);
+	return selection;
+}
+
+test("modify moves a caret by character, forward and backward", () => {
+	const document = withText("<p>hello world</p>");
+	const selection = caretAt(document, 0);
+	selection.modify("move", "forward", "character");
+	expect(selection.focusOffset).toBe(1);
+	selection.modify("move", "forward", "character");
+	expect(selection.focusOffset).toBe(2);
+	expect(selection.isCollapsed).toBe(true);
+	selection.modify("move", "backward", "character");
+	expect(selection.focusOffset).toBe(1);
+	// The first character back from the start is the start.
+	selection.modify("move", "backward", "character");
+	selection.modify("move", "backward", "character");
+	expect(selection.focusOffset).toBe(0);
+});
+
+test("a character move counts graphemes, not code units", () => {
+	const document = withText("<p>a\u{1f469}\u{200d}\u{1f4bb}b</p>");
+	const selection = caretAt(document, 0);
+	selection.modify("move", "forward", "character");
+	expect(selection.focusOffset).toBe(1);
+	// The whole ZWJ sequence is one character forward, and one back.
+	selection.modify("move", "forward", "character");
+	expect(selection.focusOffset).toBe(6);
+	selection.modify("move", "backward", "character");
+	expect(selection.focusOffset).toBe(1);
+});
+
+test("modify extends by character, leaving the anchor where it was", () => {
+	const document = withText("<p>hello world</p>");
+	const selection = caretAt(document, 2);
+	selection.modify("extend", "forward", "character");
+	selection.modify("extend", "forward", "character");
+	expect(selection.anchorOffset).toBe(2);
+	expect(selection.focusOffset).toBe(4);
+	expect(selection.toString()).toBe("ll");
+	expect(selection.direction).toBe("forward");
+	selection.modify("extend", "backward", "character");
+	expect(selection.toString()).toBe("l");
+	// Past the anchor the selection turns around.
+	selection.modify("extend", "backward", "character");
+	selection.modify("extend", "backward", "character");
+	expect(selection.direction).toBe("backward");
+	expect(selection.toString()).toBe("e");
+});
+
+test("a forward character move over a range collapses it to its end", () => {
+	const document = withText("<p>hello world</p>");
+	const text = document.body.firstChild.firstChild;
+	const selection = document.getSelection();
+	selection.setBaseAndExtent(text, 1, text, 5);
+	selection.modify("move", "forward", "character");
+	expect(selection.isCollapsed).toBe(true);
+	expect(selection.focusOffset).toBe(5);
+	selection.setBaseAndExtent(text, 1, text, 5);
+	selection.modify("move", "backward", "character");
+	expect(selection.isCollapsed).toBe(true);
+	expect(selection.focusOffset).toBe(1);
+});
+
+test("modify moves and extends by word", () => {
+	const document = withText("<p>one two three</p>");
+	const selection = caretAt(document, 0);
+	selection.modify("move", "forward", "word");
+	expect(selection.focusOffset).toBe(3);
+	selection.modify("move", "forward", "word");
+	expect(selection.focusOffset).toBe(7);
+	selection.modify("move", "backward", "word");
+	expect(selection.focusOffset).toBe(4);
+	selection.modify("extend", "forward", "word");
+	expect(selection.toString()).toBe("two");
+	selection.modify("extend", "forward", "word");
+	expect(selection.toString()).toBe("two three");
+	selection.modify("move", "backward", "word");
+	expect(selection.isCollapsed).toBe(true);
+});
+
+test("a word move crosses out of one text node and into the next", () => {
+	const document = withText("<p>one <b>two</b> three</p>");
+	const paragraph = document.body.firstChild;
+	const selection = document.getSelection();
+	selection.setBaseAndExtent(paragraph.firstChild, 0, paragraph.firstChild, 0);
+	selection.modify("move", "forward", "word");
+	selection.modify("move", "forward", "word");
+	expect(selection.focusNode).toBe(paragraph.childNodes[1].firstChild);
+	expect(selection.focusOffset).toBe(3);
+	selection.modify("extend", "forward", "word");
+	expect(selection.toString()).toBe(" three");
+});
+
+test("left and right are backward and forward", () => {
+	const document = withText("<p>hello</p>");
+	const selection = caretAt(document, 2);
+	selection.modify("move", "right", "character");
+	expect(selection.focusOffset).toBe(3);
+	selection.modify("move", "left", "character");
+	expect(selection.focusOffset).toBe(2);
+});
+
+test("the document boundaries are a granularity of their own", () => {
+	const document = withText("<p>one</p><p>two</p>");
+	const selection = caretAt(document, 1);
+	selection.modify("extend", "forward", "documentboundary");
+	expect(selection.toString()).toBe("netwo");
+	selection.modify("move", "backward", "documentboundary");
+	expect(selection.isCollapsed).toBe(true);
+	expect(selection.focusOffset).toBe(0);
+});
+
+test("an unrecognized argument, and an empty selection, do nothing", () => {
+	const document = withText("<p>hello</p>");
+	const selection = caretAt(document, 2);
+	selection.modify("mangle", "forward", "character");
+	selection.modify("move", "sideways", "character");
+	selection.modify("move", "forward", "sentence");
+	selection.modify("move", "forward", "paragraph");
+	expect(selection.focusOffset).toBe(2);
+	selection.removeAllRanges();
+	selection.modify("move", "forward", "character");
+	expect(selection.rangeCount).toBe(0);
+});
+
+test("the line granularities do nothing without a layout behind them", () => {
+	const document = withText("<p>hello world</p>");
+	const selection = caretAt(document, 3);
+	selection.modify("move", "forward", "lineboundary");
+	selection.modify("move", "forward", "line");
+	expect(selection.focusOffset).toBe(3);
+});
+
+/* --------------------------------------------- lines, as the layout has them */
+
+/** A 12-column terminal, so "hello there world" wraps into two rows. */
+async function mounted(html: string): Promise<{dom: TermDOM; document: any}> {
+	const terminal = new MockProcess({cols: 12, rows: 10});
+	const dom = new TermDOM({transport: terminal.transport});
+	const document = dom.document as any;
+	document.body.innerHTML = html;
+	await nextFrame(dom);
+	return {dom, document};
+}
+
+test("lineboundary runs to the ends of the WRAPPED line, not the string", async () => {
+	const {dom, document} = await mounted("<p>hello there world</p>");
+	const text = document.body.firstChild.firstChild;
+	const selection = document.getSelection()!;
+	// "hello there world" in 12 columns wraps as "hello there " / "world":
+	// the line's end is the end of what the row renders, space and all.
+	selection.setBaseAndExtent(text, 2, text, 2);
+	selection.modify("extend", "forward", "lineboundary");
+	expect(selection.toString()).toBe("llo there ");
+	selection.setBaseAndExtent(text, 8, text, 8);
+	selection.modify("move", "backward", "lineboundary");
+	expect(selection.focusOffset).toBe(0);
+	selection.modify("move", "forward", "lineboundary");
+	expect(selection.focusOffset).toBe(12);
+	dom.dispose();
+});
+
+test("a line move steps a wrapped row at a time, keeping the column", async () => {
+	const {dom, document} = await mounted("<p>hello there world</p>");
+	const text = document.body.firstChild.firstChild;
+	const selection = document.getSelection()!;
+	selection.setBaseAndExtent(text, 2, text, 2);
+	// Down one row from column 2 of "hello there" is column 2 of "world".
+	selection.modify("move", "forward", "line");
+	expect(selection.focusOffset).toBe(14);
+	selection.modify("move", "backward", "line");
+	expect(selection.focusOffset).toBe(2);
+	// Up from the first row spends itself on that row's start.
+	selection.modify("move", "backward", "line");
+	expect(selection.focusOffset).toBe(0);
+	dom.dispose();
+});
+
+test("a line move crosses from one block into the next, and extends", async () => {
+	const {dom, document} = await mounted("<p>abcd</p><p>wxyz</p>");
+	const first = document.body.firstChild.firstChild;
+	const second = document.body.childNodes[1].firstChild;
+	const selection = document.getSelection()!;
+	selection.setBaseAndExtent(first, 2, first, 2);
+	selection.modify("extend", "forward", "line");
+	expect(selection.focusNode).toBe(second);
+	expect(selection.focusOffset).toBe(2);
+	expect(selection.toString()).toBe("cdwx");
+	// Down again is past the last line, so it spends itself on that line's end.
+	selection.modify("extend", "forward", "line");
+	expect(selection.toString()).toBe("cdwxyz");
+	dom.dispose();
+});
+
+test("a modified selection paints where it now is", async () => {
+	const terminal = new MockProcess({cols: 12, rows: 10});
+	const dom = new TermDOM({transport: terminal.transport});
+	const document = dom.document as any;
+	document.body.innerHTML = "<p>hello there world</p>";
+	await nextFrame(dom);
+	const text = document.body.firstChild.firstChild;
+	const selection = document.getSelection()!;
+	selection.setBaseAndExtent(text, 0, text, 0);
+	selection.modify("extend", "forward", "lineboundary");
+	await nextFrame(dom);
+	// The highlight is inverse video, over the row the selection now covers.
+	expect(terminal.getScreenContents()).toContain("hello there");
+	expect(selection.toString()).toBe("hello there ");
+	dom.dispose();
+});


### PR DESCRIPTION
## Selection.modify()

`getSelection().modify(alter, direction, granularity)` with `move`/`extend`, `forward`/`backward`/`left`/`right`, and the `character`, `word`, `line`, `lineboundary`, and `documentboundary` granularities.

Character and word read the document's painted text as one string, so a caret crosses text-node boundaries without noticing. Line and lineboundary read `lineFragments()`, the primitive a textarea's vertical motion already uses, and a line move lands through `caretPositionFromPoint()` — the answer a click at that column and row would give. Painting and `selectionchange` follow, since the result goes through `extend`/`setBaseAndExtent`.

Not supported: `sentence` and `paragraph` granularities are silent no-ops, `left`/`right` map to `backward`/`forward` with no RTL affinity, a line's ends are its first and last text in tree order, and no goal column is kept across successive line moves.

Fixes #21.

## isTrusted

`Event.isTrusted` read false for a real keystroke, because nothing set it. Provenance is now decided at two entry points: `dispatchEvent()` marks untrusted, `dispatchAsUserAgent()` marks trusted, and both route through one function. What the DOM fires itself — input, change, toggle, select, selectionchange, slotchange, reset, submit, invalid, close — is trusted with no per-site assignment, with one opt-out for `Element.click()`, whose synthetic pointer event HTML specifies as untrusted.

This uncovered a bug on Bun: the platform `Event` constructor installs `isTrusted` as an unforgeable own accessor pinned to false, so this DOM's accessor was never installed and the flag was unreachable. The DOM's `Event` now reaches `globalThis.Event` on the prototype chain, keeping `instanceof` and interop, without running the platform constructor.

Keyboard activation of a button also went through `element.click()`, whose untrusted click grants nothing — so Enter on a button could not reach the clipboard where a mouse click could. It fires the user agent's trusted click now, activation behavior intact.

## Clipboard

Reachable only inside the dispatch of a user gesture: keydown (Escape and bare modifiers excluded), mousedown, mouseup, click, pointerup, and paste. Outside one, the methods reject `NotAllowedError`. The gate is a dispatch-scoped depth counter, not a clock.

**This is stricter than a browser.** A browser's transient activation is a time window, so a handler may `await` and still write the clipboard. Here the stack must still be inside the gesture. The divergence is commented where the gate lives.

- `Clipboard` is a class on `EventTarget` carrying `writeText`, `readText`, `write`, `read`; `navigator.clipboard` is an instance.
- `readText()`/`read()` query the terminal over OSC 52 and decode the reply, rejecting after a 500 ms silence — most terminals answer nothing when their own clipboard reads are off.
- `ClipboardItem` supports `text/plain` alone, since OSC 52 carries one payload terminals treat as text.
- A paste fires a cancelable `paste` event at the focused element, or at `document.body` when nothing is focused, and the `insertFromPaste` insert runs afterward as the default action. Previously a paste with no editable focused was dropped.
- `ClipboardEvent`, `DataTransfer`, `DataTransferItem`, `DataTransferItemList`, and an empty `FileList`. A transfer is read-only during a paste and empties when its dispatch ends. The drag members are present and inert.
- `copy` and `cut` exist as types; the user agent fires neither, because the terminal keeps its own copy gesture and Ctrl+C is the interrupt.
- `navigator.permissions.query()` reports `granted` inside a gesture, `prompt` outside, `denied` when the terminal is not attached, and rejects an unrecognized name.

One deviation: `PermissionStatus` never fires `change`. The gesture opens and closes inside one dispatch, so a listener would be told about a state already past.

## Tests

`tests/selection-modify.test.ts` (14) and `tests/clipboard.test.ts` (29), plus isTrusted coverage in the keyboard and dom files. No fake clocks. Suite: node 1359, bun 1384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
