### PR TITLE
Scroll content inside a fullscreen element with the viewport camera

### DIFF
--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -1603,6 +1603,18 @@ export class LayoutEngine {
 	}
 
 	/**
+	 * The bottom of the element's subtree paint extent, in document rows --
+	 * how far its content reaches, regardless of what box it was constrained
+	 * into. The fullscreen camera clamps against this: the fullscreen
+	 * element's box is pinned to the screen, so its box height says nothing
+	 * about how much content there is to scroll.
+	 */
+	subtreePaintBottom(element: Element): number {
+		const node = this.nodeMap.get(element);
+		return node ? Math.ceil(node.extentBottom) : 0;
+	}
+
+	/**
 	 * The direct DOM/pseudo-element children of `element` whose paint extent
 	 * could intersect document rows [top, bottom), in document order -- found
 	 * with a binary search instead of visiting every child, which is what let
@@ -2729,13 +2741,22 @@ export class LayoutEngine {
 	 * is what puts its geometry in viewport space rather than document space.
 	 * The one answer to that question: hit-testing converts its probe point by
 	 * it, and the public client-rect wrappers skip the camera conversion by it.
+	 *
+	 * The fullscreen element is the boundary of that walk: it is the viewport
+	 * for its content, so while its box is pinned (it is UA-styled fixed), a
+	 * descendant that reaches it without crossing a nearer fixed box scrolls
+	 * with the camera.
 	 */
 	isInFixedSpace(element: Element): boolean {
+		const fullscreen = element.ownerDocument?.fullscreenElement ?? null;
 		for (
 			let el: Element | null = element;
 			el;
 			el = flatParentElement<Element>(el)
 		) {
+			if (el === fullscreen) {
+				return el === element;
+			}
 			if (getPropertyValue(el, "position") === "fixed") {
 				return true;
 			}
@@ -3224,15 +3245,21 @@ function hitTestContext(
 	cameraScrollTop: number,
 ): Element | null {
 	const bucket = layers.get(root) ?? null;
+	// The fullscreen element pins its box and scrolls its content: its box
+	// is probed in viewport space, and what it holds lives one camera
+	// conversion below that, back in document space.
+	const fullscreen = root.ownerDocument?.fullscreenElement ?? null;
+	const contentY = root === fullscreen ? y + cameraScrollTop : y;
 	const probeMember = (element: Element): Element | null => {
 		// A fixed box's layout lives in viewport space; convert the
 		// document-space probe point for its whole subtree. Fixed-space is
 		// a property of the containing-block CHAIN, so the check walks
 		// ancestors -- an absolute box inside a fixed bar lives there too.
-		const probeY = self.isInFixedSpace(element) ? y - cameraScrollTop : y;
+		const probeY =
+			self.isInFixedSpace(element) ? contentY - cameraScrollTop : contentY;
 		return self.formsStackingContext(element) ?
 				hitTestContext(self, element, x, probeY, layers, cameraScrollTop) :
-				hitTestInFlow(self, element, x, probeY);
+				hitTestInFlow(self, element, x, probeY, cameraScrollTop);
 	};
 	if (bucket) {
 		for (let i = bucket.pos.length - 1; i >= 0; i--) {
@@ -3248,7 +3275,7 @@ function hitTestContext(
 			}
 		}
 	}
-	const inFlow = hitTestInFlow(self, root, x, y);
+	const inFlow = hitTestInFlow(self, root, x, y, cameraScrollTop);
 	if (inFlow) {
 		return inFlow;
 	}
@@ -3266,13 +3293,16 @@ function hitTestContext(
 /**
  * In-flow descent: the element must contain the point; children are probed
  * in REVERSE tree order (last-painted wins), positioned children skipped --
- * their context probes them.
+ * their context probes them. The fullscreen element probes its box where it
+ * is pinned and its children where the camera put them, the one place a box
+ * and its in-flow content sit in different frames.
  */
 function hitTestInFlow(
 	self: LayoutEngine,
 	element: Element,
 	x: number,
 	y: number,
+	cameraScrollTop: number,
 ): Element | null {
 	if (element.nodeType !== 1) {
 		return null;
@@ -3309,8 +3339,14 @@ function hitTestInFlow(
 		}
 		children.push(child as Element);
 	}
+	// The fullscreen element's box is probed where it is pinned; its content
+	// scrolled under it, so the children are probed one camera down.
+	const childY =
+		element === (element.ownerDocument?.fullscreenElement ?? null) ?
+			y + cameraScrollTop :
+			y;
 	for (let i = children.length - 1; i >= 0; i--) {
-		const hit = hitTestInFlow(self, children[i], x, y);
+		const hit = hitTestInFlow(self, children[i], x, childY, cameraScrollTop);
 		if (hit) {
 			return hit;
 		}

--- a/src/internal/painter.ts
+++ b/src/internal/painter.ts
@@ -606,6 +606,16 @@ function renderElement(
 		afterOwnBox();
 	}
 
+	// The fullscreen element is the viewport for its in-flow content: the
+	// box painted above stays pinned at the screen while the children ride
+	// the camera. The culling band shifts with them.
+	const cameraShift =
+		element === self[kDocument].fullscreenElement ?
+			self[kViewport].scrollTop :
+			0;
+	bandTop += cameraShift;
+	bandBottom += cameraShift;
+
 	// The IN-FLOW walk: children paint in tree order, and POSITIONED
 	// children don't paint here at all -- per CSS they are hoisted to
 	// their nearest stacking context and painted in its layer order (see
@@ -677,7 +687,9 @@ function renderElement(
 	const overflowY =
 		computedStyleOf(element).computedValueOf("overflow-y") || overflow;
 	const previousClip = ctx.clipRect;
+	const previousOffset = ctx.viewportOffset;
 	ctx.clipRect = overflowClipRect(rect, overflowX, overflowY, previousClip);
+	ctx.viewportOffset -= cameraShift;
 
 	try {
 		for (const childNode of children) {
@@ -693,6 +705,7 @@ function renderElement(
 		}
 	} finally {
 		ctx.clipRect = previousClip;
+		ctx.viewportOffset = previousOffset;
 	}
 
 	// A focused textarea's own selection now paints inline while the child
@@ -818,6 +831,9 @@ function renderStackingContext(
 		return;
 	}
 	const contextClip = ctx.clipRect;
+	// The offset a pinned box paints at: fixed members sit here, and members
+	// that scroll sit a camera below it.
+	const base = ctx.viewportOffset + self[kViewport].scrollTop;
 	const paintMember = (element: Element) => {
 		const previousClip = ctx.clipRect;
 		const previousOffset = ctx.viewportOffset;
@@ -825,14 +841,15 @@ function renderStackingContext(
 		// ancestor that isn't a positioned ancestor doesn't clip a
 		// deferred box, but its own containing blocks' overflow does.
 		ctx.clipRect = positionedClipFor(self, element, root, contextClip);
-		// position:fixed anchors to the VIEWPORT: cancel the camera by
-		// undoing the scroll offset for the whole subtree. Fixed-space is
-		// a property of the containing-block CHAIN: an absolute box inside
-		// a fixed bar is laid out against the bar's viewport coordinates
-		// and must ride with it, so the walk includes ancestors.
-		if (self[kLayout].isInFixedSpace(element)) {
-			ctx.viewportOffset = previousOffset + self[kViewport].scrollTop;
-		}
+		// position:fixed anchors to the VIEWPORT: cancel the camera for
+		// the whole subtree. Fixed-space is the containing-block CHAIN's,
+		// so an absolute box inside a fixed bar rides with it and the
+		// query walks ancestors -- and stops at the fullscreen element,
+		// whose content scrolls while the box stays pinned.
+		ctx.viewportOffset =
+			self[kLayout].isInFixedSpace(element) ?
+				base :
+				base - self[kViewport].scrollTop;
 		try {
 			if (self[kLayout].formsStackingContext(element)) {
 				renderStackingContext(self, element, ctx, layers);

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -141,6 +141,7 @@ export {kLayoutEngine, kObserver};
 
 const kWrite = Symbol("write");
 const kFullscreenStack = Symbol("fullscreenStack");
+const kSavedScrollTop = Symbol("savedScrollTop");
 const kIsInFullscreenMode = Symbol("isInFullscreenMode");
 
 /**
@@ -157,10 +158,17 @@ class FullscreenManager {
 
 	declare [kFullscreenStack]: Element[];
 	declare [kIsInFullscreenMode]: boolean;
+	declare [kViewport]: Viewport;
+	// The document's scroll position, held across the screen switch: while
+	// the alternate screen is up, the camera is the fullscreen element's,
+	// starting from its top; the main screen gets its position back at exit.
+	declare [kSavedScrollTop]: number;
 
-	constructor(write: (output: string) => void) {
+	constructor(viewport: Viewport, write: (output: string) => void) {
 		this[kFullscreenStack] = [];
 		this[kIsInFullscreenMode] = false;
+		this[kViewport] = viewport;
+		this[kSavedScrollTop] = 0;
 		this[kWrite] = write;
 	}
 
@@ -184,6 +192,8 @@ class FullscreenManager {
 			// Enter fullscreen mode if this is the first element
 			if (!this[kIsInFullscreenMode]) {
 				await enterFullscreenMode(this);
+				this[kSavedScrollTop] = this[kViewport].scrollTop;
+				this[kViewport].scrollTop = 0;
 			}
 
 			// Fire fullscreenchange event
@@ -212,6 +222,7 @@ class FullscreenManager {
 		// If no more elements in stack, exit fullscreen mode
 		if (this[kFullscreenStack].length === 0) {
 			await exitFullscreenMode(this);
+			this[kViewport].scrollTop = this[kSavedScrollTop];
 		}
 
 		// Fire fullscreenchange event
@@ -859,9 +870,12 @@ export class TermDOM {
 			processPendingMutationsAndRender(this),
 		);
 		this[kLayoutEngine].resize(this[kWidth], this[kHeight]);
-		this[kFullscreenManager] = new FullscreenManager((output) => {
-			void this[kSession].write(output);
-		});
+		this[kFullscreenManager] = new FullscreenManager(
+			this[kViewport],
+			(output) => {
+				void this[kSession].write(output);
+			},
+		);
 		this[kObserverManager] = new ObserverManager(this[kLayoutEngine]);
 
 		installWindowExtensions(this);
@@ -2438,6 +2452,25 @@ function documentPaintHeight(
 }
 
 /**
+ * How far the fullscreen content reaches, in rows: the fullscreen
+ * element's subtree paint extent, never less than the screen. The box
+ * height is pinned to the screen, so the extent -- not the box -- is what
+ * the camera clamps against.
+ */
+function fullscreenPaintHeight(
+	self: TermDOM,
+): number {
+	const element = self[kFullscreenManager].fullscreenElement;
+	if (!element) {
+		return self[kHeight];
+	}
+	return Math.max(
+		self[kHeight],
+		self[kLayoutEngine].subtreePaintBottom(element),
+	);
+}
+
+/**
  * The height of the window the camera shows, for the scroll-to-reveal
  * math. Fullscreen owns the whole screen from row zero, and the
  * fullscreen element has left the flow -- body.scrollHeight measures
@@ -3703,8 +3736,9 @@ async function renderInteractive(
 	// Fullscreen owns the WHOLE alternate screen from row zero: the
 	// main screen's command anchor means nothing there, and reserveRows'
 	// index-scrolls would scroll the alternate screen itself. The
-	// document's scroll position survives untouched underneath -- the
-	// fixed, Canvas-backed fullscreen element covers it regardless.
+	// document's scroll position is saved across the screen switch by the
+	// fullscreen manager: while the alternate screen is up, the camera is
+	// the fullscreen element's.
 	const isFullscreen = self[kFullscreenManager].isFullscreen;
 	const contentHeight = isFullscreen ?
 		self[kHeight] :
@@ -3714,14 +3748,17 @@ async function renderInteractive(
 	// Take the room we need by pushing earlier output up, never over it.
 	const top = isFullscreen ? 0 : reserveRows(self, regionHeight);
 
-	if (!isFullscreen) {
-		// The camera cannot run off the end of the document.
-		const maxScroll = Math.max(0, contentHeight - regionHeight);
-		self[kViewport].scrollTop = Math.min(
-			self[kViewport].scrollTop,
-			maxScroll,
-		);
-	}
+	// The camera cannot run off the end of the content: the document's
+	// paint height -- or in fullscreen the fullscreen element's, whose box
+	// is pinned to the screen while its content scrolls under it.
+	const scrollExtent = isFullscreen ?
+			fullscreenPaintHeight(self) :
+		contentHeight;
+	const maxScroll = Math.max(0, scrollExtent - regionHeight);
+	self[kViewport].scrollTop = Math.min(
+		self[kViewport].scrollTop,
+		maxScroll,
+	);
 
 	// A frame is a TRANSFORM when everything that changed since the last
 	// one is bounded: a camera delta (the terminal scrolls the region via

--- a/src/internal/viewport.ts
+++ b/src/internal/viewport.ts
@@ -51,7 +51,9 @@ export class Viewport {
 	 * The document point under a terminal cell (screen column, screen row), or
 	 * null for a row above the painted region -- a shell prompt above the
 	 * command start is not part of the document. In fullscreen the alternate
-	 * screen owns row zero, so the anchor supplies the origin directly.
+	 * screen owns row zero, so the anchor supplies the origin; the camera
+	 * offset applies there too, since fullscreen content scrolls under the
+	 * pinned fullscreen box and hit-testing converts back for what is pinned.
 	 */
 	screenToDocumentPoint(
 		x: number,
@@ -59,7 +61,7 @@ export class Viewport {
 		isFullscreen: boolean,
 	): {x: number; y: number} | null {
 		if (isFullscreen) {
-			return {x, y: row + this[kAnchorScrollTop]};
+			return {x, y: row + this[kAnchorScrollTop] + this[kScrollTop]};
 		}
 		const y = row - this[kScreenTop] + this[kScrollTop];
 		return y < 0 ? null : {x, y};

--- a/tests/fullscreen-scroll.test.ts
+++ b/tests/fullscreen-scroll.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The document camera inside a fullscreen element.
+ *
+ * A fullscreen element is the viewport for its content: its box is pinned
+ * to the screen at row zero, its in-flow descendants scroll with the
+ * camera (window.scrollTo/scrollBy), and a position:fixed descendant pins
+ * to the screen while the content moves under it. The camera clamps to
+ * the fullscreen content's height, scrollIntoView reveals descendants by
+ * moving it, and hit-testing resolves to what a scrolled cell shows.
+ */
+
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {MockProcess, nextFrame} from "./test-utils";
+
+/**
+ * A fullscreen stage taller than the 6-row screen: a pinned status bar
+ * over sixteen one-row lines, L00 through L15.
+ */
+async function mountStage(): Promise<{
+	terminal: MockProcess;
+	dom: TermDOM;
+	rows: () => string[];
+}> {
+	const terminal = new MockProcess({rows: 6, cols: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.attach();
+	const {document} = dom;
+	const lines = Array.from(
+		{length: 16},
+		(_, i) => `<div id="L${String(i).padStart(2, "0")}">` +
+			`L${String(i).padStart(2, "0")} content</div>`,
+	).join("");
+	document.body.innerHTML =
+		"<div id=\"fs\">" +
+		"<div id=\"bar\" style=\"position: fixed; top: 0; left: 0\">STATUS</div>" +
+		lines +
+		"</div>";
+	await nextFrame(dom);
+	await document.getElementById("fs")!.requestFullscreen();
+	await nextFrame(dom);
+	return {
+		terminal,
+		dom,
+		rows: () => terminal.getPlainText().split("\n"),
+	};
+}
+
+test("the camera scrolls fullscreen content under a pinned fixed bar", async () => {
+	const {dom, rows} = await mountStage();
+
+	// Before any scroll: content from the top, the bar over row zero.
+	expect(rows()[0]).toContain("STATUS");
+	expect(rows().join("\n")).toContain("L01");
+	expect(rows().join("\n")).toContain("L05");
+	expect(rows().join("\n")).not.toContain("L08");
+
+	dom.window.scrollBy(0, 3);
+	await nextFrame(dom);
+
+	// The content moved up three rows; the bar did not move.
+	expect(rows()[0]).toContain("STATUS");
+	expect(rows().join("\n")).toContain("L05");
+	expect(rows().join("\n")).toContain("L08");
+	expect(rows().join("\n")).not.toContain("L02");
+
+	dom.dispose();
+});
+
+test("the camera clamps to the fullscreen content height", async () => {
+	const {dom, rows} = await mountStage();
+
+	dom.window.scrollTo(0, 999);
+	await nextFrame(dom);
+
+	// Sixteen content rows in a 6-row screen: the camera stops at 10.
+	expect(dom.window.scrollY).toBe(10);
+	expect(rows()[0]).toContain("STATUS");
+	expect(rows().join("\n")).toContain("L15");
+	expect(rows().join("\n")).not.toContain("L09");
+
+	dom.dispose();
+});
+
+test("scrollIntoView reveals a deep fullscreen descendant", async () => {
+	const {dom, rows} = await mountStage();
+	const {document} = dom;
+
+	document.getElementById("L12")!.scrollIntoView();
+	await nextFrame(dom);
+
+	expect(dom.window.scrollY).toBe(7);
+	expect(rows().join("\n")).toContain("L12");
+	expect(rows()[0]).toContain("STATUS");
+
+	dom.dispose();
+});
+
+test("elementFromPoint resolves what a scrolled fullscreen cell shows", async () => {
+	const {dom} = await mountStage();
+	const {document} = dom;
+
+	dom.window.scrollTo(0, 7);
+	await nextFrame(dom);
+
+	// Screen row 3 shows document row 10; row 0 is the pinned bar.
+	expect(document.elementFromPoint(1, 3)?.id).toBe("L10");
+	expect(document.elementFromPoint(1, 0)?.id).toBe("bar");
+
+	dom.dispose();
+});
+
+test("the document's scroll position survives a fullscreen session", async () => {
+	const terminal = new MockProcess({rows: 6, cols: 30});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.attach();
+	const {document} = dom;
+	const lines = Array.from({length: 12}, (_, i) => `<div>doc ${i}</div>`);
+	document.body.innerHTML = lines.join("") + "<div id=\"fs\">stage</div>";
+	await nextFrame(dom);
+
+	dom.window.scrollTo(0, 4);
+	await nextFrame(dom);
+	expect(dom.window.scrollY).toBe(4);
+
+	await document.getElementById("fs")!.requestFullscreen();
+	await nextFrame(dom);
+	// Fullscreen starts its viewport at the top.
+	expect(dom.window.scrollY).toBe(0);
+
+	await document.exitFullscreen();
+	await nextFrame(dom);
+	expect(dom.window.scrollY).toBe(4);
+
+	dom.dispose();
+});


### PR DESCRIPTION
The document camera did not reach into a fullscreen element. `requestFullscreen()` UA-styles the element `position: fixed`, the painter cancels the camera for anything in fixed space, and the fullscreen element's whole subtree inherited that — so `window.scrollBy`, `scrollTo`, and `scrollIntoView()` moved `scrollTop` while nothing on the alternate screen moved. A fullscreen app taller than the screen could not scroll.

This is the viewport camera reaching into the fullscreen subtree, a separate bug from element `overflow` scrolling (#65).

A fullscreen element is the viewport for its content: its box pins at row 0, its in-flow descendants scroll with the camera, and a `position: fixed` bar inside it pins to the fullscreen viewport and stays put while the content scrolls under it.

- The boundary is decided in one place: `isInFixedSpace` stops its walk at `fullscreenElement`. The painter, the camera clamp, and hit-testing follow from that.
- The camera clamps against the fullscreen element's content height, so scrolling past the end stops.
- Entering fullscreen saves the document scroll and starts at the top; exiting restores it.
- `elementFromPoint` and mouse reports land on the element shown at the cell after scrolling.

Five tests in `tests/fullscreen-scroll.test.ts`, written failing-first. Suite green node 1318 / bun 1343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
