### PR TITLE
Add category examples for the UA defaults

### DIFF
--- a/examples/dialog.ts
+++ b/examples/dialog.ts
@@ -1,0 +1,59 @@
+/**
+ * The two lives of a dialog. show() opens it in flow: a bordered block
+ * that takes its place in the document, terminal-native, nothing else
+ * moves. showModal() takes over: top layer, viewport-centered, backdrop
+ * clearing the screen, the rest of the page inert until it closes.
+ * Tab moves, Enter activates, q quits.
+ */
+
+import {TermDOM} from "@b9g/termdom";
+
+const term = new TermDOM();
+const {document} = term;
+
+const style = document.createElement("style");
+style.textContent = `
+	body { margin: 0; padding: 0 1ch; }
+	h1 { background-color: Highlight; color: HighlightText; padding-left: 1ch; }
+	p { margin-top: 1px; }
+`;
+document.head.appendChild(style);
+
+document.body.innerHTML = `
+	<h1>dialog</h1>
+	<p>transcript line one</p>
+	<p>transcript line two</p>
+	<p>
+		<button type="button" id="flow">show()</button>
+		<button type="button" id="modal">showModal()</button>
+	</p>
+	<dialog id="dlg">
+		<p id="how"></p>
+		<button type="button" id="close">close</button>
+	</dialog>
+	<p id="tail">this line stays put for show() and vanishes under the
+	modal backdrop</p>
+	<p>tab · enter · q quits</p>
+`;
+
+const dialog = document.getElementById("dlg") as HTMLDialogElement;
+const how = document.getElementById("how")!;
+document.getElementById("flow")!.addEventListener("click", () => {
+	how.textContent = "in flow: the page grew by this box";
+	dialog.show();
+});
+document.getElementById("modal")!.addEventListener("click", () => {
+	how.textContent = "modal: centered, backdrop, page inert";
+	dialog.showModal();
+});
+document.getElementById("close")!.addEventListener("click", () => {
+	dialog.close();
+});
+
+document.addEventListener("keydown", (event) => {
+	if ((event as KeyboardEvent).key === "q" && !dialog.open) {
+		term.window.close();
+	}
+});
+
+term.attach();

--- a/examples/inputs.ts
+++ b/examples/inputs.ts
@@ -1,0 +1,71 @@
+/**
+ * The input zoo: one of each form control on its user-agent defaults.
+ * The only author styles are the page frame -- the controls themselves
+ * render as the UA sheet says. Tab moves, Enter/Space activates, q quits.
+ */
+
+import {TermDOM} from "@b9g/termdom";
+
+const term = new TermDOM();
+const {document} = term;
+
+const style = document.createElement("style");
+style.textContent = `
+	body { margin: 0; padding: 0 1ch; }
+	h1 { background-color: Highlight; color: HighlightText; padding-left: 1ch; }
+	p { margin-top: 1px; }
+`;
+document.head.appendChild(style);
+
+document.body.innerHTML = `
+	<h1>input zoo</h1>
+	<form>
+		<fieldset>
+			<legend>text</legend>
+			<p><label>text <input placeholder="placeholder ghost"></label></p>
+			<p><label>password <input type="password" value="hunter2"></label></p>
+			<p><textarea rows="3" cols="28">textarea, bordered,
+wraps its content</textarea></p>
+		</fieldset>
+		<fieldset>
+			<legend>choices</legend>
+			<p><label><input type="checkbox" checked> checkbox</label>
+			<label><input type="radio" name="r" checked> radio</label>
+			<label><input type="radio" name="r"> radio</label></p>
+			<p><label>select <select>
+				<optgroup label="group">
+					<option>first option</option>
+					<option>second, wider option</option>
+				</optgroup>
+				<option disabled>disabled option</option>
+			</select></label></p>
+		</fieldset>
+		<fieldset>
+			<legend>buttons and gauges</legend>
+			<p><button type="button">button</button> renders in brackets</p>
+			<p>progress <progress id="bar" max="100" value="30"></progress>
+			<progress></progress> (indeterminate)</p>
+			<p>meter <meter value="0.8" optimum="0.9">80%</meter>
+			<meter value="0.5" low="0.3" high="0.7" optimum="0.9">50%</meter>
+			<meter value="0.1" low="0.3" high="0.7" optimum="0.9">10%</meter></p>
+		</fieldset>
+	</form>
+	<p>tab moves · enter/space activates · q quits</p>
+`;
+
+const bar = document.getElementById("bar") as HTMLProgressElement;
+setInterval(() => {
+	bar.value = (bar.value + 10) % 110;
+}, 1000);
+
+document.addEventListener("keydown", (event) => {
+	const key = (event as KeyboardEvent).key;
+	const target = event.target as HTMLElement;
+	if (
+		key === "q" && target.tagName !== "INPUT" && target.tagName !== "TEXTAREA"
+	) {
+		term.window.close();
+	}
+});
+
+term.attach();

--- a/examples/semantics.ts
+++ b/examples/semantics.ts
@@ -1,0 +1,65 @@
+/**
+ * Text-level and grouping semantics on their user-agent defaults: what
+ * unstyled prose HTML looks like on a terminal. The headings band is the
+ * only author rule. Tab reaches the link and the disclosure; q quits.
+ */
+
+import {TermDOM} from "@b9g/termdom";
+
+const term = new TermDOM();
+const {document} = term;
+
+const style = document.createElement("style");
+style.textContent = `
+	body { margin: 0; padding: 0 1ch; }
+	h2 { background-color: Highlight; color: HighlightText; padding-left: 1ch; }
+	section { margin-top: 1px; }
+`;
+document.head.appendChild(style);
+
+document.body.innerHTML = `
+	<h1>semantics</h1>
+	<section>
+		<h2>text-level</h2>
+		<p><b>b bold</b>, <em>em italic</em>, <u>u underline</u>,
+		<s>s struck</s>, <code>code faint block</code>, <kbd>kbd</kbd>,
+		<small>small lighter</small>, <cite>cite</cite>, <var>var</var>,
+		and <a href="https://termdom.org">a link, underlined</a>.</p>
+	</section>
+	<section>
+		<h2>headings</h2>
+		<h1>h1</h1><h3>h3</h3><h6>h6</h6>
+	</section>
+	<section>
+		<h2>grouping</h2>
+		<blockquote>blockquote, indented</blockquote>
+		<pre>pre   preserves   spacing
+	and newlines</pre>
+		<hr>
+	</section>
+	<section>
+		<h2>disclosure</h2>
+		<details>
+			<summary>a closed details shows ▸</summary>
+			<p>and an open one shows ▾, with this body revealed.</p>
+		</details>
+	</section>
+	<section>
+		<h2>hidden</h2>
+		<p><button type="button" id="hide">toggle</button>
+		<span id="target">the [hidden] attribute removes this span</span></p>
+	</section>
+	<p>tab moves · enter activates · drag to select · q quits</p>
+`;
+
+document.getElementById("hide")!.addEventListener("click", () => {
+	document.getElementById("target")!.toggleAttribute("hidden");
+});
+
+document.addEventListener("keydown", (event) => {
+	if ((event as KeyboardEvent).key === "q") {
+		term.window.close();
+	}
+});
+
+term.attach();

--- a/examples/table.ts
+++ b/examples/table.ts
@@ -1,0 +1,70 @@
+/**
+ * Tables on their user-agent defaults: collapsed borders, bold header
+ * cells, caption above. The season selector rebuilds the body to show
+ * the borders re-collapse around changing content. q quits.
+ */
+
+import {TermDOM} from "@b9g/termdom";
+
+const term = new TermDOM();
+const {document} = term;
+
+const style = document.createElement("style");
+style.textContent = `
+	body { margin: 0; padding: 0 1ch; }
+	h1 { background-color: Highlight; color: HighlightText; padding-left: 1ch; }
+	p { margin-top: 1px; }
+`;
+document.head.appendChild(style);
+
+const SEASONS: Record<string, Array<[string, string, string]>> = {
+	spring: [
+		["daffodil", "march", "yellow"],
+		["tulip", "april", "red"],
+		["lilac", "may", "purple"],
+	],
+	autumn: [
+		["aster", "september", "violet"],
+		["chrysanthemum", "october", "gold"],
+	],
+};
+
+document.body.innerHTML = `
+	<h1>table</h1>
+	<p><label>season <select id="season">
+		<option>spring</option>
+		<option>autumn</option>
+	</select></label></p>
+	<table>
+		<caption>bloom calendar</caption>
+		<thead><tr><th>flower</th><th>month</th><th>color</th></tr></thead>
+		<tbody id="rows"></tbody>
+	</table>
+	<p>tab · enter opens the picker · q quits</p>
+`;
+
+const rows = document.getElementById("rows")!;
+function fill(season: string): void {
+	rows.textContent = "";
+	for (const [flower, month, color] of SEASONS[season]) {
+		const tr = document.createElement("tr");
+		for (const text of [flower, month, color]) {
+			const td = document.createElement("td");
+			td.textContent = text;
+			tr.appendChild(td);
+		}
+		rows.appendChild(tr);
+	}
+}
+fill("spring");
+
+const select = document.getElementById("season") as HTMLSelectElement;
+select.addEventListener("change", () => fill(select.value));
+
+document.addEventListener("keydown", (event) => {
+	if ((event as KeyboardEvent).key === "q") {
+		term.window.close();
+	}
+});
+
+term.attach();

--- a/src/internal/ansi.ts
+++ b/src/internal/ansi.ts
@@ -1640,6 +1640,24 @@ function inClip(
 	return col >= left && col < right && row >= top && row < bottom;
 }
 
+/**
+ * Whether a terminal row is a scroll frame's to paint. Rows outside the
+ * bands were seeded from the shifted previous grid and still hold their
+ * content; a writer that lands on one would overwrite cells nothing is
+ * going to repaint.
+ */
+function inPaintBand(context: CellContext, terminalRow: number): boolean {
+	if (!context.paintBands) {
+		return true;
+	}
+	for (const [start, end] of context.paintBands) {
+		if (terminalRow >= start && terminalRow < end) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function setCell(
 	context: CellContext,
 	row: number,
@@ -1658,17 +1676,8 @@ function setCell(
 		return;
 	}
 
-	if (context.paintBands) {
-		let inBand = false;
-		for (const [start, end] of context.paintBands) {
-			if (terminalRow >= start && terminalRow < end) {
-				inBand = true;
-				break;
-			}
-		}
-		if (!inBand) {
-			return;
-		}
+	if (!inPaintBand(context, terminalRow)) {
+		return;
 	}
 
 	if (context.clipRect && !inClip(context, row, col)) {
@@ -1705,6 +1714,13 @@ function setBorderCell(
 	if (
 		terminalY < 0 || terminalY >= context.rows || x < 0 || x >= context.cols
 	) {
+		return;
+	}
+	// The band mask binds border strokes as it binds text: a box whose extent
+	// touches an exposed band still stamps its whole outline, and the rows
+	// outside the bands -- a top border row wearing a legend, say -- keep
+	// what the seeded grid holds.
+	if (!inPaintBand(context, terminalY)) {
 		return;
 	}
 	if (!inClip(context, y, x)) {

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -11315,6 +11315,7 @@ export class HTMLDialogElement extends HTMLElement {
 			return;
 		}
 		this.setAttribute("open", "");
+		focusDialog(this);
 	}
 
 	showModal(): void {
@@ -11403,7 +11404,9 @@ function focusDialog(
 		(fallback as HTMLElement).focus();
 		return;
 	}
-	dialog[kDocument][kActiveElement] = dialog;
+	if (isModalDialog(dialog)) {
+		dialog[kDocument][kActiveElement] = dialog;
+	}
 }
 
 function close(
@@ -11414,19 +11417,25 @@ function close(
 	if (!dialog.hasAttribute("open")) {
 		return;
 	}
+	const document = dialog[kDocument];
+	const wasModal = isModalDialog(dialog);
 	dialog.removeAttribute("open");
-	topLayerOf(dialog[kDocument]).delete(dialog);
-	// The page gets its focus back where the dialog took it from, so the
-	// keyboard returns to what the user was doing before it opened.
-	if (dialog[kPreviouslyFocused] !== null) {
-		const previous = dialog[kPreviouslyFocused];
-		dialog[kPreviouslyFocused] = null;
-		if (
-			dialog[kDocument][kActiveElement] === dialog ||
-			dialog.contains(dialog[kDocument][kActiveElement])
-		) {
-			(previous as HTMLElement).focus();
-		}
+	topLayerOf(document).delete(dialog);
+	// The page gets its focus back where the dialog took it from -- when the
+	// dialog holds focus, or held the whole page inert as the modal one.
+	const previous = dialog[kPreviouslyFocused];
+	dialog[kPreviouslyFocused] = null;
+	const active = document[kActiveElement];
+	const heldFocus =
+		active !== null && isShadowIncludingInclusiveAncestor(dialog, active);
+	if (previous !== null && (wasModal || heldFocus)) {
+		(previous as HTMLElement).focus();
+	}
+	// focus() refuses a target that left the tree or stopped being
+	// focusable; focus still in the closed dialog falls back to the body.
+	const after = document[kActiveElement];
+	if (after !== null && isShadowIncludingInclusiveAncestor(dialog, after)) {
+		(after as HTMLElement).blur();
 	}
 	if (returnValue !== undefined) {
 		dialog[kReturnValue] = String(returnValue);

--- a/src/internal/flex.ts
+++ b/src/internal/flex.ts
@@ -98,6 +98,17 @@ const UNIT_POINT = 1;
 const UNIT_PERCENT = 2;
 const UNIT_AUTO = 3;
 
+/**
+ * The intrinsic sizing keywords of css-sizing-3 §5, carried beside a width of
+ * auto rather than as units of it: min/max resolution, percentages and flex
+ * arithmetic go on reading auto, and only the places that decide how wide an
+ * auto box comes out consult the keyword.
+ */
+const SIZING_NONE = 0;
+const SIZING_MIN_CONTENT = 1;
+const SIZING_MAX_CONTENT = 2;
+const SIZING_FIT_CONTENT = 3;
+
 export type Align = number;
 export type Justify = number;
 export type Wrap = number;
@@ -411,6 +422,8 @@ interface Style {
 	border: number[];
 
 	width: Value;
+	/** SIZING_*: how an auto width resolves; none means fill or measure. */
+	widthSizing: number;
 	height: Value;
 	minWidth: Value;
 	minHeight: Value;
@@ -534,6 +547,7 @@ function createStyle(): Style {
 		border: [0, 0, 0, 0],
 
 		width: AUTO_VALUE,
+		widthSizing: SIZING_NONE,
 		height: AUTO_VALUE,
 		minWidth: UNDEFINED_VALUE,
 		minHeight: UNDEFINED_VALUE,
@@ -1077,6 +1091,13 @@ export class Node {
 		this.markDirty();
 	}
 
+	setWidthSizing(v: number): void {
+		if (this.style.widthSizing !== v) {
+			this.style.widthSizing = v;
+			this.markDirty();
+		}
+	}
+
 	setHeight(v: number | string | undefined): void {
 		this.style.height = toValue(v);
 		this.markDirty();
@@ -1251,14 +1272,31 @@ export class Node {
 		const width = resolveValue(this.style.width, ownerWidth);
 		const height = resolveValue(this.style.height, ownerHeight);
 
-		const availableWidth = isDefined(width) ? width : ownerWidth;
+		let availableWidth = isDefined(width) ? width : ownerWidth;
+		let widthMode = isDefined(availableWidth) ?
+			MEASURE_MODE_EXACTLY :
+			MEASURE_MODE_UNDEFINED;
+		// A sizing keyword on a root turns the owner's width from the used
+		// width into a probe: zero for min-content, a ceiling for fit-content,
+		// and no offer at all for max-content.
+		if (!isDefined(width) && this.style.widthSizing !== SIZING_NONE) {
+			if (this.style.widthSizing === SIZING_MIN_CONTENT) {
+				availableWidth = 0;
+				widthMode = MEASURE_MODE_AT_MOST;
+			} else if (this.style.widthSizing === SIZING_MAX_CONTENT) {
+				availableWidth = NaN;
+				widthMode = MEASURE_MODE_UNDEFINED;
+			} else if (isDefined(availableWidth)) {
+				widthMode = MEASURE_MODE_AT_MOST;
+			}
+		}
 		const availableHeight = isDefined(height) ? height : ownerHeight;
 
 		layoutNode(
 			this,
 			availableWidth,
 			availableHeight,
-			isDefined(availableWidth) ? MEASURE_MODE_EXACTLY : MEASURE_MODE_UNDEFINED,
+			widthMode,
 			isDefined(availableHeight) ?
 				MEASURE_MODE_EXACTLY :
 				MEASURE_MODE_UNDEFINED,
@@ -5887,7 +5925,10 @@ function readCollapseBottom(child: Node, into: MarginSet): void {
 
 /** A box that wraps its own content rather than filling its container. */
 function shrinkWrapsWidth(node: Node): boolean {
-	return node.style.display === DISPLAY_TABLE;
+	return (
+		node.style.display === DISPLAY_TABLE ||
+		node.style.widthSizing !== SIZING_NONE
+	);
 }
 
 /**
@@ -5938,7 +5979,17 @@ function layoutBlockChild(
 				contentWidth,
 			) + marginRow;
 		childWidth.mode = MEASURE_MODE_EXACTLY;
+	} else if (child.style.widthSizing === SIZING_MIN_CONTENT) {
+		// The min-content probe: an AT_MOST offer of zero breaks the content
+		// at its narrowest, and the wrapped width is the box's.
+		childWidth.value = 0;
+		childWidth.mode = MEASURE_MODE_AT_MOST;
+	} else if (child.style.widthSizing === SIZING_MAX_CONTENT) {
+		// An undefined offer measures the content unbroken, so the box takes
+		// its max-content width whatever the container offers.
 	} else if (isDefined(contentWidth)) {
+		// A non-filling child's AT_MOST offer is fit-content already:
+		// min(max-content, max(min-content, available)).
 		childWidth.value = contentWidth;
 		childWidth.mode = fill ? MEASURE_MODE_EXACTLY : MEASURE_MODE_AT_MOST;
 	}
@@ -6697,6 +6748,11 @@ const Flex = {
 	UNIT_POINT,
 	UNIT_PERCENT,
 	UNIT_AUTO,
+
+	SIZING_NONE,
+	SIZING_MIN_CONTENT,
+	SIZING_MAX_CONTENT,
+	SIZING_FIT_CONTENT,
 };
 
 export default Flex;

--- a/src/internal/layout.ts
+++ b/src/internal/layout.ts
@@ -856,6 +856,20 @@ function applyGridContainer(
 	);
 }
 
+/** The css-sizing-3 §5 keyword a width computed to, as the engine's constant. */
+function widthSizingConstant(value: string): number {
+	switch (value) {
+		case "min-content":
+			return Flex.SIZING_MIN_CONTENT;
+		case "max-content":
+			return Flex.SIZING_MAX_CONTENT;
+		case "fit-content":
+			return Flex.SIZING_FIT_CONTENT;
+		default:
+			return Flex.SIZING_NONE;
+	}
+}
+
 function styleFlexNode(
 	element: Element,
 	flexNode: FlexTypes.Node,
@@ -879,6 +893,7 @@ function styleFlexNode(
 	if (display === "inline" && !parentIsFlex) {
 		// For pure inline elements, unset dimensions since they handle dimensions in their measure function
 		flexNode.setWidthAuto();
+		flexNode.setWidthSizing(Flex.SIZING_NONE);
 		flexNode.setHeightAuto();
 		// Also unset min/max constraints for pure inline elements
 		flexNode.setMinWidth(undefined);
@@ -889,12 +904,14 @@ function styleFlexNode(
 		// For atomic inline elements, unset width/height but preserve min/max constraints
 		// This allows the measure function to work while still respecting CSS constraints
 		flexNode.setWidthAuto();
+		flexNode.setWidthSizing(Flex.SIZING_NONE);
 		flexNode.setHeightAuto();
 
 		applyMinMax(flexNode, computedStyle);
 	} else {
 		// For block elements, apply explicit dimensions normally
-		const width = parseUnitValue(computedStyle.computedValueOf("width"));
+		const widthValue = computedStyle.computedValueOf("width");
+		const width = parseUnitValue(widthValue);
 		if (typeof width === "number") {
 			flexNode.setWidth(width);
 		} else if (width && "percentage" in width) {
@@ -902,6 +919,7 @@ function styleFlexNode(
 		} else {
 			flexNode.setWidthAuto();
 		}
+		flexNode.setWidthSizing(widthSizingConstant(widthValue));
 
 		const height = parseUnitValue(computedStyle.computedValueOf("height"));
 		if (typeof height === "number") {
@@ -3860,9 +3878,27 @@ function collectLeavesUnder(
 				let contentWidthMode = Flex.MEASURE_MODE_UNDEFINED;
 				let contentHeightMode = Flex.MEASURE_MODE_UNDEFINED;
 
+				// A sizing keyword never reaches getBoxModel's numbers; it
+				// picks the probe the content is measured under instead.
+				const widthSizing =
+					boxModel.width === undefined ?
+							widthSizingConstant(getPropertyValue(element, "width")) :
+						Flex.SIZING_NONE;
 				if (boxModel.width !== undefined) {
 					contentWidth = Math.max(0, boxModel.width - horizontalBoxSpace);
 					contentWidthMode = Flex.MEASURE_MODE_EXACTLY;
+				} else if (widthSizing === Flex.SIZING_MIN_CONTENT) {
+					contentWidth = 0;
+					contentWidthMode = Flex.MEASURE_MODE_AT_MOST;
+				} else if (
+					widthSizing === Flex.SIZING_FIT_CONTENT &&
+					Number.isFinite(availableWidth) &&
+					availableWidth < Number.MAX_SAFE_INTEGER
+				) {
+					// fit-content: break at the run's available width, which
+					// caps max-content without flooring below min-content.
+					contentWidth = Math.max(0, availableWidth - horizontalBoxSpace);
+					contentWidthMode = Flex.MEASURE_MODE_AT_MOST;
 				} else if (element.tagName === "TEXTAREA") {
 					// cols sizes the CONTENT box (spec default 20), exactly as the
 					// attribute does in a browser; the box then adds whatever
@@ -3963,8 +3999,13 @@ function collectLeavesUnder(
 					// out here, since nothing above it will. An indefinite
 					// width shrinks to fit, which is what an inline-block does.
 					// NaN is the engine's "undefined": the axis shrinks to fit.
+					// A sizing keyword rides on the root, which turns a passed
+					// width into the matching probe instead of a used width.
+					contentRoot.setWidthSizing(widthSizing);
 					contentRoot.calculateLayout(
-						contentWidthMode === Flex.MEASURE_MODE_EXACTLY ?
+						contentWidthMode === Flex.MEASURE_MODE_EXACTLY ||
+						(widthSizing !== Flex.SIZING_NONE &&
+							contentWidthMode === Flex.MEASURE_MODE_AT_MOST) ?
 							contentWidth :
 							Number.NaN,
 						contentHeightMode === Flex.MEASURE_MODE_EXACTLY ?

--- a/tests/dialog.test.ts
+++ b/tests/dialog.test.ts
@@ -7,6 +7,7 @@
  */
 import {test, expect} from "@b9g/libuild/test";
 import {TermDOM} from "../src/internal/termdom.js";
+import {parseHTMLDocument} from "../src/internal/dom.js";
 import {MockProcess, nextFrame} from "./test-utils.js";
 
 async function open(html: string, cols = 30, rows = 8): Promise<
@@ -211,6 +212,56 @@ test("a dialog with nothing focusable takes focus itself", async () => {
 	dialog.showModal();
 	expect(dom.document.activeElement).toBe(dialog);
 	dom.dispose();
+});
+
+test("closing a dialog opened with show() gives focus back to the opener", async () => {
+	const {dom, dialog} = await open(
+		"<button id=\"page\">page</button>" +
+		"<dialog><button id=\"ok\">OK</button></dialog>",
+	);
+	const {document} = dom;
+	(document.getElementById("page") as HTMLElement).focus();
+
+	dialog.show();
+	// show() runs the dialog focusing steps too, not only showModal().
+	expect(document.activeElement?.id).toBe("ok");
+
+	dialog.close();
+	expect(document.activeElement?.id).toBe("page");
+	dom.dispose();
+});
+
+test("close falls back to the body when the opener left the document", async () => {
+	const {dom, dialog} = await open(
+		"<button id=\"page\">page</button>" +
+		"<dialog><button id=\"ok\">OK</button></dialog>",
+	);
+	const {document} = dom;
+	(document.getElementById("page") as HTMLElement).focus();
+
+	dialog.showModal();
+	expect(document.activeElement?.id).toBe("ok");
+
+	document.getElementById("page")!.remove();
+	expect(() => dialog.close()).not.toThrow();
+	// Focus cannot stay inside the closed dialog or go to a gone opener.
+	expect(document.activeElement).toBe(document.body);
+	dom.dispose();
+});
+
+test("a headless document moves focus state through show and close", () => {
+	const document = parseHTMLDocument(
+		"<!doctype html><button id=\"page\">page</button>" +
+		"<dialog><button id=\"ok\">OK</button></dialog>",
+	);
+	const dialog = document.querySelector("dialog") as HTMLDialogElement;
+	(document.getElementById("page") as HTMLElement).focus();
+
+	dialog.showModal();
+	expect(document.activeElement?.id).toBe("ok");
+
+	dialog.close();
+	expect(document.activeElement?.id).toBe("page");
 });
 
 /* ----------------------------------------------------------------- keys */

--- a/tests/dialog.test.ts
+++ b/tests/dialog.test.ts
@@ -254,8 +254,10 @@ test("a headless document moves focus state through show and close", () => {
 		"<!doctype html><button id=\"page\">page</button>" +
 		"<dialog><button id=\"ok\">OK</button></dialog>",
 	);
-	const dialog = document.querySelector("dialog") as HTMLDialogElement;
-	(document.getElementById("page") as HTMLElement).focus();
+	const dialog = (document as any).querySelector(
+		"dialog",
+	) as HTMLDialogElement;
+	(document.getElementById("page") as any).focus();
 
 	dialog.showModal();
 	expect(document.activeElement?.id).toBe("ok");

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -3008,3 +3008,66 @@ test("an empty inline element measures zero, not its container's width", async (
 	// An inline whose text lives in a nested inline still measures that text.
 	expect(layoutEngine.getRect(nested)?.width).toBe(2);
 });
+
+describe("width sizing keywords", () => {
+	test("a block sized with the css-sizing-3 keywords next to known text", async () => {
+		const terminal = new MockProcess({rows: 12, cols: 40});
+		const dom = new TermDOM({transport: terminal.transport});
+		const {document} = dom;
+		document.body.innerHTML =
+			"<div id=\"fit\" style=\"width: fit-content\">one two</div>" +
+			"<div id=\"max\" style=\"width: max-content\">one two</div>" +
+			"<div id=\"min\" style=\"width: min-content\">aa bbbb</div>" +
+			"<div id=\"auto\">one two</div>" +
+			"<div id=\"long\" style=\"width: fit-content\">a line that " +
+			"runs on well past the forty columns this screen has</div>";
+		await nextFrame(dom);
+
+		const width = (id: string): number =>
+			document.getElementById(id)!.getBoundingClientRect().width;
+		// fit-content wraps the text; auto keeps filling the container.
+		expect(width("fit")).toBe(7);
+		expect(width("max")).toBe(7);
+		// min-content is the widest word: "bbbb".
+		expect(width("min")).toBe(4);
+		expect(width("auto")).toBe(40);
+		// fit-content is capped by the available width, unlike max-content.
+		expect(width("long")).toBe(40);
+		dom.dispose();
+	});
+
+	test("an inline-block takes the keywords through its own measurement", async () => {
+		const terminal = new MockProcess({rows: 12, cols: 40});
+		const dom = new TermDOM({transport: terminal.transport});
+		const {document} = dom;
+		document.body.innerHTML =
+			"<div><span id=\"fit\" style=\"display:inline-block; " +
+			"width: fit-content\">one two</span></div>" +
+			"<div><span id=\"min\" style=\"display:inline-block; " +
+			"width: min-content\">aa bbbb</span></div>";
+		await nextFrame(dom);
+
+		const width = (id: string): number =>
+			document.getElementById(id)!.getBoundingClientRect().width;
+		expect(width("fit")).toBe(7);
+		expect(width("min")).toBe(4);
+		dom.dispose();
+	});
+
+	test("a dialog with width: fit-content shrinks to its content", async () => {
+		const terminal = new MockProcess({rows: 12, cols: 40});
+		const dom = new TermDOM({transport: terminal.transport});
+		const {document} = dom;
+		document.body.innerHTML =
+			"<style>dialog { width: fit-content }</style>" +
+			"<dialog>Save?</dialog>";
+		await nextFrame(dom);
+
+		const dialog = document.querySelector("dialog") as HTMLDialogElement;
+		dialog.show();
+		await nextFrame(dom);
+		// "Save?" is 5 columns; the UA border and padding add 2 apiece.
+		expect(dialog.getBoundingClientRect().width).toBe(9);
+		dom.dispose();
+	});
+});

--- a/tests/scroll-unification.test.ts
+++ b/tests/scroll-unification.test.ts
@@ -128,3 +128,31 @@ test("negative scrollTo values clamp to 0, matching scrollBy", async () => {
 	expect(dom.window.scrollY).toBe(0);
 	dom.dispose();
 });
+
+test("a scroll repaint keeps the legend on the fieldset's border row", async () => {
+	// A legend's negative margin sets it INTO the top border row. A camera
+	// scroll repaints only the newly exposed rows and carries the rest of
+	// the screen over; the fieldset intersects the exposed band, so its
+	// border strokes repaint -- and they must not blank the carried-over
+	// border row's legend, which nothing in the band redraws.
+	const terminal = new MockProcess({cols: 30, rows: 6});
+	const dom = new TermDOM({transport: terminal.transport});
+	dom.document.body.innerHTML =
+		"<div>l0</div><div>l1</div><div>l2</div><div>l3</div>" +
+		"<fieldset><legend>Legend</legend><div>field body</div></fieldset>" +
+		"<div>t0</div><div>t1</div><div>t2</div><div>t3</div>" +
+		"<div>t4</div><div>t5</div><div>t6</div><div>t7</div>";
+	await nextFrame(dom);
+
+	dom.window.scrollTo(0, 1);
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toContain("Legend");
+
+	// The border row scrolled off and back re-exposes it whole.
+	dom.window.scrollTo(0, 8);
+	await nextFrame(dom);
+	dom.window.scrollTo(0, 4);
+	await nextFrame(dom);
+	expect(terminal.getPlainText()).toContain("Legend");
+	dom.dispose();
+});


### PR DESCRIPTION
Examples grouped by category, each showing a slice of the UA defaults on unstyled markup:

- **inputs.ts** — the control zoo: text/password/textarea, checkbox/radio/select, buttons, an animated progress bar and the meter's three levels, in fieldsets with legends.
- **semantics.ts** — text-level semantics, headings, blockquote/pre/hr, details disclosure, and a `[hidden]` toggle.
- **table.ts** — collapsed borders, caption, bold header cells, with a season select that rebuilds the body.
- **dialog.ts** — the two lives of a dialog: `show()` grows the page in flow; `showModal()` centers with backdrop and an inert page.

Lists stay with lists.ts, direction with rtl.ts, popover with popover.ts.

Exercising these surfaced three engine bugs, now fixed here, one commit each: `setBorderCell` ignored the scroll frame's paint-band mask, so a border box touching the exposed band re-stamped its outline over carried-over rows (visible as the fieldset legend vanishing under camera scroll); the `fit-content`/`min-content`/`max-content` width keywords parsed but degraded to auto, and now route to the shrink-to-fit probes on blocks and inline-blocks; `dialog.close()` did not restore focus to the opener (`show()` never ran the focusing steps, the restore check was light-tree only), and now both paths store and restore per the spec, with a removed opener falling back to body.

All four verified in the emulator; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8sSHf9EvBZroVnsXJbJSD
