### PR TITLE
Reserve the backdrop's rows for a modal over an anchored session

### DIFF
--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -3338,6 +3338,15 @@ function documentPaintHeight(
 		if (!termdom[kUAToolkit].flatIsConnected(element)) {
 			continue;
 		}
+		// A modal's ::backdrop paints the whole viewport, so the frame
+		// emits that many rows whatever the dialog's own box says. The
+		// reserve must match what the emitter writes: reserving less
+		// lets the frame's last rows push the terminal past its bottom,
+		// a physical scroll no bookkeeping records -- and from then on
+		// the anchor lies by that many rows.
+		if (termdom[kUAToolkit].isModalDialog(element)) {
+			return termdom[kHeight];
+		}
 		const rect = termdom[kLayoutEngine].getRect(element);
 		if (rect) {
 			height = Math.max(height, Math.ceil(rect.bottom));

--- a/tests/dialog.test.ts
+++ b/tests/dialog.test.ts
@@ -266,3 +266,37 @@ test("Escape reaches no dialog while nothing is showing modally", async () => {
 	expect(dialog.open).toBe(true);
 	dom.dispose();
 });
+
+test("a modal over an anchored session reserves the backdrop's rows", async () => {
+	// The modal's ::backdrop paints the whole viewport, so the frame emits
+	// viewport-height rows. Reserving less let those rows push the
+	// terminal past its bottom -- a physical scroll no bookkeeping
+	// recorded, after which the anchor lied by that amount and later
+	// frames and the exit payout painted over the wrong rows.
+	const terminal = new MockProcess({cols: 50, rows: 12});
+	terminal.stdout.write("SHELL BANNER\r\n");
+	const dom = new TermDOM({transport: terminal.sharedTransport});
+	await dom.attach();
+	const {document, window} = dom;
+	document.body.innerHTML =
+		"<main><div>row a</div><div>row b</div></main>" +
+		"<dialog id=\"d\"><button>OK</button></dialog>";
+	await nextFrame(dom);
+	const anchored = window.screenTop;
+	expect(anchored).toBeGreaterThan(0);
+
+	const dialog = document.getElementById("d") as HTMLDialogElement;
+	dialog.showModal();
+	await nextFrame(dom);
+	// The whole viewport is reserved: the anchor moved up through the
+	// engine's own scroll, not the terminal's silent one.
+	expect(window.screenTop).toBe(0);
+
+	dialog.close();
+	dialog.remove();
+	await nextFrame(dom);
+	const text = terminal.getVisibleText();
+	expect(text.split("row a").length - 1).toBe(1);
+	expect(text.split("row b").length - 1).toBe(1);
+	dom.dispose();
+});


### PR DESCRIPTION
**What "anchored (flow)" means.** TermDOM attaches in one of two modes. Fullscreen takes the alternate screen and owns every row from row zero. Anchored — flow — mode is the other: the document renders inline in the main screen, like ordinary command output. At attach, cursor detection finds the row the shell left the cursor on; that row becomes the anchor (`window.screenTop`), and the app's region is the rows from the anchor down to the bottom of the terminal. Everything above the anchor is the shell's history and is never written to. When the document needs more rows than exist below the anchor, `reserveRows` scrolls the terminal itself (`ESC D` at the bottom row), which moves the anchor up and pushes prior output into scrollback — intact, not overwritten. The coordinate system rests on one invariant: the engine knows where the anchor is, so every physical scroll must pass through its own bookkeeping.

**The bug.** A modal dialog's `::backdrop` paints the full viewport, so a frame with a modal open emits viewport-height rows. But the reserve negotiated only the dialog element's own box. The terminal scrolled by the difference — a physical scroll the engine never recorded — and from then on the anchor lied. Every later frame and the exit payout painted relative to the stale anchor: duplicated transcripts, interleaved lines, prior output clobbered. Found driving Gierge's permission modal; reproduced down to the exact overflow bytes on the wire.

**The fix.** Reserved rows must equal emitted rows. While a connected modal is in the top layer, `documentPaintHeight` reports the terminal height, so the reserve grows to the full viewport *before* the frame paints. The scroll then happens through `reserveRows`' own `ESC D` path — the anchor moves up with the engine watching, and coordinates stay true.

**Does a modal damage output above the command?** No — that is what routing everything through the reserve buys. The room a modal needs is created by scrolling, not by painting: prior shell output moves up into scrollback unharmed, and nothing above the anchor is ever written. There is nothing to restore because nothing is destroyed. The cost is displacement, not damage: a terminal can't be scrolled back down without repainting rows we never owned, so after the modal closes the anchor stays where the modal pushed it (row zero, for a document shorter than the screen) and the earlier output lives in scrollback rather than on screen.

**Left open.** That displacement is the open design question: should a modal center in the terminal viewport (current behavior, now correct), or in the app's own region — which would leave the anchor alone for short documents, at the price of a dialog that isn't viewport-centered. That's a design call, separable from this correctness fix.

The regression test asserts, via the emulator, that the anchor reaches row zero under the modal and content paints exactly once — this bug class turns out to be suite-visible as banner loss, no tty needed.

Suites green both lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
