### PR TITLE
Small fixes: grid-template-areas serialization, kbd as an accelerator mark

### DIFF
--- a/src/internal/styles.ts
+++ b/src/internal/styles.ts
@@ -620,16 +620,47 @@ function collapseRadius(value: string): string {
 }
 
 /**
+ * `grid-template-areas` computes to a list of rows, each a list of cell names
+ * (css-grid-2 §7.3), so the spacing an author lines a picture of the grid up
+ * with is not part of the value: every row writes its cells one space apart.
+ * A value that is not a run of strings -- `none`, a var() still to substitute
+ * -- is left as it is written.
+ */
+function normalizeGridAreas(value: string): string {
+	type ValueNode = {type: string; value?: string};
+	let children: ValueNode[];
+	try {
+		const ast = CSSTree.parse(value, {context: "value"}) as unknown as {
+			children?: {toArray(): ValueNode[]};
+		};
+		children = ast.children ? ast.children.toArray() : [];
+	} catch (_err) {
+		return value;
+	}
+	if (
+		children.length === 0 ||
+		children.some((node) => node.type !== "String")
+	) {
+		return value;
+	}
+	return children
+		.map((node) => `"${(node.value ?? "").trim().split(/\s+/).join(" ")}"`)
+		.join(" ");
+}
+
+/**
  * The computed spelling of a declared value: the one place a struct becomes
  * a string, at the getPropertyValue boundary.
  */
 function normalizeValue(property: string, declared: string): string {
 	const value = declared.trim();
-	if (
-		!value ||
-		property.startsWith("--") ||
-		VERBATIM_PROPERTIES.has(property)
-	) {
+	if (!value || property.startsWith("--")) {
+		return value;
+	}
+	if (property === "grid-template-areas") {
+		return normalizeGridAreas(value);
+	}
+	if (VERBATIM_PROPERTIES.has(property)) {
 		return value;
 	}
 	if (COLOR_PROPERTIES.has(property)) {

--- a/src/internal/useragent.ts
+++ b/src/internal/useragent.ts
@@ -953,10 +953,15 @@ const TERMINAL_ELEMENT_DEFAULTS: Record<string, Record<string, string>> = {
 	// A key is a keycap: bold text inside brackets, "[q]", the form every
 	// terminal help screen and man page uses for a key to press. A browser
 	// draws the cap with a border and a monospace face; a terminal is already
-	// monospace and cannot afford a box around one glyph, so the brackets are
-	// the cap. They are UA ::before/::after rules in the UA document
-	// stylesheet, so author content rules replace them.
-	kbd: {"display": "inline", "font-weight": "bold"},
+	// monospace and cannot afford a box around one glyph, so the accelerator
+	// convention stands in: the marked keys are bold and underlined, the way
+	// CUA-era TUIs marked a menu's mnemonic letter. A decoration costs no
+	// cells, so marking up a key never moves layout.
+	kbd: {
+		"display": "inline",
+		"font-weight": "bold",
+		"text-decoration": "underline",
+	},
 	label: {display: "inline"},
 	mark: {display: "inline"},
 	q: {display: "inline"},
@@ -1297,8 +1302,6 @@ export const UA_DOCUMENT_STYLES = `
 	*::selection { background-color: Highlight; color: HighlightText; }
 	button::before { content: "[ "; }
 	button::after { content: " ]"; }
-	kbd::before { content: "["; }
-	kbd::after { content: "]"; }
 	a[href] { text-decoration: underline; }
 	/*
 	 * The dir attribute, so it reaches layout as the direction property it

--- a/tests/grid.test.ts
+++ b/tests/grid.test.ts
@@ -1413,6 +1413,43 @@ test("grid-template-areas reports its rows", async () => {
 	expect(resolved("grid-template-areas")).toBe("\"a b\" \"c d\"");
 });
 
+test("an area map lined up as a picture reports one space between cells", async () => {
+	// css-grid-2 §7.3: the value is rows of cell names, so the padding an
+	// author aligns the picture with is not part of it. The map comes off a
+	// stylesheet, where a row can be written across several lines.
+	const terminal = new MockProcess({cols: 30, rows: 6});
+	const dom = new TermDOM({transport: terminal.transport});
+	const style = dom.document.createElement("style");
+	style.textContent = `
+		#g {
+			display: grid;
+			grid-template-areas:
+				"head  head"
+				"side  main";
+			grid-template-columns: 8px 1fr;
+			grid-template-rows: 1px 1px;
+		}
+	`;
+	dom.document.head.appendChild(style);
+	dom.document.body.innerHTML =
+		"<div id=\"g\"><i style=\"grid-area:head\">HEAD</i>" +
+		"<i style=\"grid-area:side\">SIDE</i>" +
+		"<i style=\"grid-area:main\">MAIN</i></div>";
+	await nextFrame(dom);
+
+	const grid = dom.document.querySelector("#g")!;
+	const computed = dom.window.getComputedStyle(grid);
+	expect(computed.getPropertyValue("grid-template-areas")).toBe(
+		"\"head head\" \"side main\"",
+	);
+	const main = dom.document.querySelectorAll("i")[2].getBoundingClientRect();
+	expect({left: main.left, top: main.top, width: main.width}).toEqual({
+		left: 8,
+		top: 1,
+		width: 22,
+	});
+});
+
 test("a length in a track list computes to cells", async () => {
 	const {resolved} = await render(
 		"<div id=\"g\" style=\"grid-template-columns: 2ch 1em\"></div>",

--- a/tests/widgets.test.ts
+++ b/tests/widgets.test.ts
@@ -209,27 +209,29 @@ function cellAt(terminal: MockProcess, row: number, col: number): any {
 	return (terminal as any).terminal.buffer.active.getLine(row).getCell(col);
 }
 
-test("a kbd wears brackets and bold", async () => {
+test("a kbd is bold and underlined, the accelerator convention", async () => {
 	const terminal = new MockProcess({rows: 4, cols: 40});
 	const dom = new TermDOM({transport: terminal.transport});
-	dom.document.body.innerHTML = "<kbd>x</kbd>";
+	dom.document.body.innerHTML = "<kbd>q</kbd>uit";
 	await nextFrame(dom);
 
-	expect(terminal.getPlainText()).toContain("[x]");
-	// The brackets are generated content of the kbd, so they carry its weight.
+	// The mark is a decoration, not generated content: no cells are added.
+	expect(terminal.getPlainText()).toContain("quit");
+	expect(terminal.getPlainText()).not.toContain("[");
 	expect(cellAt(terminal, 0, 0).isBold()).toBeTruthy();
-	expect(cellAt(terminal, 0, 1).isBold()).toBeTruthy();
-	expect(cellAt(terminal, 0, 2).isBold()).toBeTruthy();
+	expect(cellAt(terminal, 0, 0).isUnderline()).toBeTruthy();
+	expect(cellAt(terminal, 0, 1).isBold()).toBeFalsy();
+	expect(cellAt(terminal, 0, 1).isUnderline()).toBeFalsy();
 
 	dom.dispose();
 });
 
-test("author rules replace the keycap's brackets and weight", async () => {
+test("author rules restyle the keycap", async () => {
 	const terminal = new MockProcess({rows: 4, cols: 40});
 	const dom = new TermDOM({transport: terminal.transport});
 	dom.document.body.innerHTML =
 		"<style>" +
-		"kbd { font-weight: normal; }" +
+		"kbd { font-weight: normal; text-decoration: none; }" +
 		"kbd::before { content: \"<\"; }" +
 		"kbd::after { content: \">\"; }" +
 		"</style>" +
@@ -238,6 +240,7 @@ test("author rules replace the keycap's brackets and weight", async () => {
 
 	expect(terminal.getPlainText()).toContain("<x>");
 	expect(cellAt(terminal, 0, 1).isBold()).toBeFalsy();
+	expect(cellAt(terminal, 0, 1).isUnderline()).toBeFalsy();
 
 	dom.dispose();
 });


### PR DESCRIPTION
Two small fixes.

**`grid-template-areas` serialization.** `getComputedStyle(el).gridTemplateAreas` returned the declared text verbatim, author formatting included: an area map lined up as a picture — `"nav      chart    stats"` — reported its padding spaces in the computed value. Per css-grid-2 §7.3 the computed value serializes each row as its cell names, one space apart. Layout never noticed (`parseGridAreas` splits on `/\s+/`), so this was CSSOM-only. The cause: `grid-template-areas` sat in `VERBATIM_PROPERTIES`, so `normalizeValue` returned it untouched. The fix reparses the value and rewrites each string as its cells one space apart, leaving `none` and unsubstituted `var()` alone. The new test builds its grid from a `<style>` element with a multi-line, column-aligned map — the two things the existing grid fixtures never do, which is how 140 tests missed it.

**`kbd` marks its key instead of bracketing it.** The UA brackets were generated content, so wrapping a letter in `<kbd>` cost two cells and moved the layout around it. The element now renders bold and underlined — the CUA-era accelerator convention — and a decoration costs no cells, so `<kbd>q</kbd>uit` lays out as `quit` with a marked q. Author rules restyle or re-bracket it as before.

Suite: node 1518 passed, bun 1543 passed, 0 failed. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD