### PR TITLE
Stop exiting fullscreen on Escape

### DIFF
--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -4602,23 +4602,12 @@ function dispatchGlobalKeyboardEvent(
 			active :
 			termdom[kFullscreenManager].fullscreenElement || termdom.document.body;
 
-	// Escape in fullscreen is the user agent's key, never dispatched to the
-	// DOM: an app can't trap the user past it with preventDefault. It spends
-	// itself on the innermost trap first -- a focused text field owns the
-	// keyboard, so the first Escape gives it back, and only a free
-	// keyboard's Escape exits the screen.
-	if (keyName === "Escape" && termdom[kFullscreenManager].isFullscreen) {
-		if (
-			active &&
-			active !== termdom.document.body &&
-			termdom[kUAToolkit].isTextField(active as Element)
-		) {
-			(active as HTMLElement).blur();
-			return;
-		}
-		termdom[kFullscreenManager].exitFullscreen().catch(() => {});
-		return;
-	}
+	// Escape does NOT exit fullscreen. The browser's guarantee exists
+	// because requestFullscreen takes the user's screen; the alt screen
+	// takes nothing -- the emulator, the multiplexer and the signals stay
+	// the user's -- and terminal convention gives Escape to the app, where
+	// a modal editor or a cancel affordance spends it. A fullscreen app
+	// exits by its own affordance or document.exitFullscreen().
 
 	// Create and dispatch keydown event
 	const keydownEvent = new termdom.window.KeyboardEvent("keydown", {
@@ -4643,10 +4632,7 @@ function dispatchGlobalKeyboardEvent(
 	// a popover, which is why a manual one -- answering no close request
 	// -- is the way to keep one up). Whichever entered the layer last is
 	// the one the key reaches, so a popover over a dialog closes first.
-	// Both get Escape only when nothing is fullscreen -- the branch above
-	// already returned -- which is the browser's own precedence: the
-	// fullscreen exit is the user agent's guarantee, and only after it is
-	// spent does the key reach the page's own modality. Unlike Tab below,
+	// Fullscreen does not intercept the key on the way. Unlike Tab below,
 	// a preventDefault on keydown does not suppress it.
 	if (keyName === "Escape") {
 		const target = topmostCloseRequestTarget(termdom);

--- a/tests/keyboard.test.ts
+++ b/tests/keyboard.test.ts
@@ -1369,7 +1369,7 @@ test("fullscreen routes keydown through the general pipeline: tokenization, mous
 	dom.dispose();
 });
 
-test("Escape still exits fullscreen, now dispatched from the general pipeline", async () => {
+test("Escape is the app's key in fullscreen: dispatched, and the screen stays", async () => {
 	const terminal = new MockProcess({rows: 10, cols: 40});
 	const dom = new TermDOM({transport: transportFromProcess(terminal as any)});
 	dom.attach();
@@ -1386,39 +1386,12 @@ test("Escape still exits fullscreen, now dispatched from the general pipeline", 
 	);
 
 	(terminal.stdin as any).emit("data", Buffer.from("\x1b"));
-	await new Promise((r) => setTimeout(r, 0));
-
-	await new Promise((r) => setTimeout(r, 0));
-	await new Promise((resolve) => setTimeout(resolve, 10));
-
-	expect(document.fullscreenElement).toBe(null);
-	// Escape exits unconditionally, the same as a real browser -- it is never
-	// dispatched to the DOM, so the app can't preventDefault its way out.
-	expect(escapeSeenByContainer).toEqual([]);
-	dom.dispose();
-});
-
-test("Escape blurs a focused text field first; only the next Escape exits fullscreen", async () => {
-	const terminal = new MockProcess({rows: 10, cols: 40});
-	const dom = new TermDOM({transport: transportFromProcess(terminal as any)});
-	dom.attach();
-	await new Promise((r) => setTimeout(r, 0));
-	const {document} = dom;
-	const container = document.createElement("div");
-	const input = document.createElement("input");
-	container.appendChild(input);
-	document.body.appendChild(container);
-	await container.requestFullscreen();
-	input.focus();
-	expect(document.activeElement).toBe(input);
-
-	(terminal.stdin as any).emit("data", Buffer.from("\x1b"));
 	await new Promise((r) => setTimeout(r, 10));
-	expect(document.activeElement).not.toBe(input);
+
+	expect(escapeSeenByContainer).toEqual(["Escape"]);
 	expect(document.fullscreenElement).toBe(container);
 
-	(terminal.stdin as any).emit("data", Buffer.from("\x1b"));
-	await new Promise((r) => setTimeout(r, 10));
+	await document.exitFullscreen();
 	expect(document.fullscreenElement).toBe(null);
 	dom.dispose();
 });


### PR DESCRIPTION
Escape no longer exits fullscreen. Mapping it to escape full screen by default is likely surprising and unexpected for the ALT buffer use-case.