### PR TITLE
Track hover and enable motion reporting on demand

### DIFF
--- a/src/internal/cascade.ts
+++ b/src/internal/cascade.ts
@@ -9099,7 +9099,6 @@ const kListItemRulesExist = Symbol("listItemRulesExist");
 const kScopedRulesExist = Symbol("scopedRulesExist");
 const kHasRulesExist = Symbol("hasRulesExist");
 const kHoverRulesExist = Symbol("hoverRulesExist");
-const kHoverAvailable = Symbol("hoverAvailable");
 const kLayerPaths = Symbol("layerPaths");
 const kAnonymousLayers = Symbol("anonymousLayers");
 const kUnlayeredRank = Symbol("unlayeredRank");
@@ -9181,10 +9180,6 @@ export class StyleManager {
 	// The `:focus-visible` state, driven by TermDOM from the last input modality
 	// (keyboard true, pointer false). kRuleMatches gates such rules on it.
 	declare [kFocusVisibleActive]: boolean;
-	// Whether this display has hover at all, which is what `@media (hover)`
-	// answers. TermDOM sets it false when its `hover` option forbids motion
-	// reporting; a headless document keeps the default.
-	declare [kHoverAvailable]: boolean;
 	/**
 	 * How many document.styleSheets the last parse consumed; -1 = never
 	 * parsed. A changed count re-parses on the next style computation --
@@ -9230,7 +9225,6 @@ export class StyleManager {
 		this[kHasRulesExist] = false;
 		this[kHoverRulesExist] = false;
 		this[kFocusVisibleActive] = true;
-		this[kHoverAvailable] = true;
 		this[kParsedStyleSheetCount] = -1;
 		this[kCounterScopes] = new WeakMap<Element, CounterScope>();
 		this[kLayoutFlush] = null;
@@ -9808,11 +9802,6 @@ export class StyleManager {
 			parseStylesheets(this);
 		}
 		return this[kHoverRulesExist];
-	}
-
-	/** Set whether this display has hover, which `@media (hover)` reports. */
-	setHoverAvailable(available: boolean): void {
-		this[kHoverAvailable] = available;
 	}
 
 	/** Set the `:focus-visible` state; returns whether it changed. */
@@ -10781,13 +10770,12 @@ function mediaFeatureMatches(
 	feature: string,
 ): boolean {
 	// mediaqueries-4's hover feature: `hover` when the primary pointer can
-	// hover, `none` when it cannot. Here that is whether the terminal
-	// reports motion -- or would, were anything observing hover; a bare
-	// `(hover)` is the boolean context, true only on `hover`.
+	// hover. Motion reporting turns on whenever the document observes
+	// hover, so the answer is unconditional; a bare `(hover)` is the
+	// boolean context.
 	const hoverMatch = feature.match(/^(any-)?hover(\s*:\s*(hover|none))?$/i);
 	if (hoverMatch) {
-		const wanted = hoverMatch[3]?.toLowerCase() ?? "hover";
-		return (wanted === "hover") === manager[kHoverAvailable];
+		return (hoverMatch[3]?.toLowerCase() ?? "hover") === "hover";
 	}
 	const match = feature.match(
 		/^(min-|max-)?(width|height)\s*:\s*([\d.]+)(px|ch)?$/i,

--- a/src/internal/cascade.ts
+++ b/src/internal/cascade.ts
@@ -9098,6 +9098,8 @@ const kCounterRulesExist = Symbol("counterRulesExist");
 const kListItemRulesExist = Symbol("listItemRulesExist");
 const kScopedRulesExist = Symbol("scopedRulesExist");
 const kHasRulesExist = Symbol("hasRulesExist");
+const kHoverRulesExist = Symbol("hoverRulesExist");
+const kHoverAvailable = Symbol("hoverAvailable");
 const kLayerPaths = Symbol("layerPaths");
 const kAnonymousLayers = Symbol("anonymousLayers");
 const kUnlayeredRank = Symbol("unlayeredRank");
@@ -9169,9 +9171,20 @@ export class StyleManager {
 	/** Whether any rule is scoped, which is what puts proximity in the sort. */
 	declare [kScopedRulesExist]: boolean;
 	declare [kHasRulesExist]: boolean;
+	/**
+	 * Whether any parsed selector mentions `:hover`. The engine reads this to
+	 * decide whether the terminal must report pointer motion: a sheet that
+	 * never tests hover is a document that cannot show it, and motion
+	 * reporting has a per-cell cost the document should not pay for nothing.
+	 */
+	declare [kHoverRulesExist]: boolean;
 	// The `:focus-visible` state, driven by TermDOM from the last input modality
 	// (keyboard true, pointer false). kRuleMatches gates such rules on it.
 	declare [kFocusVisibleActive]: boolean;
+	// Whether this display has hover at all, which is what `@media (hover)`
+	// answers. TermDOM sets it false when its `hover` option forbids motion
+	// reporting; a headless document keeps the default.
+	declare [kHoverAvailable]: boolean;
 	/**
 	 * How many document.styleSheets the last parse consumed; -1 = never
 	 * parsed. A changed count re-parses on the next style computation --
@@ -9215,7 +9228,9 @@ export class StyleManager {
 		this[kListItemRulesExist] = false;
 		this[kScopedRulesExist] = false;
 		this[kHasRulesExist] = false;
+		this[kHoverRulesExist] = false;
 		this[kFocusVisibleActive] = true;
+		this[kHoverAvailable] = true;
 		this[kParsedStyleSheetCount] = -1;
 		this[kCounterScopes] = new WeakMap<Element, CounterScope>();
 		this[kLayoutFlush] = null;
@@ -9726,6 +9741,78 @@ export class StyleManager {
 		// and the rows the element claims are the damage to repaint.
 		this[kPendingStyleDamage]?.add(element);
 		this[kLayoutEngine]?.invalidateFrame();
+	}
+
+	/**
+	 * The pointer moved to a new element: the cached declarations of both
+	 * hover chains hold rule sets matched under the OLD hover state, the
+	 * same staleness a focus move leaves. Scoped to the symmetric
+	 * difference of the two flat-tree chains -- the part of the tree whose
+	 * `:hover` answer moved; the shared ancestors above the fork answered
+	 * hovered before and answer hovered still. Each invalidated stop also
+	 * lands in the style damage the frame drains, so the repaint stays a
+	 * banded one: hover is not a mutation and nothing else names its rows.
+	 */
+	handleHoverChange(
+		previous: Element | null,
+		next: Element | null,
+	): void {
+		const chainOf = (element: Element | null): Set<Element> => {
+			const chain = new Set<Element>();
+			for (
+				let node: Element | null = element;
+				node;
+				node = flatParentElement<Element>(node)
+			) {
+				chain.add(node);
+			}
+			return chain;
+		};
+		const previousChain = chainOf(previous);
+		const nextChain = chainOf(next);
+		const invalidate = (node: Element): void => {
+			invalidateElementCaches(this, node);
+			this[kPendingStyleDamage]?.add(node);
+			// A host's hover reaches into its shadow tree through
+			// :host(:hover) rules and inheritance, the same reach a focus
+			// move has.
+			const shadowRoot = shadowRootOf<ShadowRoot>(node);
+			if (shadowRoot) {
+				for (const descendant of shadowRoot.querySelectorAll("*")) {
+					invalidateElementCaches(this, descendant);
+				}
+			}
+		};
+		for (const node of previousChain) {
+			if (!nextChain.has(node)) {
+				invalidate(node);
+			}
+		}
+		for (const node of nextChain) {
+			if (!previousChain.has(node)) {
+				invalidate(node);
+			}
+		}
+	}
+
+	/**
+	 * Whether any active rule tests `:hover`, against the sheets as they
+	 * stand -- a dirty sheet list parses first, so an answer read between
+	 * frames still describes the current document.
+	 */
+	hoverRulesExist(): boolean {
+		if (
+			this[kStylesheetsDirty] ||
+			styleSheetCount(this) !== this[kParsedStyleSheetCount]
+		) {
+			parseStylesheets(this);
+		}
+		return this[kHoverRulesExist];
+	}
+
+	/** Set whether this display has hover, which `@media (hover)` reports. */
+	setHoverAvailable(available: boolean): void {
+		this[kHoverAvailable] = available;
 	}
 
 	/** Set the `:focus-visible` state; returns whether it changed. */
@@ -10466,6 +10553,7 @@ function parseStylesheets(
 	manager[kListItemRulesExist] = false;
 	manager[kScopedRulesExist] = false;
 	manager[kHasRulesExist] = false;
+	manager[kHoverRulesExist] = false;
 	manager[kStylesheetsDirty] = false;
 	manager[kLayerPaths] = [];
 	manager[kAnonymousLayers] = 0;
@@ -10692,6 +10780,15 @@ function mediaFeatureMatches(
 	manager: StyleManager,
 	feature: string,
 ): boolean {
+	// mediaqueries-4's hover feature: `hover` when the primary pointer can
+	// hover, `none` when it cannot. Here that is whether the terminal
+	// reports motion -- or would, were anything observing hover; a bare
+	// `(hover)` is the boolean context, true only on `hover`.
+	const hoverMatch = feature.match(/^(any-)?hover(\s*:\s*(hover|none))?$/i);
+	if (hoverMatch) {
+		const wanted = hoverMatch[3]?.toLowerCase() ?? "hover";
+		return (wanted === "hover") === manager[kHoverAvailable];
+	}
 	const match = feature.match(
 		/^(min-|max-)?(width|height)\s*:\s*([\d.]+)(px|ch)?$/i,
 	);
@@ -10814,6 +10911,9 @@ function parseSelector(
 	// documents that actually pay for it.
 	if (selector.includes(":has(")) {
 		manager[kHasRulesExist] = true;
+	}
+	if (selector.includes(":hover")) {
+		manager[kHoverRulesExist] = true;
 	}
 	let scopes: readonly ScopeCondition[] | undefined;
 	if (context.scopes.length > 0) {

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -2745,6 +2745,90 @@ export interface EventListenerOptions {
 	capture?: boolean;
 }
 
+/** The event types whose listeners mean a document observes pointer hover. */
+const HOVER_EVENT_TYPES = new Set([
+	"mousemove",
+	"mouseover",
+	"mouseout",
+	"mouseenter",
+	"mouseleave",
+]);
+
+/**
+ * How many hover-observing listeners a document's targets hold, and who to
+ * tell when the count moves. The engine watches this to decide whether the
+ * terminal should report pointer motion at all: motion reporting floods
+ * stdin, so it stays off until something can actually see the events.
+ */
+interface HoverListenerTally {
+	count: number;
+	onChange: (() => void) | null;
+}
+
+const hoverListenerTallies = new WeakMap<Document, HoverListenerTally>();
+
+function hoverTallyOf(document: Document): HoverListenerTally {
+	let tally = hoverListenerTallies.get(document);
+	if (tally === undefined) {
+		tally = {count: 0, onChange: null};
+		hoverListenerTallies.set(document, tally);
+	}
+	return tally;
+}
+
+/**
+ * The tally a hover listener on this target counts into, or null when the
+ * type is not a hover type or the target belongs to no document.
+ */
+function hoverTallyFor(
+	target: EventTarget,
+	type: string,
+): HoverListenerTally | null {
+	if (!HOVER_EVENT_TYPES.has(type)) {
+		return null;
+	}
+	if (target instanceof Node) {
+		return hoverTallyOf(target[kDocument]);
+	}
+	// A window is an EventTarget with a document; anything else counts
+	// nowhere.
+	const document = (target as {document?: unknown}).document;
+	return document instanceof Document ? hoverTallyOf(document) : null;
+}
+
+/**
+ * True while the UA's own machinery registers listeners: nwsapi installs
+ * document mouseover/mouseout trackers for its builtin `:hover`, and those
+ * are nobody observing hover.
+ */
+let hoverTallySuspended = false;
+
+function tallyHoverListener(target: EventTarget, listener: Listener): void {
+	if (hoverTallySuspended) {
+		return;
+	}
+	const tally = hoverTallyFor(target, listener.type);
+	if (tally !== null) {
+		listener.hoverTally = tally;
+		tally.count++;
+		tally.onChange?.();
+	}
+}
+
+/**
+ * Watch a document's hover-listener count: `onChange` fires whenever it
+ * moves, and the returned reader answers the current count. One watcher per
+ * document -- the engine that displays it.
+ */
+export function watchHoverListeners(
+	document: Document,
+	onChange: () => void,
+): () => number {
+	const tally = hoverTallyOf(document);
+	tally.onChange = onChange;
+	return () => tally.count;
+}
+
 interface Listener {
 	type: string;
 	callback: EventListenerOrEventListenerObject;
@@ -2752,6 +2836,8 @@ interface Listener {
 	once: boolean;
 	passive: boolean;
 	removed: boolean;
+	/** The hover tally this listener counts into, where it counts at all. */
+	hoverTally?: HoverListenerTally;
 }
 
 /** The AbortSignal the platform supplies, which a listener's signal must be. */
@@ -2921,6 +3007,7 @@ export class EventTarget {
 			removed: false,
 		};
 		this[kListeners].push(listener);
+		tallyHoverListener(this, listener);
 		if (flat.signal !== null) {
 			flat.signal.addEventListener("abort", () => {
 				removeListener(this[kListeners], listener);
@@ -2993,6 +3080,10 @@ function removeListener(listeners: Listener[], listener: Listener): void {
 	const index = listeners.indexOf(listener);
 	if (index !== -1) {
 		listeners.splice(index, 1);
+		if (listener.hoverTally !== undefined) {
+			listener.hoverTally.count--;
+			listener.hoverTally.onChange?.();
+		}
 	}
 }
 
@@ -3100,6 +3191,7 @@ function registerHandlerListener(
 		removed: false,
 	};
 	target[kListeners].push(listener);
+	tallyHoverListener(target, listener);
 	return listener;
 }
 
@@ -22904,6 +22996,26 @@ Object.defineProperty(TreeWalker.prototype, Symbol.toStringTag, {
 
 /* --------------------------------------------------------------- selectors */
 
+/**
+ * The element under the pointer, per document. Hover is not a mutation and
+ * no attribute records it: the engine writes it here as motion reports
+ * arrive, and the `:hover` resolver below reads it. Absent means nothing is
+ * hovered -- a document without motion reporting, or a pointer that left.
+ */
+const hoveredElements = new WeakMap<Document, Element>();
+
+/** Record the element the pointer is over, which `:hover` matches from. */
+export function setHoveredElement(
+	document: Document,
+	element: Element | null,
+): void {
+	if (element === null) {
+		hoveredElements.delete(document);
+	} else {
+		hoveredElements.set(document, element);
+	}
+}
+
 interface SelectorEngine {
 	match(selector: string, element: never): boolean;
 	first(selector: string, context: never): unknown;
@@ -22915,10 +23027,18 @@ interface SelectorEngine {
 function selectorEngine(document: Document): SelectorEngine {
 	let engine = document[kNwsapi];
 	if (engine === null) {
-		engine = NWSAPI({
-			document: document as never,
-			DOMException: PlatformDOMException as never,
-		});
+		// nwsapi's factory registers document mouseover/mouseout listeners
+		// for its own builtin :hover, which the rewrites below bypass; they
+		// must not read as the document observing hover.
+		hoverTallySuspended = true;
+		try {
+			engine = NWSAPI({
+				document: document as never,
+				DOMException: PlatformDOMException as never,
+			});
+		} finally {
+			hoverTallySuspended = false;
+		}
 		engine.configure({
 			LOGERRORS: false,
 			IDS_DUPES: true,
@@ -23021,23 +23141,51 @@ function selectorEngine(document: Document): SelectorEngine {
 				modvar: null,
 			}),
 		);
+		// `:hover` matches the element under the pointer and its flat-tree
+		// ancestors, per css-selectors-4's "an element that is designated" --
+		// which slot projection and shadow hosts reorder past what the light
+		// tree records, so the climb is the flat parent's.
+		engine.Snapshot.hasHoverState = (element: Element): boolean => {
+			for (
+				let node: Element | null = hoveredElements.get(document) ?? null;
+				node !== null;
+				node = flatParentElement<Element>(node)
+			) {
+				if (node === element) {
+					return true;
+				}
+			}
+			return false;
+		};
+		engine.registerSelector(
+			":-termdom-hover",
+			/^:-termdom-hover(?![\w-])(.*)/i,
+			(match: string[], source: string) => ({
+				match,
+				source: `if(s.hasHoverState(e)){${source}}`,
+				status: true,
+				modvar: null,
+			}),
+		);
 		// The engine's own compiled `:focus` family predates shadow trees:
 		// its focus test wants a focusable-looking shape at
 		// document.activeElement, and its `:focus-within` cannot reach an
-		// ancestor at all. The names above resolve through the raw focus
-		// state instead, and every selector is spelled onto them on the way
-		// in -- the four entry points below are the only doors.
-		const FOCUS_REWRITES: Array<[RegExp, string]> = [
+		// ancestor at all. Its `:hover` predates hover state existing here at
+		// all. The names above resolve through the raw states instead, and
+		// every selector is spelled onto them on the way in -- the four entry
+		// points below are the only doors.
+		const STATE_REWRITES: Array<[RegExp, string]> = [
 			[/:focus-within(?![\w-])/gi, ":-termdom-focus-within"],
 			[/:focus-visible(?![\w-])/gi, ":-termdom-focus"],
 			[/:focus(?![\w-])/gi, ":-termdom-focus"],
+			[/:hover(?![\w-])/gi, ":-termdom-hover"],
 		];
-		const rewriteFocus = (selector: string): string => {
-			if (!/:focus/i.test(selector)) {
+		const rewriteState = (selector: string): string => {
+			if (!/:focus|:hover/i.test(selector)) {
 				return selector;
 			}
 			let rewritten = selector;
-			for (const [pattern, name] of FOCUS_REWRITES) {
+			for (const [pattern, name] of STATE_REWRITES) {
 				rewritten = rewritten.replace(pattern, name);
 			}
 			return rewritten;
@@ -23050,13 +23198,13 @@ function selectorEngine(document: Document): SelectorEngine {
 		};
 		const rawClosest = withClosest.closest.bind(engine);
 		engine.match = (selector: string, element: unknown, ...rest: unknown[]) =>
-			rawMatch(rewriteFocus(selector), element, ...rest);
+			rawMatch(rewriteState(selector), element, ...rest);
 		engine.first = (selector: string, ...rest: unknown[]) =>
-			rawFirst(rewriteFocus(selector), ...rest);
+			rawFirst(rewriteState(selector), ...rest);
 		engine.select = (selector: string, ...rest: unknown[]) =>
-			rawSelect(rewriteFocus(selector), ...rest);
+			rawSelect(rewriteState(selector), ...rest);
 		withClosest.closest = (selector: string, ...rest: unknown[]) =>
-			rawClosest(rewriteFocus(selector), ...rest);
+			rawClosest(rewriteState(selector), ...rest);
 		if (document.documentElement !== null) {
 			document[kNwsapi] = engine;
 		}

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -245,16 +245,6 @@ export interface TermDOMOptions {
 	html?: string;
 	/** The initial document's URL. */
 	url?: string;
-	/**
-	 * Pointer-motion (hover) reporting. Terminals deliver hover as a report
-	 * per cell crossed, which floods stdin, so "auto" (the default) enables
-	 * it only while the document observes hover -- a sheet with a `:hover`
-	 * rule, or a listener for the mousemove/mouseover/mouseout/mouseenter/
-	 * mouseleave family -- and disables it when the last observer goes.
-	 * `true` enables it for the whole attachment; `false` never enables it,
-	 * and `@media (hover: none)` matches.
-	 */
-	hover?: "auto" | boolean;
 }
 
 const kLayoutEngine = Symbol("layoutEngine");
@@ -733,7 +723,6 @@ const kAttachBeginning = Symbol("attachBeginning");
 const kAttachBegun = Symbol("attachBegun");
 const kDisposed = Symbol("disposed");
 const kMouseReportingEnabled = Symbol("mouseReportingEnabled");
-const kHoverOption = Symbol("hoverOption");
 const kHoverReportingEnabled = Symbol("hoverReportingEnabled");
 const kHoverListenerCount = Symbol("hoverListenerCount");
 const kPendingHover = Symbol("pendingHover");
@@ -892,9 +881,6 @@ export class TermDOM {
 	// Whether the terminal is currently reporting mouse events to us. See
 	// updateMouseReporting for when capture is on.
 	declare [kMouseReportingEnabled]: boolean;
-	// The `hover` option as given: "auto" turns motion reporting on and off
-	// with observation, a boolean pins it.
-	declare [kHoverOption]: "auto" | boolean;
 	// Whether the terminal is currently reporting pointer MOTION (SGR 1003)
 	// on top of button/drag reporting. See updateHoverReporting.
 	declare [kHoverReportingEnabled]: boolean;
@@ -1013,7 +999,6 @@ export class TermDOM {
 		this[kScrolledElements] = new Set();
 		this[kResizeEpoch] = 0;
 		this[kMouseReportingEnabled] = false;
-		this[kHoverOption] = options.hover ?? "auto";
 		this[kHoverReportingEnabled] = false;
 		this[kPendingHover] = null;
 		this[kHoverElement] = null;
@@ -1086,7 +1071,6 @@ export class TermDOM {
 
 		// Setup style management FIRST to override getComputedStyle before LayoutEngine uses it
 		this[kStyleManager] = new StyleManager(this.window);
-		this[kStyleManager].setHoverAvailable(this[kHoverOption] !== false);
 		// A hover listener appearing or vanishing moves the "does anything
 		// observe hover" answer between frames, so it pokes the mode update
 		// directly; the stylesheet half is re-read after each frame instead,
@@ -3267,9 +3251,6 @@ function updateMouseReporting(
 function hoverObserved(
 	termdom: TermDOM,
 ): boolean {
-	if (termdom[kHoverOption] !== "auto") {
-		return termdom[kHoverOption];
-	}
 	return (
 		termdom[kHoverListenerCount]() > 0 ||
 		termdom[kStyleManager].hoverRulesExist()
@@ -3280,8 +3261,9 @@ function hoverObserved(
  * Motion (hover) reporting -- SGR 1003 -- is DEMAND-DRIVEN: a terminal
  * reporting motion sends a report per cell the pointer crosses, a flood an
  * app that never looks at hover should not receive. So it turns on only
- * while base capture is on AND something observes hover (see the `hover`
- * option for the override), and turns back off when the last observer goes.
+ * while base capture is on AND something observes hover, and turns back
+ * off when the last observer goes. There is no override: observation is
+ * the whole switch.
  *
  * Idempotent; called from every edge that can move the answer: capture
  * toggles, listener registration, and the end of each frame (where a

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -245,6 +245,16 @@ export interface TermDOMOptions {
 	html?: string;
 	/** The initial document's URL. */
 	url?: string;
+	/**
+	 * Pointer-motion (hover) reporting. Terminals deliver hover as a report
+	 * per cell crossed, which floods stdin, so "auto" (the default) enables
+	 * it only while the document observes hover -- a sheet with a `:hover`
+	 * rule, or a listener for the mousemove/mouseover/mouseout/mouseenter/
+	 * mouseleave family -- and disables it when the last observer goes.
+	 * `true` enables it for the whole attachment; `false` never enables it,
+	 * and `@media (hover: none)` matches.
+	 */
+	hover?: "auto" | boolean;
 }
 
 const kLayoutEngine = Symbol("layoutEngine");
@@ -723,6 +733,11 @@ const kAttachBeginning = Symbol("attachBeginning");
 const kAttachBegun = Symbol("attachBegun");
 const kDisposed = Symbol("disposed");
 const kMouseReportingEnabled = Symbol("mouseReportingEnabled");
+const kHoverOption = Symbol("hoverOption");
+const kHoverReportingEnabled = Symbol("hoverReportingEnabled");
+const kHoverListenerCount = Symbol("hoverListenerCount");
+const kPendingHover = Symbol("pendingHover");
+const kHoverElement = Symbol("hoverElement");
 const kScrollChainTimer = Symbol("scrollChainTimer");
 const kResizeInProgress = Symbol("resizeInProgress");
 const kIsRendering = Symbol("isRendering");
@@ -877,6 +892,31 @@ export class TermDOM {
 	// Whether the terminal is currently reporting mouse events to us. See
 	// updateMouseReporting for when capture is on.
 	declare [kMouseReportingEnabled]: boolean;
+	// The `hover` option as given: "auto" turns motion reporting on and off
+	// with observation, a boolean pins it.
+	declare [kHoverOption]: "auto" | boolean;
+	// Whether the terminal is currently reporting pointer MOTION (SGR 1003)
+	// on top of button/drag reporting. See updateHoverReporting.
+	declare [kHoverReportingEnabled]: boolean;
+	// Reads the document's live count of hover-family listeners, half of
+	// what "the document observes hover" means (the other half is a sheet
+	// with a :hover rule).
+	declare [kHoverListenerCount]: () => number;
+	// The last motion report's position, coalesced: however many reports a
+	// chunk delivers, the frame hit-tests once, here. `quiet` marks a drag's
+	// motion, whose mousemove the report itself already dispatched.
+	declare [kPendingHover]: {
+		x: number;
+		y: number;
+		shiftKey: boolean;
+		altKey: boolean;
+		ctrlKey: boolean;
+		quiet: boolean;
+	} | null;
+
+	// The element under the pointer, which :hover styling and the boundary
+	// events (mouseover/out/enter/leave) are both diffed against.
+	declare [kHoverElement]: Element | null;
 	// Scroll chaining yielded the mouse back to the terminal: the camera hit
 	// the document top and the user kept scrolling up, so the wheel now
 	// belongs to the terminal's own scrollback. Cleared by the next keystroke
@@ -973,6 +1013,10 @@ export class TermDOM {
 		this[kScrolledElements] = new Set();
 		this[kResizeEpoch] = 0;
 		this[kMouseReportingEnabled] = false;
+		this[kHoverOption] = options.hover ?? "auto";
+		this[kHoverReportingEnabled] = false;
+		this[kPendingHover] = null;
+		this[kHoverElement] = null;
 		this[kMouseCaptureYielded] = false;
 		this[kScrollChainTimer] = null;
 		this[kMouseDownTarget] = null;
@@ -1042,6 +1086,14 @@ export class TermDOM {
 
 		// Setup style management FIRST to override getComputedStyle before LayoutEngine uses it
 		this[kStyleManager] = new StyleManager(this.window);
+		this[kStyleManager].setHoverAvailable(this[kHoverOption] !== false);
+		// A hover listener appearing or vanishing moves the "does anything
+		// observe hover" answer between frames, so it pokes the mode update
+		// directly; the stylesheet half is re-read after each frame instead,
+		// where the sheets have already parsed.
+		this[kHoverListenerCount] = DOM.watchHoverListeners(document, () => {
+			updateHoverReporting(this);
+		});
 
 		// Create layout engine after StyleManager overrides getComputedStyle
 		this[kLayoutEngine] = new LayoutEngine(this.window);
@@ -2164,6 +2216,10 @@ export class TermDOM {
 		// bookkeeping, not UI); hand it back visible on the way out. The mouse
 		// goes back to the terminal the same way, and the title we replaced
 		// pops back to what the terminal held before attach pushed it.
+		if (this[kHoverReportingEnabled]) {
+			void this[kSession].write("\x1b[?1003l");
+			this[kHoverReportingEnabled] = false;
+		}
 		if (this[kMouseReportingEnabled]) {
 			void this[kSession].write("\x1b[?1006l\x1b[?1002l");
 			this[kMouseReportingEnabled] = false;
@@ -3202,6 +3258,44 @@ function updateMouseReporting(
 	void termdom[kSession].write(
 		wanted ? "\x1b[?1002h\x1b[?1006h" : "\x1b[?1006l\x1b[?1002l",
 	);
+	// Motion reporting rides on top of capture: it follows capture off (a
+	// scroll-chaining yield hands the WHOLE mouse back) and back on.
+	updateHoverReporting(termdom);
+}
+
+/** Whether anything in the document can observe pointer hover right now. */
+function hoverObserved(
+	termdom: TermDOM,
+): boolean {
+	if (termdom[kHoverOption] !== "auto") {
+		return termdom[kHoverOption];
+	}
+	return (
+		termdom[kHoverListenerCount]() > 0 ||
+		termdom[kStyleManager].hoverRulesExist()
+	);
+}
+
+/**
+ * Motion (hover) reporting -- SGR 1003 -- is DEMAND-DRIVEN: a terminal
+ * reporting motion sends a report per cell the pointer crosses, a flood an
+ * app that never looks at hover should not receive. So it turns on only
+ * while base capture is on AND something observes hover (see the `hover`
+ * option for the override), and turns back off when the last observer goes.
+ *
+ * Idempotent; called from every edge that can move the answer: capture
+ * toggles, listener registration, and the end of each frame (where a
+ * stylesheet's `:hover` rules have just parsed).
+ */
+function updateHoverReporting(
+	termdom: TermDOM,
+): void {
+	const wanted = termdom[kMouseReportingEnabled] && hoverObserved(termdom);
+	if (wanted === termdom[kHoverReportingEnabled]) {
+		return;
+	}
+	termdom[kHoverReportingEnabled] = wanted;
+	void termdom[kSession].write(wanted ? "\x1b[?1003h" : "\x1b[?1003l");
 }
 
 /**
@@ -3793,6 +3887,9 @@ function afterRender(
 		termdom[kHeight],
 	);
 	termdom[kObserverManager].flush(viewport, termdom[kRenderCount]);
+	// The frame's stylesheets have parsed, so "does any rule test :hover"
+	// is current: re-answer whether the terminal should report motion.
+	updateHoverReporting(termdom);
 }
 
 /**
@@ -4158,6 +4255,28 @@ function handleMouseReport(
 	);
 	const x = point?.x ?? col - 1;
 	const y = point?.y ?? 0;
+
+	// Motion arrives at cell granularity -- with 1003 on, a report per cell
+	// crossed -- so it is COALESCED: the frame hit-tests the last position
+	// once and updates the hover chain there (see processPendingHover),
+	// instead of paying a hit-test per report. A drag's motion (base <= 2)
+	// falls through besides: its per-report mousemove and selection updates
+	// predate hover and keep their timing.
+	if (isMotion) {
+		termdom[kPendingHover] = {
+			x,
+			y,
+			shiftKey,
+			altKey,
+			ctrlKey,
+			quiet: base <= 2,
+		};
+		if (base > 2) {
+			void render(termdom);
+			return;
+		}
+	}
+
 	// Already document-relative -- go straight to the shared hit-test rather
 	// than through the public elementFromPoint, which expects viewport-
 	// relative input and would convert it right back.
@@ -4477,6 +4596,127 @@ function handleMouseReport(
 		}
 	}
 	termdom[kMouseDownTarget] = null;
+}
+
+/**
+ * Resolve the frame's coalesced motion: one hit-test at the last reported
+ * position, then whatever moved -- the hover chain re-styled, the boundary
+ * events, a mousemove -- from that one answer.
+ *
+ * Runs at the top of the interactive frame, before it takes its mutation
+ * records: a listener's synchronous mutations land in this frame, and the
+ * `:hover` invalidation precedes the style resolution that repaints it.
+ */
+function processPendingHover(
+	termdom: TermDOM,
+): void {
+	const pending = termdom[kPendingHover];
+	if (pending === null) {
+		return;
+	}
+	termdom[kPendingHover] = null;
+	const {x, y, shiftKey, altKey, ctrlKey} = pending;
+	const target =
+		findElementAtDocumentPoint(termdom, x, y) || termdom.document.body;
+	const previous = termdom[kHoverElement];
+	if (target !== previous) {
+		termdom[kHoverElement] = target;
+		DOM.setHoveredElement(
+			termdom.document as unknown as DOM.Document,
+			target as unknown as DOM.Element,
+		);
+		termdom[kStyleManager].handleHoverChange(previous, target);
+		const chainOf = (element: Element | null): Element[] => {
+			const chain: Element[] = [];
+			for (
+				let node: Element | null = element;
+				node;
+				node = termdom[kUAToolkit].flatParentElement<Element>(node)
+			) {
+				chain.push(node);
+			}
+			return chain;
+		};
+		const previousChain = chainOf(previous);
+		const targetChain = chainOf(target);
+		const previousSet = new Set(previousChain);
+		const targetSet = new Set(targetChain);
+		const boundaryInit = {
+			button: 0,
+			buttons: 0,
+			clientX: x,
+			clientY: y,
+			shiftKey,
+			altKey,
+			ctrlKey,
+		};
+		// UI Events' boundary order: out, then leave from the exited element
+		// up, then over, then enter from the outermost entered ancestor
+		// down; the mousemove in the entered element follows them.
+		if (previous !== null) {
+			fireAsUserAgent(
+				previous,
+				new termdom.window.MouseEvent("mouseout", {
+					...boundaryInit,
+					bubbles: true,
+					cancelable: true,
+					relatedTarget: target,
+				}),
+			);
+			for (const node of previousChain) {
+				if (!targetSet.has(node)) {
+					fireAsUserAgent(
+						node,
+						new termdom.window.MouseEvent("mouseleave", {
+							...boundaryInit,
+							relatedTarget: target,
+						}),
+					);
+				}
+			}
+		}
+		fireAsUserAgent(
+			target,
+			new termdom.window.MouseEvent("mouseover", {
+				...boundaryInit,
+				bubbles: true,
+				cancelable: true,
+				relatedTarget: previous,
+			}),
+		);
+		const entering = targetChain.filter((node) => !previousSet.has(node));
+		for (let i = entering.length - 1; i >= 0; i--) {
+			fireAsUserAgent(
+				entering[i],
+				new termdom.window.MouseEvent("mouseenter", {
+					...boundaryInit,
+					relatedTarget: previous,
+				}),
+			);
+		}
+	}
+	// A drag's motion already dispatched its own mousemove, report by
+	// report; only buttonless motion owes one here.
+	if (!pending.quiet) {
+		const last = termdom[kLastMouse];
+		fireAsUserAgent(
+			target,
+			new termdom.window.MouseEvent("mousemove", {
+				button: 0,
+				buttons: 0,
+				clientX: x,
+				clientY: y,
+				movementX: last === null ? 0 : x - last.x,
+				movementY: last === null ? 0 : y - last.y,
+				shiftKey,
+				altKey,
+				ctrlKey,
+				bubbles: true,
+				cancelable: true,
+			}),
+		);
+		termdom[kLastMouse] = {x, y};
+	}
 }
 
 /**
@@ -4884,6 +5124,11 @@ async function renderInteractive(
 		await detectionPending;
 	}
 
+	// Coalesced pointer motion resolves first: a hover listener's
+	// synchronous mutations join the records taken below, and the hover
+	// chain's invalidation precedes this frame's style resolution.
+	processPendingHover(termdom);
+
 	const pending = termdom[kObserver].takeRecords();
 	if (pending.length > 0) {
 		handlePendingMutations(termdom, pending);
@@ -4966,10 +5211,9 @@ async function renderInteractive(
 	// event, a live selection, a drag, a geometry change (cascades) --
 	// takes the full diff. What a mouse report changes names its elements:
 	// a click moves focus, which the cascade damages, and a drag holds an
-	// anchor this gate already reads. A pointer that flipped state
-	// anywhere on the screen would not, but no such state exists here --
-	// :hover matches nothing -- and adding one means damaging the chains
-	// it entered and left, not giving up the transform.
+	// anchor this gate already reads. Pointer motion flipping `:hover`
+	// names its elements too -- handleHoverChange damages the chains the
+	// pointer entered and left -- so hover keeps the transform.
 	let scroll: {delta: number; bands: Array<[number, number]>} | undefined;
 	const scrollTop = termdom[kViewport].scrollTop;
 	const styleDamage = termdom[kStyleManager].drainStyleDamage();

--- a/src/internal/terminalsession.ts
+++ b/src/internal/terminalsession.ts
@@ -174,7 +174,9 @@ function installCursorRestoreOnExit(): void {
 		for (const proc of undisposedProcesses) {
 			try {
 				// Mouse capture off, cursor back on, bracketed paste off.
-				proc.stdout.write("\x1b[?1006l\x1b[?1002l\x1b[?25h\x1b[?2004l");
+				proc.stdout.write(
+					"\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?25h\x1b[?2004l",
+				);
 			} catch (_err) {
 				// The stream may already be gone; the shell will survive.
 			}
@@ -216,7 +218,7 @@ export function transportFromProcess(
 		// queue, and `dispose(); process.exit()` exits before it flushes.
 		// These are the modes whose survival breaks the user's shell; each is
 		// idempotent, so the queued restores repeating them is harmless.
-		proc.stdout.write("[?1006l[?1002l[?25h[?2004l[23;0t");
+		proc.stdout.write("[?1006l[?1003l[?1002l[?25h[?2004l[23;0t");
 		if (dataListener && proc.stdin) {
 			proc.stdin.removeListener?.("data", dataListener);
 			dataListener = null;

--- a/tests/hover.test.ts
+++ b/tests/hover.test.ts
@@ -1,0 +1,392 @@
+import {test, expect} from "@b9g/libuild/test";
+import {TermDOM} from "../src/internal/termdom.js";
+import {transportFromProcess} from "../src/internal/terminalsession.js";
+import {nextFrame} from "./test-utils.js";
+import {EventEmitter} from "events";
+
+// A TTY-shaped process that records everything written to stdout, so tests
+// can assert on the escape sequences that enable and disable motion
+// reporting, and that feeds SGR reports back in through stdin.
+class MockTTYStream extends EventEmitter {
+	constructor(...args: ConstructorParameters<typeof EventEmitter>) {
+		super(...args);
+		this.isTTY = true;
+	}
+
+	isTTY: boolean;
+
+	setRawMode(_mode: boolean): this {
+		return this;
+	}
+
+	resume(): this {
+		return this;
+	}
+
+	pause(): this {
+		return this;
+	}
+
+	send(data: string): Promise<void> {
+		this.emit("data", Buffer.from(data));
+		// Input rides the transport's readable: delivery is a microtask away.
+		return new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+class MockHoverProcess extends EventEmitter {
+	constructor(...args: ConstructorParameters<typeof EventEmitter>) {
+		super(...args);
+		this.output = [];
+		this.stdout = {
+			isTTY: true,
+			columns: 80,
+			rows: 24,
+			write: (chunk: any, encoding?: any, callback?: any): boolean => {
+				this.output.push(String(chunk));
+				if (typeof encoding === "function") {
+					encoding();
+				} else if (callback) {
+					callback();
+				}
+				return true;
+			},
+		};
+		this.stdin = new MockTTYStream();
+		this.env = {
+			TERM: "xterm-256color",
+			COLORTERM: "truecolor",
+		};
+	}
+
+	output: string[];
+
+	stdout: {
+		isTTY: boolean;
+		columns: number;
+		rows: number;
+		write: (chunk: any, encoding?: any, callback?: any) => boolean;
+	};
+
+	stdin: MockTTYStream;
+
+	env: {TERM: string; COLORTERM: string};
+
+	exit(_code?: number): never {
+		throw new Error("Process exit");
+	}
+
+	get written(): string {
+		return this.output.join("");
+	}
+}
+
+const MOTION_ON = "\x1b[?1003h";
+const MOTION_OFF = "\x1b[?1003l";
+
+function makeApp(options: {hover?: "auto" | boolean; html?: string} = {}): {
+	proc: MockHoverProcess;
+	termdom: TermDOM;
+	document: Document;
+} {
+	const proc = new MockHoverProcess();
+	const termdom = new TermDOM({
+		transport: transportFromProcess(proc as any),
+		hover: options.hover,
+		html: options.html,
+	});
+	return {proc, termdom, document: termdom.document};
+}
+
+/** An SGR buttonless-motion report at a 1-based column and row. */
+function motion(col: number, row: number): string {
+	return `\x1b[<35;${col};${row}M`;
+}
+
+test("no motion reporting for an app that never observes hover", async () => {
+	const {proc, termdom, document} = makeApp();
+	const div = document.createElement("div");
+	div.textContent = "plain";
+	document.body.appendChild(div);
+	await nextFrame(termdom);
+
+	expect(proc.written).toContain("\x1b[?1002h");
+	expect(proc.written).not.toContain(MOTION_ON);
+	termdom.dispose();
+});
+
+test("a :hover rule turns motion reporting on; removing it turns it off", async () => {
+	const {proc, termdom, document} = makeApp();
+	const div = document.createElement("div");
+	div.textContent = "target";
+	document.body.appendChild(div);
+	await nextFrame(termdom);
+	expect(proc.written).not.toContain(MOTION_ON);
+
+	const style = document.createElement("style");
+	style.textContent = "div:hover { color: red; }";
+	document.head.appendChild(style);
+	await nextFrame(termdom);
+	expect(proc.written).toContain(MOTION_ON);
+	expect(proc.written).not.toContain(MOTION_OFF);
+
+	style.remove();
+	await nextFrame(termdom);
+	expect(proc.written).toContain(MOTION_OFF);
+	termdom.dispose();
+});
+
+test("a hover-family listener turns motion reporting on; removal turns it off", async () => {
+	const {proc, termdom, document} = makeApp();
+	const div = document.createElement("div");
+	div.textContent = "target";
+	document.body.appendChild(div);
+	await nextFrame(termdom);
+	expect(proc.written).not.toContain(MOTION_ON);
+
+	const listener = () => {};
+	document.addEventListener("mousemove", listener);
+	expect(proc.written).toContain(MOTION_ON);
+
+	document.removeEventListener("mousemove", listener);
+	// The disable rides the session's write queue; let it flush.
+	await new Promise((r) => setTimeout(r, 0));
+	expect(proc.written).toContain(MOTION_OFF);
+	termdom.dispose();
+});
+
+test("a window mouseover listener counts as observing hover", async () => {
+	const {proc, termdom} = makeApp();
+	await nextFrame(termdom);
+	expect(proc.written).not.toContain(MOTION_ON);
+
+	const listener = () => {};
+	(termdom.window as any).addEventListener("mouseover", listener);
+	// The enable rides the session's write queue; let it flush.
+	await new Promise((r) => setTimeout(r, 0));
+	expect(proc.written).toContain(MOTION_ON);
+	(termdom.window as any).removeEventListener("mouseover", listener);
+	await new Promise((r) => setTimeout(r, 0));
+	expect(proc.written).toContain(MOTION_OFF);
+	termdom.dispose();
+});
+
+test("hover: true forces motion reporting on at attach", async () => {
+	const {proc, termdom} = makeApp({hover: true});
+	await nextFrame(termdom);
+	await new Promise((r) => setTimeout(r, 0));
+	expect(proc.written).toContain(MOTION_ON);
+
+	termdom.dispose();
+	await new Promise((r) => setTimeout(r, 0));
+	expect(proc.written).toContain(MOTION_OFF);
+});
+
+test("hover: false never enables motion reporting", async () => {
+	const {proc, termdom, document} = makeApp({
+		hover: false,
+		html: "<style>div:hover { color: red; }</style><div>target</div>",
+	});
+	document.addEventListener("mousemove", () => {});
+	await nextFrame(termdom);
+	expect(proc.written).not.toContain(MOTION_ON);
+	termdom.dispose();
+});
+
+test(":hover styles the element under the pointer and its ancestors", async () => {
+	const {proc, termdom, document} = makeApp({
+		html:
+			"<style>" +
+			"div:hover { color: rgb(255, 0, 0); }" +
+			"section:hover { background-color: rgb(0, 0, 255); }" +
+			"</style>" +
+			"<section><div>first</div><div>second</div></section>",
+	});
+	await nextFrame(termdom);
+	const [first, second] = Array.from(document.querySelectorAll("div"));
+	const section = document.querySelector("section")!;
+
+	await proc.stdin.send(motion(2, 1));
+	await nextFrame(termdom);
+	expect(first.matches(":hover")).toBe(true);
+	expect(section.matches(":hover")).toBe(true);
+	expect(second.matches(":hover")).toBe(false);
+	const styles = termdom.window.getComputedStyle(first);
+	expect(styles.getPropertyValue("color")).toBe("rgb(255, 0, 0)");
+	expect(
+		termdom.window
+			.getComputedStyle(section)
+			.getPropertyValue("background-color"),
+	).toBe("rgb(0, 0, 255)");
+
+	await proc.stdin.send(motion(2, 2));
+	await nextFrame(termdom);
+	expect(first.matches(":hover")).toBe(false);
+	expect(second.matches(":hover")).toBe(true);
+	expect(termdom.window.getComputedStyle(first).getPropertyValue("color"))
+		.toBe("rgb(0, 0, 0)");
+	termdom.dispose();
+});
+
+test("boundary events fire in UI Events order with relatedTarget", async () => {
+	const {proc, termdom, document} = makeApp({
+		html: "<div id=parent><span id=a>aaaa</span><span id=b>bbbb</span></div>",
+	});
+	await nextFrame(termdom);
+	const parent = document.getElementById("parent")!;
+	const a = document.getElementById("a")!;
+	const b = document.getElementById("b")!;
+
+	const log: string[] = [];
+	const related: Record<string, unknown> = {};
+	for (const [element, name] of [
+		[parent, "parent"],
+		[a, "a"],
+		[b, "b"],
+	] as const) {
+		for (const type of [
+			"mouseover",
+			"mouseout",
+			"mouseenter",
+			"mouseleave",
+			"mousemove",
+		]) {
+			// Filtered to the element's own events: mouseover and mouseout
+			// bubble, and a bubbled arrival would double-log.
+			element.addEventListener(type, (event: any) => {
+				if (event.target !== element) {
+					return;
+				}
+				log.push(`${type}:${name}`);
+				related[`${type}:${name}`] = event.relatedTarget;
+			});
+		}
+	}
+
+	await proc.stdin.send(motion(2, 1)); // over "a"
+	await nextFrame(termdom);
+	expect(log).toEqual([
+		"mouseover:a",
+		"mouseenter:parent",
+		"mouseenter:a",
+		"mousemove:a",
+	]);
+	expect(related["mouseover:a"]).toBe(null);
+
+	log.length = 0;
+	await proc.stdin.send(motion(6, 1)); // over "b"
+	await nextFrame(termdom);
+	expect(log).toEqual([
+		"mouseout:a",
+		"mouseleave:a",
+		"mouseover:b",
+		"mouseenter:b",
+		"mousemove:b",
+	]);
+	expect(related["mouseout:a"]).toBe(b);
+	expect(related["mouseover:b"]).toBe(a);
+	termdom.dispose();
+});
+
+test("mouseenter does not bubble; mouseover does", async () => {
+	const {proc, termdom, document} = makeApp({
+		html: "<div id=parent><span id=a>aaaa</span></div>",
+	});
+	await nextFrame(termdom);
+	const parent = document.getElementById("parent")!;
+	const a = document.getElementById("a")!;
+
+	let parentEnter = 0;
+	let parentOver = 0;
+	parent.addEventListener("mouseenter", () => parentEnter++);
+	parent.addEventListener("mouseover", () => parentOver++);
+
+	await proc.stdin.send(motion(2, 1)); // onto the span
+	await nextFrame(termdom);
+	expect(a.matches(":hover")).toBe(true);
+	// The parent's own enter, once; the span's over, bubbled up to it.
+	expect(parentEnter).toBe(1);
+	expect(parentOver).toBe(1);
+	termdom.dispose();
+});
+
+test("motion reports coalesce into at most one hit-test per frame", async () => {
+	const {proc, termdom, document} = makeApp();
+	for (let i = 0; i < 5; i++) {
+		const div = document.createElement("div");
+		div.textContent = `line ${i}`;
+		document.body.appendChild(div);
+	}
+	await nextFrame(termdom);
+
+	const moves: number[] = [];
+	document.addEventListener("mousemove", (event: any) => {
+		moves.push(event.clientY);
+	});
+
+	// A held pointer sweep delivers a report per cell in one chunk; the
+	// frame handles the last position, not one per report.
+	await proc.stdin.send(motion(2, 1) + motion(2, 2) + motion(2, 3));
+	await nextFrame(termdom);
+	expect(moves.length).toBeLessThan(3);
+	expect(moves[moves.length - 1]).toBe(2);
+	termdom.dispose();
+});
+
+test("@media (hover) answers hover by default and none under hover: false", async () => {
+	const capable = makeApp();
+	await nextFrame(capable.termdom);
+	expect(capable.termdom.window.matchMedia("(hover: hover)").matches)
+		.toBe(true);
+	expect(capable.termdom.window.matchMedia("(hover: none)").matches)
+		.toBe(false);
+	expect(capable.termdom.window.matchMedia("(hover)").matches).toBe(true);
+	capable.termdom.dispose();
+
+	const incapable = makeApp({hover: false});
+	await nextFrame(incapable.termdom);
+	expect(incapable.termdom.window.matchMedia("(hover: hover)").matches)
+		.toBe(false);
+	expect(incapable.termdom.window.matchMedia("(hover: none)").matches)
+		.toBe(true);
+	expect(incapable.termdom.window.matchMedia("(hover)").matches).toBe(false);
+	incapable.termdom.dispose();
+});
+
+test("@media (hover: none) rules apply only when hover is disabled", async () => {
+	const html =
+		"<style>@media (hover: none) { div { color: rgb(1, 2, 3); } }</style>" +
+		"<div>target</div>";
+
+	const capable = makeApp({html});
+	await nextFrame(capable.termdom);
+	const capableDiv = capable.document.querySelector("div")!;
+	expect(
+		capable.termdom.window
+			.getComputedStyle(capableDiv)
+			.getPropertyValue("color"),
+	).toBe("rgb(0, 0, 0)");
+	capable.termdom.dispose();
+
+	const incapable = makeApp({html, hover: false});
+	await nextFrame(incapable.termdom);
+	const incapableDiv = incapable.document.querySelector("div")!;
+	expect(
+		incapable.termdom.window
+			.getComputedStyle(incapableDiv)
+			.getPropertyValue("color"),
+	).toBe("rgb(1, 2, 3)");
+	incapable.termdom.dispose();
+});
+
+test("dispose turns motion reporting off", async () => {
+	const {proc, termdom} = makeApp({
+		html: "<style>div:hover { color: red; }</style><div>target</div>",
+	});
+	await nextFrame(termdom);
+	expect(proc.written).toContain(MOTION_ON);
+
+	termdom.dispose();
+	await new Promise((r) => setTimeout(r, 0));
+	expect(proc.written).toContain(MOTION_OFF);
+});

--- a/tests/hover.test.ts
+++ b/tests/hover.test.ts
@@ -84,7 +84,7 @@ class MockHoverProcess extends EventEmitter {
 const MOTION_ON = "\x1b[?1003h";
 const MOTION_OFF = "\x1b[?1003l";
 
-function makeApp(options: {hover?: "auto" | boolean; html?: string} = {}): {
+function makeApp(options: {html?: string} = {}): {
 	proc: MockHoverProcess;
 	termdom: TermDOM;
 	document: Document;
@@ -92,7 +92,6 @@ function makeApp(options: {hover?: "auto" | boolean; html?: string} = {}): {
 	const proc = new MockHoverProcess();
 	const termdom = new TermDOM({
 		transport: transportFromProcess(proc as any),
-		hover: options.hover,
 		html: options.html,
 	});
 	return {proc, termdom, document: termdom.document};
@@ -168,28 +167,6 @@ test("a window mouseover listener counts as observing hover", async () => {
 	(termdom.window as any).removeEventListener("mouseover", listener);
 	await new Promise((r) => setTimeout(r, 0));
 	expect(proc.written).toContain(MOTION_OFF);
-	termdom.dispose();
-});
-
-test("hover: true forces motion reporting on at attach", async () => {
-	const {proc, termdom} = makeApp({hover: true});
-	await nextFrame(termdom);
-	await new Promise((r) => setTimeout(r, 0));
-	expect(proc.written).toContain(MOTION_ON);
-
-	termdom.dispose();
-	await new Promise((r) => setTimeout(r, 0));
-	expect(proc.written).toContain(MOTION_OFF);
-});
-
-test("hover: false never enables motion reporting", async () => {
-	const {proc, termdom, document} = makeApp({
-		hover: false,
-		html: "<style>div:hover { color: red; }</style><div>target</div>",
-	});
-	document.addEventListener("mousemove", () => {});
-	await nextFrame(termdom);
-	expect(proc.written).not.toContain(MOTION_ON);
 	termdom.dispose();
 });
 
@@ -333,50 +310,26 @@ test("motion reports coalesce into at most one hit-test per frame", async () => 
 	termdom.dispose();
 });
 
-test("@media (hover) answers hover by default and none under hover: false", async () => {
-	const capable = makeApp();
-	await nextFrame(capable.termdom);
-	expect(capable.termdom.window.matchMedia("(hover: hover)").matches)
-		.toBe(true);
-	expect(capable.termdom.window.matchMedia("(hover: none)").matches)
-		.toBe(false);
-	expect(capable.termdom.window.matchMedia("(hover)").matches).toBe(true);
-	capable.termdom.dispose();
-
-	const incapable = makeApp({hover: false});
-	await nextFrame(incapable.termdom);
-	expect(incapable.termdom.window.matchMedia("(hover: hover)").matches)
-		.toBe(false);
-	expect(incapable.termdom.window.matchMedia("(hover: none)").matches)
-		.toBe(true);
-	expect(incapable.termdom.window.matchMedia("(hover)").matches).toBe(false);
-	incapable.termdom.dispose();
+test("@media (hover) answers hover, unconditionally", async () => {
+	const {termdom} = makeApp();
+	await nextFrame(termdom);
+	expect(termdom.window.matchMedia("(hover: hover)").matches).toBe(true);
+	expect(termdom.window.matchMedia("(hover: none)").matches).toBe(false);
+	expect(termdom.window.matchMedia("(hover)").matches).toBe(true);
+	termdom.dispose();
 });
 
-test("@media (hover: none) rules apply only when hover is disabled", async () => {
+test("@media (hover: none) rules never apply", async () => {
 	const html =
 		"<style>@media (hover: none) { div { color: rgb(1, 2, 3); } }</style>" +
 		"<div>target</div>";
-
-	const capable = makeApp({html});
-	await nextFrame(capable.termdom);
-	const capableDiv = capable.document.querySelector("div")!;
+	const {termdom, document} = makeApp({html});
+	await nextFrame(termdom);
+	const div = document.querySelector("div")!;
 	expect(
-		capable.termdom.window
-			.getComputedStyle(capableDiv)
-			.getPropertyValue("color"),
+		termdom.window.getComputedStyle(div).getPropertyValue("color"),
 	).toBe("rgb(0, 0, 0)");
-	capable.termdom.dispose();
-
-	const incapable = makeApp({html, hover: false});
-	await nextFrame(incapable.termdom);
-	const incapableDiv = incapable.document.querySelector("div")!;
-	expect(
-		incapable.termdom.window
-			.getComputedStyle(incapableDiv)
-			.getPropertyValue("color"),
-	).toBe("rgb(1, 2, 3)");
-	incapable.termdom.dispose();
+	termdom.dispose();
 });
 
 test("dispose turns motion reporting off", async () => {


### PR DESCRIPTION
Resolves #72 by making motion reporting demand-driven rather than a standing cost. There is no constructor option: observation is the whole switch.

**Enablement.** SGR 1003 turns on only when the document observes hover: a sheet mentions `:hover` (a `kHoverRulesExist` flag set at selector parse, beside the `:has()` one) or a `mousemove`/`mouseover`/`mouseout`/`mouseenter`/`mouseleave` listener is registered. Listeners are tallied through the one add/remove funnel, so abort signals and `once` decrement correctly; nwsapi's internal document trackers are excluded so an empty document does not read as observing. When the last observer goes, `?1003l` is written; dispose and the crash-exit hook restore it too. An app with no hover interest pays zero bytes over stdin.

**Coalescing.** Motion reports record a position and schedule a render; one hit-test runs per frame at the last position, so CPU scales with frames, not bytes. The 1002 drag path is untouched and only contributes its position to the hover diff.

**Matching and invalidation.** `:hover` respells through the focus rewrite mechanism (now `STATE_REWRITES`) to a resolver over the raw hovered element and its flat ancestors. On hover change the symmetric difference of the old and new flat chains is invalidated, mirroring `handleFocusChange`.

**Events.** `mouseout`, `mouseleave` (bottom-up), `mouseover`, `mouseenter` (top-down), then `mousemove`, with relatedTarget, per UI Events order.

**Media feature.** `@media (hover)` / `(any-hover)` answer `hover` unconditionally: the display can hover, and enablement is the engine's business, not a mode the page can observe.

Open edges, deliberate: hover updates on motion reports only (not press/release); a removed hovered element self-heals on the next motion; `:active` is out of scope but would ride the identical mechanism; the two hover WPT files still fail because the runner has no pointer-injection backend yet.

Tests: tests/hover.test.ts (11) asserts the enable/disable bytes on the wire per source, `:hover` styling via getComputedStyle, boundary-event order, coalescing, and the media feature. Suites green both lanes (node and bun, 1510 each).

Implemented by a delegated Claude agent; reviewed and posted by Claude on Brian's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
