### PR TITLE
Pass every event to the exchange after its propagation path

### DIFF
--- a/docs/guides/04-api.md
+++ b/docs/guides/04-api.md
@@ -75,6 +75,10 @@ once the first frame has been written.
 While attached to the process transport, the Node event loop stays alive
 until `dispose()` or `window.close()`.
 
+`document.visibilityState` is `"hidden"` before `attach()`, `"visible"`
+until `dispose()`, and `"hidden"` after. `visibilitychange` fires on each
+change.
+
 Passing a transport rebinds the instance to it, only before the first
 attach.
 

--- a/examples/hover.ts
+++ b/examples/hover.ts
@@ -1,0 +1,70 @@
+// Hover: a :hover rule and the mouseover family
+//
+//   node examples/hover.ts
+//
+//   Move the mouse over the swatches. The one under the pointer lights up
+//   by a :hover rule, and the status line names it from mouseover. The
+//   terminal reports mouse motion only while something observes it, so a
+//   page with no :hover rule and no hover listener costs the terminal
+//   nothing.
+import {TermDOM} from "@b9g/termdom";
+
+const term = new TermDOM();
+term.attach();
+const {document} = term;
+
+const COLORS = [
+	["Red", "#e63946"],
+	["Orange", "#f77f00"],
+	["Yellow", "#ffd166"],
+	["Green", "#06d6a0"],
+	["Blue", "#118ab2"],
+	["Purple", "#8338ec"],
+];
+
+document.head.innerHTML = `
+	<style>
+		h1 { color: cyan; }
+		.swatches { display: flex; flex-direction: row; gap: 1ch;
+		            border: 1px solid #444444; padding: 0 1ch; }
+		.swatches:hover { border-color: white; }
+		.swatch { padding: 1px 2ch; color: black; }
+		.swatch:hover { font-weight: bold; text-decoration: underline; }
+		a { color: cyan; }
+		a:hover { color: white; background-color: blue; }
+		.status { margin-top: 1px; color: gray; }
+	</style>
+`;
+
+document.body.innerHTML = `
+	<h1>Hover</h1>
+	<div class="swatches">
+		${COLORS.map(
+			([name, hex]) =>
+				`<div class="swatch" style="background-color: ${hex}">${name}</div>`,
+		).join("")}
+	</div>
+	<p>Links respond too: <a>one</a>, <a>two</a>, <a>three</a>.</p>
+	<p class="status">Nothing under the pointer.</p>
+	<p>Press q or Ctrl+C to quit.</p>
+`;
+
+const status = document.querySelector(".status")!;
+const swatches = document.querySelector(".swatches")!;
+
+swatches.addEventListener("mouseover", (event) => {
+	const swatch = (event.target as Element).closest(".swatch");
+	if (swatch) {
+		status.textContent = `Over ${swatch.textContent}.`;
+	}
+});
+
+swatches.addEventListener("mouseleave", () => {
+	status.textContent = "Nothing under the pointer.";
+});
+
+document.addEventListener("keydown", (event) => {
+	if (event.key === "q") {
+		term.window.close();
+	}
+});

--- a/fuzz/document.test.ts
+++ b/fuzz/document.test.ts
@@ -267,6 +267,35 @@ const sizeArbitrary = fc.record({
 	rows: fc.integer({min: 14, max: 30}),
 });
 
+// The frame is repainted in place and commits nothing, so on the way out
+// the document is printed whole as command output. What that leaves on the
+// screen has to be the frame the terminal was showing, cell for cell,
+// colors included.
+test("exiting leaves the frame it was showing", async () => {
+	await fc.assert(
+		fc.asyncProperty(runArbitrary, async (run: Run) => {
+			const live = await play(run);
+			// Content taller than the terminal scrolls into the scrollback on
+			// the way out, and the screen shows its tail.
+			if (live.dom.document.body.scrollHeight > live.rows) {
+				live.dom.dispose();
+				return;
+			}
+			const before = live.terminal.getStaticANSI();
+			await live.dom.dispose();
+			const after = live.terminal.getStaticANSI();
+			if (after !== before) {
+				throw new Error(
+					`html: ${run.document.html}\n` +
+					`script: ${JSON.stringify(run.script)}\n` +
+					`--- showing\n${before}\n--- left behind\n${after}`,
+				);
+			}
+		}),
+		assertOptions,
+	);
+}, 900000);
+
 test("a resize round trip lands back on the frame it left", async () => {
 	await fc.assert(
 		fc.asyncProperty(

--- a/fuzz/scenes.ts
+++ b/fuzz/scenes.ts
@@ -34,6 +34,7 @@ export const SHEET = `
 	.editing .view { display: none; }
 	.on ~ .light { color: red; }
 	.dim { color: #808080; }
+	.bg { background-color: #333366; }
 	.pane { height: 4em; overflow-y: scroll; }
 	.box { border: 1px solid; }
 	.round { border-radius: 1ch; }
@@ -72,6 +73,7 @@ const BASE_CLASSES = [
 	"on",
 	"light",
 	"dim",
+	"bg",
 	"pane",
 ];
 const BASE_TAGS = ["div", "span", "p", "b", "em", "section", "li"];

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -4122,12 +4122,16 @@ function dispatch(
 		}
 	}
 	protectClipboardData(event);
-	// The exchange's listeners get the original targets; the clearing
-	// happens after they run.
 	if (exchange !== null) {
+		// The exchange's listeners get the original targets; the retargeted
+		// values invokeListeners left return once they've run.
+		const retargetedTarget = state.target;
+		const retargetedRelatedTarget = state.relatedTarget;
 		state.target = target;
 		state.relatedTarget = originalRelatedTarget;
 		deliverToSession(exchange, event);
+		state.target = retargetedTarget;
+		state.relatedTarget = retargetedRelatedTarget;
 	}
 	if (clearTargets) {
 		state.target = null;

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -189,6 +189,7 @@ const kLayout = Symbol("layout");
 const kCascade = Symbol("cascade");
 const kExchange = Symbol("exchange");
 const kScreen = Symbol("screen");
+const kPendingCaretReveal = Symbol("pendingCaretReveal");
 
 /**
  * The focus offset of a control's selection record, in offsets of the
@@ -10302,15 +10303,7 @@ Object.defineProperties(HTMLElement.prototype, {
 			if (!rect) {
 				return;
 			}
-			const document = this[kDocument];
-			const flow = attached[kLayout].getRect(document.documentElement);
-			const regionHeight =
-				getFullscreenElement(document) !== null
-					? attached[kScreen].rows
-					: Math.min(
-						attached[kScreen].rows,
-						flow ? Math.ceil(flow.height) : 0,
-					);
+			const regionHeight = getScrollingRegionHeight(this[kDocument]);
 			const top = attached[kScreen].scrollTop;
 			if (rect.top < top) {
 				attached[kScreen].scrollTo(rect.top);
@@ -22066,6 +22059,9 @@ export class Document extends Node implements globalThis.Document {
 	declare [kCascade]: Cascade;
 	declare [kExchange]: Exchange;
 	declare [kScreen]: Screen;
+	// The text control whose caret the next frame reveals. The last edit
+	// before the frame wins.
+	declare [kPendingCaretReveal]: TextControlOrSelect | null;
 
 	declare [kImplementation]: DOMImplementation | null;
 
@@ -29080,6 +29076,11 @@ export function attachDocument(
 	attached[kCascade] = styles;
 	attached[kExchange] = exchange;
 	attached[kScreen] = screen;
+	attached[kPendingCaretReveal] = null;
+	for (const type of ["input", "select", "change", "selectionchange"]) {
+		exchange.addEventListener(type, onTextControlEditEvent);
+	}
+	exchange.addEventListener("toggle", onDisclosureToggle);
 	hoverListenerCounts.set(
 		attached,
 		watchHoverListeners(attached, () => render()),
@@ -29102,6 +29103,154 @@ export function attachDocument(
 }
 
 const engineObservers = new WeakMap<Document, MutationObserver>();
+
+type TextControlOrSelect =
+	HTMLInputElement |
+	HTMLTextAreaElement |
+	HTMLSelectElement;
+
+// Only the active text control. A select commit or an author's dispatch on
+// an unfocused control must not move the document scroll. The reveal
+// happens on the frame the edit scheduled, so there is one document scroll
+// decision per frame instead of a layout flush per keystroke.
+function onTextControlEditEvent(event: globalThis.Event): void {
+	const target = event.target;
+	if (
+		!(
+			target instanceof HTMLInputElement ||
+			target instanceof HTMLTextAreaElement ||
+			target instanceof HTMLSelectElement
+		)
+	) {
+		return;
+	}
+	const attached = getAttachedDocument(target);
+	if (attached === undefined || target !== getFocusedElement(attached)) {
+		return;
+	}
+	attached[kPendingCaretReveal] = target;
+	// A document scroll move and a caret move. No mutation record describes
+	// either.
+	attached[kScreen].invalidate();
+	void attached[kRender]();
+}
+
+// A terminal page is one screen tall, and what a details opened is often
+// below the fold. A details that closes took content away, so only opening
+// reveals.
+function onDisclosureToggle(event: globalThis.Event): void {
+	const details = event.target;
+	if (!(details instanceof HTMLDetailsElement) || !details.open) {
+		return;
+	}
+	details.scrollIntoView({block: "nearest"});
+}
+
+/** The focused element, through shadow roots. */
+export function getFocusedElement(
+	document: globalThis.Document,
+): globalThis.Element | null {
+	let active = document.activeElement;
+	for (
+		let inner = active && getShadowRoot(active)?.activeElement;
+		inner;
+		inner = getShadowRoot(inner)?.activeElement
+	) {
+		active = inner;
+	}
+	return active;
+}
+
+// The rows the document scroll shows. Fullscreen owns the screen from row
+// zero, and its element has left the flow, which then measures next to
+// nothing.
+function getScrollingRegionHeight(document: globalThis.Document): number {
+	const attached = getAttachedDocument(document as unknown as Node)!;
+	if (getFullscreenElement(attached) !== null) {
+		return attached[kScreen].rows;
+	}
+	const flow = attached[kLayout].getRect(document.documentElement!);
+	return Math.min(attached[kScreen].rows, flow ? Math.ceil(flow.height) : 0);
+}
+
+// The caret as the painter derives it: the selection focus, measured
+// through the rendered text. Null when there is no record, text or box.
+function getCaretRect(
+	attached: Document,
+	element: globalThis.Element,
+): {x: number; y: number} | null {
+	const focus = getSelectionFocus(element);
+	if (focus === null) {
+		return null;
+	}
+	const node = getTextControlValueText(element);
+	if (node === null) {
+		return null;
+	}
+	const range = element.ownerDocument!.createRange();
+	range.setStart(node, Math.min(focus, node.data.length));
+	range.collapse(true);
+	const rects = attached[kLayout].getRangeRects(range);
+	if (rects.length === 0) {
+		return null;
+	}
+	return {x: Math.round(rects[0].x), y: Math.round(rects[0].y)};
+}
+
+/**
+ * Scrolls the document to the caret of the text control an edit queued,
+ * after layout. Skipped if focus has moved on: revealing a control the user
+ * left would yank the document scroll back. Wheel-scrolling away from a
+ * focused control stays allowed, since only edits queue a reveal.
+ */
+export function revealPendingCaret(document: globalThis.Document): void {
+	const attached = document as Document;
+	const element = attached[kPendingCaretReveal];
+	if (element === null) {
+		return;
+	}
+	attached[kPendingCaretReveal] = null;
+	if (element !== getFocusedElement(document)) {
+		return;
+	}
+	flushLayout(element);
+	const rect = attached[kLayout].getRect(element);
+	if (!rect) {
+		return;
+	}
+	let caretY = Math.round(rect.top);
+	const caret = getCaretRect(attached, element);
+	if (caret !== null) {
+		caretY = caret.y;
+	}
+	// Widened to the text control's edge when the caret is on its first or
+	// last row, so the border shows instead of a cropped box.
+	const boxModel = getBoxModel(element);
+	let revealTop = caretY;
+	let revealBottom = caretY + 1;
+	if (caretY <= Math.round(rect.top) + (boxModel.borderTopWidth || 0)) {
+		revealTop = Math.round(rect.top);
+	}
+	if (
+		caretY >=
+		Math.round(rect.bottom) - (boxModel.borderBottomWidth || 0) - 1
+	) {
+		revealBottom = Math.round(rect.bottom);
+	}
+	const regionHeight = getScrollingRegionHeight(document);
+	const top = attached[kScreen].scrollTop;
+	const delta =
+		revealTop < top
+			? revealTop - top
+			: revealBottom > top + regionHeight
+				? revealBottom - (top + regionHeight)
+				: 0;
+	if (delta) {
+		attached[kScreen].scrollTo(top + delta);
+		// No mutation record describes a document scroll move.
+		void attached[kRender]();
+	}
+}
 
 // Everything except painting: the flat-tree memo, UA shadow tree upgrades,
 // the cascade, the layout tree and the focus default actions, always in

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -32,13 +32,6 @@ import {
 import type {Layout} from "./layout.ts";
 import type {Screen} from "./screen.ts";
 import {
-	closeTermDOM,
-	isAttached,
-	render,
-	sealTermDOM,
-	type TermDOM,
-} from "./termdom.ts";
-import {
 	getNextGraphemeBoundary,
 	getPreviousGraphemeBoundary,
 	getStringWidth,
@@ -190,7 +183,8 @@ export function getTextControlValueText(
 	);
 }
 
-const kTermDOM = Symbol("termDOM");
+const kRender = Symbol("render");
+const kVisible = Symbol("visible");
 const kLayout = Symbol("layout");
 const kCascade = Symbol("cascade");
 const kExchange = Symbol("exchange");
@@ -3254,7 +3248,7 @@ const kListeners = Symbol("event listener list");
 const kGetTheParent = Symbol("get the parent");
 
 /** An event target: a listener list, and the parent dispatch walks to. */
-class EventTarget implements globalThis.EventTarget {
+export class EventTarget implements globalThis.EventTarget {
 	declare [kListeners]: Listener[];
 
 	/** Null until this target is given an event handler. Most never are. */
@@ -4005,6 +3999,8 @@ function dispatch(
 	const state = event[kState];
 	state.trusted = trusted;
 	state.dispatch = true;
+	const exchange = getSessionExchange(target);
+	const originalRelatedTarget = state.relatedTarget;
 	let activationTarget: EventTarget | null = null;
 	let relatedTarget = retarget(state.relatedTarget, target);
 	let clearTargets = false;
@@ -4117,10 +4113,6 @@ function dispatch(
 	state.dispatch = false;
 	state.stopPropagation = false;
 	state.stopImmediate = false;
-	if (clearTargets) {
-		state.target = null;
-		state.relatedTarget = null;
-	}
 	if (activationTarget !== null) {
 		if (!state.canceled) {
 			runActivationBehavior(activationTarget, event);
@@ -4129,6 +4121,17 @@ function dispatch(
 		}
 	}
 	protectClipboardData(event);
+	// The exchange's listeners get the original targets; the clearing
+	// happens after they run.
+	if (exchange !== null) {
+		state.target = target;
+		state.relatedTarget = originalRelatedTarget;
+		deliverToSession(exchange, event);
+	}
+	if (clearTargets) {
+		state.target = null;
+		state.relatedTarget = null;
+	}
 	return !state.canceled;
 }
 
@@ -4382,6 +4385,54 @@ function innerInvoke(
 		}
 	}
 	return found;
+}
+
+// Every dispatched event is passed to the exchange's listeners after its
+// path, regardless of bubbles, composed, or stopPropagation().
+function getSessionExchange(target: EventTarget): EventTarget | null {
+	const document = getEventTargetDocument(target);
+	if (document === null) {
+		return null;
+	}
+	const attached = getAttachedDocument(document);
+	return attached === undefined ? null : attached[kExchange];
+}
+
+function deliverToSession(exchange: EventTarget, event: Event): void {
+	for (const listener of exchange[kListeners].slice()) {
+		if (listener.removed || listener.type !== event.type) {
+			continue;
+		}
+		try {
+			callListener(listener.callback, exchange, event);
+		} catch (error) {
+			reportError(error, getEventTargetDocument(event.target as EventTarget));
+		}
+	}
+}
+
+export function requestRender(document: globalThis.Document): void {
+	const attached = getAttachedDocument(document as unknown as Node);
+	if (attached !== undefined) {
+		void attached[kRender]();
+	}
+}
+
+export function setDocumentVisible(
+	document: globalThis.Document,
+	visible: boolean,
+): void {
+	const attached = getAttachedDocument(document as unknown as Node);
+	if (attached === undefined || attached[kVisible] === visible) {
+		return;
+	}
+	attached[kVisible] = visible;
+	dispatch(attached, new Event("visibilitychange", {bubbles: true}));
+}
+
+function isDocumentVisible(document: Document): boolean {
+	const attached = getAttachedDocument(document);
+	return attached === undefined || attached[kVisible];
 }
 
 // For an object callback, handleEvent is looked up at call time.
@@ -8637,7 +8688,7 @@ export class Element extends Node implements globalThis.Element {
 			if (this.isConnected) {
 				attached[kLayout].invalidate(this);
 				attached[kScreen].invalidate();
-				void render(attached[kTermDOM]);
+				void attached[kRender]();
 			}
 		}
 		return root as unknown as globalThis.ShadowRoot;
@@ -8655,7 +8706,7 @@ export class Element extends Node implements globalThis.Element {
 		// Fullscreen switches to the alternate screen, and attach() is the only
 		// consent for that. A browser rejects without a user gesture; this is
 		// the terminal equivalent.
-		if (!isAttached(attached[kTermDOM])) {
+		if (!attached[kVisible]) {
 			return Promise.reject(
 				new Error("requestFullscreen(): attach() the terminal first"),
 			);
@@ -9899,7 +9950,7 @@ export class HTMLElement extends Element {
 		// anything.
 		attached[kCascade].handleFocusChange(previous, this);
 		attached[kScreen].invalidate();
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 		// The body holds focus whenever nothing else does, so moving focus off
 		// the body fires no blur.
 		if (previous !== null && previous !== (document.body as unknown)) {
@@ -9934,7 +9985,7 @@ export class HTMLElement extends Element {
 		}
 		attached[kCascade].handleFocusChange(this, null);
 		attached[kScreen].invalidate();
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 		dispatchAsUserAgent(
 			this,
 			new FocusEvent("blur", {relatedTarget: null, bubbles: false}),
@@ -10265,10 +10316,10 @@ Object.defineProperties(HTMLElement.prototype, {
 			const top = attached[kScreen].scrollTop;
 			if (rect.top < top) {
 				attached[kScreen].scrollTo(rect.top);
-				void render(attached[kTermDOM]);
+				void attached[kRender]();
 			} else if (rect.bottom > top + regionHeight) {
 				attached[kScreen].scrollTo(rect.bottom - regionHeight);
-				void render(attached[kTermDOM]);
+				void attached[kRender]();
 			}
 		},
 		configurable: true,
@@ -18800,7 +18851,7 @@ function popoverStateChanged(element: Element): void {
 	}
 	attached[kCascade].handleStateChange(element);
 	attached[kScreen].invalidate();
-	void render(attached[kTermDOM]);
+	void attached[kRender]();
 }
 
 // Returns true, false for a call that should silently do nothing, or the
@@ -22011,7 +22062,8 @@ export class Document extends Node implements globalThis.Document {
 	// What an attached document renders through, set by attachDocument. A
 	// headless document has none and behaves as a document with no browsing
 	// context.
-	declare [kTermDOM]: TermDOM;
+	declare [kRender]: () => Promise<void>;
+	declare [kVisible]: boolean;
 	declare [kLayout]: Layout;
 	declare [kCascade]: Cascade;
 	declare [kExchange]: Exchange;
@@ -22280,7 +22332,7 @@ export class Document extends Node implements globalThis.Document {
 		const attached = getAttachedDocument(this);
 		if (
 			attached !== undefined &&
-			isAttached(attached[kTermDOM]) &&
+			attached[kVisible] &&
 			attached[kExchange].interactive
 		) {
 			void attached[kExchange].setTitle(String(value));
@@ -22406,13 +22458,12 @@ export class Document extends Node implements globalThis.Document {
 		this.body?.setAttribute("vlink", value);
 	}
 
-	/** A terminal shows what it renders, immediately. */
 	get hidden(): boolean {
-		return false;
+		return !isDocumentVisible(this);
 	}
 
 	get visibilityState(): globalThis.DocumentVisibilityState {
-		return "visible";
+		return isDocumentVisible(this) ? "visible" : "hidden";
 	}
 
 	get fullscreen(): boolean {
@@ -22605,10 +22656,7 @@ export class Document extends Node implements globalThis.Document {
 	// sealed into the terminal's scrollback, and a later mutation starts a
 	// fresh document below the sealed block.
 	close(): void {
-		const attached = getAttachedDocument(this);
-		if (attached !== undefined) {
-			sealTermDOM(attached[kTermDOM]);
-		}
+		getAttachedDocument(this)?.[kExchange].dispatchEvent(new Event("seal"));
 	}
 
 	getElementsByTagName<K extends keyof globalThis.HTMLElementTagNameMap>(
@@ -24082,7 +24130,7 @@ function setScrollOffset(
 	if (isDocumentScroller(element)) {
 		if (axis === "top") {
 			attached[kScreen].scrollTo(Number(value));
-			void render(attached[kTermDOM]);
+			void attached[kRender]();
 		}
 		return;
 	}
@@ -24116,7 +24164,7 @@ function setScrollOffset(
 	} else {
 		attached[kScreen].invalidate();
 	}
-	void render(attached[kTermDOM]);
+	void attached[kRender]();
 }
 
 /**
@@ -24165,7 +24213,7 @@ export function clampScrollOffsets(document: globalThis.Document): void {
 	if (changed) {
 		scrollShifts.delete(document as Document);
 		attached[kScreen].invalidate();
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 	}
 }
 
@@ -25710,7 +25758,7 @@ function scheduleSelectionChange(document: Document): void {
 	const attached = getAttachedDocument(document);
 	if (attached !== undefined) {
 		attached[kScreen].invalidate();
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 	}
 	if (document[kSelectionChangeScheduled]) {
 		return;
@@ -29018,31 +29066,32 @@ export function syncMediaQueries(document: globalThis.Document): void {
  */
 export function attachDocument(
 	document: globalThis.Document,
-	termDOM: TermDOM,
 	layout: Layout,
 	styles: Cascade,
 	exchange: Exchange,
 	screen: Screen,
+	render: () => Promise<void>,
 ): void {
 	const attached = document as Document;
-	if (attached[kTermDOM] !== undefined) {
+	if (attached[kExchange] !== undefined) {
 		throw new Error("This document already has its engine.");
 	}
-	attached[kTermDOM] = termDOM;
+	attached[kRender] = render;
+	attached[kVisible] = false;
 	attached[kLayout] = layout;
 	attached[kCascade] = styles;
 	attached[kExchange] = exchange;
 	attached[kScreen] = screen;
 	hoverListenerCounts.set(
 		attached,
-		watchHoverListeners(attached, () => render(termDOM)),
+		watchHoverListeners(attached, () => render()),
 	);
 	// The document owns the observer. Mutations fan out to the cascade, the
 	// layout tree and the UA default actions here, and the engine is only
 	// asked to render the frame that shows the result.
 	const observer = new MutationObserver((mutations) => {
 		handleMutationRecords(attached, mutations);
-		void render(termDOM);
+		void render();
 	});
 	observer.observe(document.documentElement as unknown as Node, {
 		childList: true,
@@ -29208,7 +29257,7 @@ export function flushLayout(node: globalThis.Node): boolean {
 	) as globalThis.Document;
 	const had = applyMutations(document);
 	if (had) {
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 	}
 	attached[kLayout].performLayout();
 	clampScrollOffsets(document);
@@ -29224,7 +29273,8 @@ export function hoverListenerCount(document: globalThis.Document): number {
 // A document that has been adopted. It renders, and knows what it
 // renders through.
 type AttachedDocument = Document & {
-	[kTermDOM]: TermDOM;
+	[kRender]: () => Promise<void>;
+	[kVisible]: boolean;
 	[kLayout]: Layout;
 	[kCascade]: Cascade;
 	[kExchange]: Exchange;
@@ -29238,7 +29288,7 @@ function getAttachedDocument(
 	const document = (
 		shaped.nodeType === DOCUMENT_NODE ? node : shaped.ownerDocument
 	) as Document | null;
-	return document !== null && document[kTermDOM] !== undefined
+	return document !== null && document[kExchange] !== undefined
 		? (document as AttachedDocument)
 		: undefined;
 }
@@ -29399,7 +29449,7 @@ function reachClipboard(document: Document, what: string): Exchange {
 	const attached = getAttachedDocument(document);
 	if (
 		attached === undefined ||
-		!isAttached(attached[kTermDOM]) ||
+		!attached[kVisible] ||
 		!attached[kExchange].interactive
 	) {
 		throw clipboardDenied(
@@ -29487,7 +29537,7 @@ class PermissionStatus extends EventTarget {
 		const attached = getAttachedDocument(document);
 		if (
 			!attached ||
-			!isAttached(attached[kTermDOM]) ||
+			!attached[kVisible] ||
 			!attached[kExchange].interactive
 		) {
 			return "denied";
@@ -29790,7 +29840,7 @@ function frameSettled(
 		holdFrameCallback(document, () => {
 			resolve();
 		});
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 	});
 }
 
@@ -30294,7 +30344,7 @@ export class Window extends EventTarget {
 				? (xOrOptions.top ?? attached[kScreen].scrollTop)
 				: (y ?? 0);
 		attached[kScreen].scrollTo(top);
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 	}
 
 	scroll(options?: globalThis.ScrollToOptions): void;
@@ -30319,7 +30369,7 @@ export class Window extends EventTarget {
 				? (xOrOptions.top ?? 0)
 				: (y ?? 0);
 		attached[kScreen].scrollTo(attached[kScreen].scrollTop + top);
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 	}
 
 	// requestAnimationFrame is the only way to await a painted frame. It
@@ -30332,7 +30382,7 @@ export class Window extends EventTarget {
 			return 0;
 		}
 		const handle = holdFrameCallback(this.document, callback);
-		void render(attached[kTermDOM]);
+		void attached[kRender]();
 		return handle;
 	}
 
@@ -30419,7 +30469,6 @@ export class Window extends EventTarget {
 		if (event.defaultPrevented || event.returnValue !== "") {
 			return;
 		}
-		closeTermDOM(attached[kTermDOM]);
 		this[kClosed] = true;
 	}
 
@@ -33097,7 +33146,6 @@ export type {
 	Storage,
 	NodeListOf,
 	HTMLCollectionOf,
-	EventTarget,
 	BeforeUnloadEvent,
 	MessageEvent,
 	HashChangeEvent,

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -4399,16 +4399,14 @@ function getSessionExchange(target: EventTarget): EventTarget | null {
 }
 
 function deliverToSession(exchange: EventTarget, event: Event): void {
-	for (const listener of exchange[kListeners].slice()) {
-		if (listener.removed || listener.type !== event.type) {
-			continue;
-		}
-		try {
-			callListener(listener.callback, exchange, event);
-		} catch (error) {
-			reportError(error, getEventTargetDocument(event.target as EventTarget));
-		}
-	}
+	const state = event[kState];
+	state.currentTarget = exchange;
+	const listeners = exchange[kListeners].slice();
+	innerInvoke(event, listeners, true);
+	state.stopImmediate = false;
+	innerInvoke(event, listeners, false);
+	state.stopImmediate = false;
+	state.currentTarget = null;
 }
 
 export function requestRender(document: globalThis.Document): void {

--- a/src/internal/dom.ts
+++ b/src/internal/dom.ts
@@ -4388,8 +4388,6 @@ function innerInvoke(
 	return found;
 }
 
-// Every dispatched event is passed to the exchange's listeners after its
-// path, regardless of bubbles, composed, or stopPropagation().
 function getSessionExchange(target: EventTarget): EventTarget | null {
 	const document = getEventTargetDocument(target);
 	if (document === null) {
@@ -4399,6 +4397,8 @@ function getSessionExchange(target: EventTarget): EventTarget | null {
 	return attached === undefined ? null : attached[kExchange];
 }
 
+// Every dispatched event reaches the exchange's listeners after its path,
+// regardless of bubbles, composed, or stopPropagation().
 function deliverToSession(exchange: EventTarget, event: Event): void {
 	const state = event[kState];
 	state.currentTarget = exchange;

--- a/src/internal/exchange.ts
+++ b/src/internal/exchange.ts
@@ -682,7 +682,10 @@ const kWidthDeferralWait = Symbol("widthDeferralWait");
 /**
  * One reader, one writer, and the demultiplexer between them. Every
  * query is bounded by a timer, since most terminals reply with nothing.
- * Silence means the terminal has no opinion and ours holds.
+ * Silence means the terminal has no opinion and ours holds. What the
+ * terminal reports is applied to the screen and layout here. As an event
+ * target it receives every event dispatched in the document after the
+ * event's path, and dispatches seal and terminalclose on itself.
  */
 export class Exchange extends EventTarget {
 	// A terminal replying late is still replying. Only one that never

--- a/src/internal/exchange.ts
+++ b/src/internal/exchange.ts
@@ -1088,6 +1088,32 @@ export class Exchange extends EventTarget {
 		);
 	}
 
+	/**
+	 * Room below the anchor for `rows` comes from scrolling earlier output
+	 * into the scrollback, never from painting over it. Returns the screen
+	 * row the region starts at.
+	 */
+	reserveRows(rows: number): number {
+		const screen = this[kScreen];
+		const overflow = screen.documentTop + rows - screen.rows;
+		const push = overflow <= 0 ? 0 : Math.min(overflow, screen.documentTop);
+		if (push > 0) {
+			screen.documentTop -= push;
+			void this.scrollUp(screen.rows, push);
+			// The previous buffer is not shifted. Its rows are region-relative
+			// and the region top moved by exactly the scroll. A pending
+			// post-resize reset is screen-absolute and does shift.
+			screen.scrolled(push);
+		}
+		return screen.documentTop;
+	}
+
+	/**
+	 * The scroll is IND (ESC D) from the bottom row. A bare LF after an
+	 * absolute CUP does not scroll (tmux and xterm-headless both), and CSI n S
+	 * scrolls without adding the rows to xterm-headless's scrollback, which
+	 * would make this untestable.
+	 */
 	scrollUp(bottomRow: number, rows: number): Promise<void> {
 		return this.write(getRowStart(bottomRow) + SCROLL_STEP.repeat(rows));
 	}

--- a/src/internal/exchange.ts
+++ b/src/internal/exchange.ts
@@ -1,5 +1,15 @@
-import {CustomEvent, Event, EventTarget, type Window} from "./dom.ts";
+import type {Cascade} from "./cssom.ts";
+import {
+	dispatchAsUserAgent,
+	Event,
+	EventTarget,
+	requestRender,
+	syncMediaQueries,
+	type Window,
+} from "./dom.ts";
 import type {Input} from "./input.ts";
+import type {Layout} from "./layout.ts";
+import type {Screen} from "./screen.ts";
 import {recordClusterAdvance} from "./text.ts";
 
 export type ColorDepth = "ansi" | "rgb" | "256";
@@ -632,18 +642,6 @@ interface PendingReply {
 	clipboard?: boolean;
 }
 
-export interface FrameStanding {
-	contentHeight: number;
-	wrappedRowsAbove: number | null;
-	documentTop: number;
-}
-
-export interface ResizeReport {
-	cols: number;
-	rows: number;
-	standing: FrameStanding | null;
-}
-
 const kTransport = Symbol("transport");
 const kInteractive = Symbol("interactive");
 const kEngagedModes = Symbol("engagedModes");
@@ -652,6 +650,9 @@ const kResizeTimer = Symbol("resizeTimer");
 const kSettlingResize = Symbol("settlingResize");
 const kTransportClosed = Symbol("transportClosed");
 const kWindow = Symbol("window");
+const kLayout = Symbol("layout");
+const kCascade = Symbol("cascade");
+const kScreen = Symbol("screen");
 const kInput = Symbol("input");
 
 const kWriter = Symbol("writer");
@@ -698,6 +699,9 @@ export class Exchange extends EventTarget {
 	declare [kEngagedModes]: Set<ModeName>;
 	declare [kAnchorDetectionEnabled]: boolean;
 	declare [kWindow]: Window;
+	declare [kLayout]: Layout;
+	declare [kCascade]: Cascade;
+	declare [kScreen]: Screen;
 	declare [kResizeTimer]: ReturnType<typeof setTimeout> | null;
 	// A token per resize burst, so a redraw that lands after a newer burst
 	// began is abandoned. Null between bursts.
@@ -727,7 +731,13 @@ export class Exchange extends EventTarget {
 	declare [kProbingEnded]: boolean;
 	declare [kWidths]: WidthProbes;
 
-	constructor(transport: TerminalTransport, window: Window) {
+	constructor(
+		transport: TerminalTransport,
+		window: Window,
+		layout: Layout,
+		styles: Cascade,
+		screen: Screen,
+	) {
 		super();
 		const interactive = transport.interactive;
 		this[kWriter] = null;
@@ -751,6 +761,9 @@ export class Exchange extends EventTarget {
 		// Anchor detection only makes sense when a shell's rows are above ours.
 		this[kAnchorDetectionEnabled] = transport.sharesScreen && interactive;
 		this[kWindow] = window;
+		this[kLayout] = layout;
+		this[kCascade] = styles;
+		this[kScreen] = screen;
 		this[kInput] = null;
 		this[kResizeTimer] = null;
 		this[kSettlingResize] = null;
@@ -903,11 +916,7 @@ export class Exchange extends EventTarget {
 		this[kAnchorDetectionEnabled] =
 			transport.sharesScreen && transport.interactive;
 		this[kWidths] = createWidthProbes(transport.interactive);
-		this.dispatchEvent(
-			new CustomEvent<ResizeReport>("terminalresize", {
-				detail: {cols: transport.cols, rows: transport.rows, standing: null},
-			}),
-		);
+		terminalResized(this, transport.cols, transport.rows);
 	}
 
 	start(input: Input): void {
@@ -965,7 +974,7 @@ export class Exchange extends EventTarget {
 		}
 		this[kPriorBidiMode] = answer;
 		if (answer === 1 || answer === 3) {
-			this.dispatchEvent(new Event("reorder"));
+			this[kLayout].adoptTerminalReordering();
 		}
 	}
 
@@ -1014,7 +1023,7 @@ export class Exchange extends EventTarget {
 			timeoutMs: 1000,
 			sequence: this[kDSRSequence]++,
 			read: ({row}) => {
-				this.dispatchEvent(new CustomEvent("anchor", {detail: {row}}));
+				anchorDetected(this, row);
 				this[kHasDetectedAnchor] = true;
 				return row;
 			},
@@ -1254,7 +1263,7 @@ function requestDeferredProbeFrame(session: Exchange): void {
 		if (session[kDisposed] || widths.deferred.size === 0) {
 			return;
 		}
-		session.dispatchEvent(new Event("probes"));
+		probesDeferred(session);
 	}, Exchange[kWidthDeferralWait]);
 }
 
@@ -1340,7 +1349,7 @@ function settleWidthProbe(
 	widths.settled.add(probe.cluster);
 	widths.drift += advance - probe.width;
 	if (recordClusterAdvance(probe.cluster, advance)) {
-		session.dispatchEvent(new Event("widths"));
+		widthsCorrected(session);
 	}
 }
 
@@ -1408,6 +1417,78 @@ function scheduleResize(session: Exchange): void {
 	}, RESIZE_DEBOUNCE_MS);
 }
 
+function terminalResized(
+	session: Exchange,
+	width: number,
+	height: number,
+): void {
+	const screen = session[kScreen];
+	// A SIGWINCH with an unchanged size still redraws but fires no event.
+	const sizeChanged = width !== screen.cols || height !== screen.rows;
+	screen.resize(height, width);
+	session[kLayout].resize(width, height);
+	// A size change can flip any @media result and every vw/vh value.
+	session[kCascade].syncStylesheets();
+	const window = session[kWindow];
+	if (sizeChanged) {
+		dispatchAsUserAgent(window, new window.Event("resize"));
+	}
+	syncMediaQueries(window.document);
+}
+
+/** Where the frame is after a resize, for the re-anchor. */
+function frameStanding(
+	session: Exchange,
+	cols: number,
+): {
+	contentHeight: number;
+	wrappedRowsAbove: number | null;
+	documentTop: number;
+} {
+	const layout = session[kLayout];
+	layout.performLayout();
+	return {
+		contentHeight: layout.documentPaintHeight(),
+		wrappedRowsAbove: session[kScreen].wrappedRowsAbovePark(cols),
+		documentTop: session[kScreen].documentTop,
+	};
+}
+
+/** The frame now starts at `startRow`. Repaint it from there. */
+function frameReplaced(session: Exchange, startRow: number): void {
+	const screen = session[kScreen];
+	screen.documentTop = startRow;
+	screen.anchorScrollTop = -startRow;
+	screen.replaced(startRow);
+	requestRender(session[kWindow].document);
+}
+
+/**
+ * The 1-based terminal row the command started on becomes the 0-based anchor.
+ */
+function anchorDetected(session: Exchange, row: number): void {
+	session[kScreen].documentTop = row - 1;
+	session[kScreen].anchorScrollTop = 1 - row;
+}
+
+/** Deferred width probes go out with the next frame even if nothing changed. */
+function probesDeferred(session: Exchange): void {
+	session[kScreen].flushProbes();
+	requestRender(session[kWindow].document);
+}
+
+/**
+ * A cluster measured wider or narrower than the tables said, so every
+ * column after it on a painted row is off. The previous frame described
+ * a screen that was never drawn. Drop it and paint again from the
+ * corrected measurements.
+ */
+function widthsCorrected(session: Exchange): void {
+	session[kLayout].invalidateTextMeasurement();
+	session[kScreen].repaintAll();
+	requestRender(session[kWindow].document);
+}
+
 // The terminal has rewrapped the old frame with the text above it. The
 // cursor was parked on the frame's bottom row and stayed on its line
 // through the rewrap, and every painted row is a hard line, so the
@@ -1416,21 +1497,15 @@ function scheduleResize(session: Exchange): void {
 // exact for height changes.
 function handleResize(session: Exchange): void {
 	const {cols: newWidth, rows: newHeight} = session[kTransport];
-	// The terminalresize listener fills in standing.
-	const report: ResizeReport = {
-		cols: newWidth,
-		rows: newHeight,
-		standing: null,
-	};
-	session.dispatchEvent(new CustomEvent("terminalresize", {detail: report}));
-	if (report.standing === null) {
-		return;
-	}
-	const {contentHeight, wrappedRowsAbove, documentTop} = report.standing;
+	terminalResized(session, newWidth, newHeight);
+	const {contentHeight, wrappedRowsAbove, documentTop} = frameStanding(
+		session,
+		newWidth,
+	);
 	const settling = session[kSettlingResize];
 
 	const redraw = (startRow: number) => {
-		session.dispatchEvent(new CustomEvent("replace", {detail: {startRow}}));
+		frameReplaced(session, startRow);
 
 		// The frame is placed by the screen reset. Cursor detection is
 		// suspended until it is written.

--- a/src/internal/exchange.ts
+++ b/src/internal/exchange.ts
@@ -1,15 +1,5 @@
+import {CustomEvent, Event, EventTarget, type Window} from "./dom.ts";
 import type {Input} from "./input.ts";
-import {
-	anchorDetected,
-	closeTermDOM,
-	frameReplaced,
-	frameStanding,
-	probesDeferred,
-	type TermDOM,
-	terminalReorders,
-	terminalResized,
-	widthsCorrected,
-} from "./termdom.ts";
 import {recordClusterAdvance} from "./text.ts";
 
 export type ColorDepth = "ansi" | "rgb" | "256";
@@ -642,6 +632,18 @@ interface PendingReply {
 	clipboard?: boolean;
 }
 
+export interface FrameStanding {
+	contentHeight: number;
+	wrappedRowsAbove: number | null;
+	documentTop: number;
+}
+
+export interface ResizeReport {
+	cols: number;
+	rows: number;
+	standing: FrameStanding | null;
+}
+
 const kTransport = Symbol("transport");
 const kInteractive = Symbol("interactive");
 const kEngagedModes = Symbol("engagedModes");
@@ -649,7 +651,7 @@ const kAnchorDetectionEnabled = Symbol("anchorDetectionEnabled");
 const kResizeTimer = Symbol("resizeTimer");
 const kSettlingResize = Symbol("settlingResize");
 const kTransportClosed = Symbol("transportClosed");
-const kTermDOM = Symbol("termDOM");
+const kWindow = Symbol("window");
 const kInput = Symbol("input");
 
 const kWriter = Symbol("writer");
@@ -681,7 +683,7 @@ const kWidthDeferralWait = Symbol("widthDeferralWait");
  * query is bounded by a timer, since most terminals reply with nothing.
  * Silence means the terminal has no opinion and ours holds.
  */
-export class Exchange {
+export class Exchange extends EventTarget {
 	// A terminal replying late is still replying. Only one that never
 	// replies at all stops probing.
 	static readonly [kWidthProbeTimeout] = 2000;
@@ -695,7 +697,7 @@ export class Exchange {
 	declare [kInteractive]: boolean;
 	declare [kEngagedModes]: Set<ModeName>;
 	declare [kAnchorDetectionEnabled]: boolean;
-	declare [kTermDOM]: TermDOM;
+	declare [kWindow]: Window;
 	declare [kResizeTimer]: ReturnType<typeof setTimeout> | null;
 	// A token per resize burst, so a redraw that lands after a newer burst
 	// began is abandoned. Null between bursts.
@@ -725,7 +727,8 @@ export class Exchange {
 	declare [kProbingEnded]: boolean;
 	declare [kWidths]: WidthProbes;
 
-	constructor(transport: TerminalTransport, termDOM: TermDOM) {
+	constructor(transport: TerminalTransport, window: Window) {
+		super();
 		const interactive = transport.interactive;
 		this[kWriter] = null;
 		this[kReader] = null;
@@ -747,7 +750,7 @@ export class Exchange {
 		this[kEngagedModes] = new Set<ModeName>();
 		// Anchor detection only makes sense when a shell's rows are above ours.
 		this[kAnchorDetectionEnabled] = transport.sharesScreen && interactive;
-		this[kTermDOM] = termDOM;
+		this[kWindow] = window;
 		this[kInput] = null;
 		this[kResizeTimer] = null;
 		this[kSettlingResize] = null;
@@ -900,7 +903,11 @@ export class Exchange {
 		this[kAnchorDetectionEnabled] =
 			transport.sharesScreen && transport.interactive;
 		this[kWidths] = createWidthProbes(transport.interactive);
-		terminalResized(this[kTermDOM], transport.cols, transport.rows);
+		this.dispatchEvent(
+			new CustomEvent<ResizeReport>("terminalresize", {
+				detail: {cols: transport.cols, rows: transport.rows, standing: null},
+			}),
+		);
 	}
 
 	start(input: Input): void {
@@ -919,7 +926,7 @@ export class Exchange {
 		void this[kTransport].closed.then(() => {
 			if (!this[kDisposed]) {
 				this[kTransportClosed] = true;
-				closeTermDOM(this[kTermDOM]);
+				this.dispatchEvent(new Event("terminalclose"));
 			}
 		});
 	}
@@ -958,7 +965,7 @@ export class Exchange {
 		}
 		this[kPriorBidiMode] = answer;
 		if (answer === 1 || answer === 3) {
-			terminalReorders(this[kTermDOM]);
+			this.dispatchEvent(new Event("reorder"));
 		}
 	}
 
@@ -1007,7 +1014,7 @@ export class Exchange {
 			timeoutMs: 1000,
 			sequence: this[kDSRSequence]++,
 			read: ({row}) => {
-				anchorDetected(this[kTermDOM], row);
+				this.dispatchEvent(new CustomEvent("anchor", {detail: {row}}));
 				this[kHasDetectedAnchor] = true;
 				return row;
 			},
@@ -1247,7 +1254,7 @@ function requestDeferredProbeFrame(session: Exchange): void {
 		if (session[kDisposed] || widths.deferred.size === 0) {
 			return;
 		}
-		probesDeferred(session[kTermDOM]);
+		session.dispatchEvent(new Event("probes"));
 	}, Exchange[kWidthDeferralWait]);
 }
 
@@ -1333,7 +1340,7 @@ function settleWidthProbe(
 	widths.settled.add(probe.cluster);
 	widths.drift += advance - probe.width;
 	if (recordClusterAdvance(probe.cluster, advance)) {
-		widthsCorrected(session[kTermDOM]);
+		session.dispatchEvent(new Event("widths"));
 	}
 }
 
@@ -1408,24 +1415,26 @@ function scheduleResize(session: Exchange): void {
 // new top. A terminal that does not reply gets the computed re-anchor,
 // exact for height changes.
 function handleResize(session: Exchange): void {
-	const termDOM = session[kTermDOM];
 	const {cols: newWidth, rows: newHeight} = session[kTransport];
-	terminalResized(termDOM, newWidth, newHeight);
-	const {contentHeight, wrappedRowsAbove, documentTop} = frameStanding(
-		termDOM,
-		newWidth,
-	);
+	// The terminalresize listener fills in standing.
+	const report: ResizeReport = {
+		cols: newWidth,
+		rows: newHeight,
+		standing: null,
+	};
+	session.dispatchEvent(new CustomEvent("terminalresize", {detail: report}));
+	const {contentHeight, wrappedRowsAbove, documentTop} = report.standing!;
 	const settling = session[kSettlingResize];
 
 	const redraw = (startRow: number) => {
-		frameReplaced(termDOM, startRow);
+		session.dispatchEvent(new CustomEvent("replace", {detail: {startRow}}));
 
 		// The frame is placed by the screen reset. Cursor detection is
 		// suspended until it is written.
 		session[kSettlingResize] = null;
 		const wasDetected = session[kHasDetectedAnchor];
 		session[kHasDetectedAnchor] = false;
-		termDOM.window.requestAnimationFrame(() => {
+		session[kWindow].requestAnimationFrame(() => {
 			session[kHasDetectedAnchor] = wasDetected;
 		});
 	};
@@ -1481,7 +1490,7 @@ function routeChunk(session: Exchange, chunk: string): void {
 				// decision.
 				if (item.ctrlKey && item.key === "c") {
 					flushKeys();
-					session[kTermDOM].window.close();
+					session[kWindow].close();
 					break;
 				}
 				keys.push(item);

--- a/src/internal/exchange.ts
+++ b/src/internal/exchange.ts
@@ -1423,7 +1423,10 @@ function handleResize(session: Exchange): void {
 		standing: null,
 	};
 	session.dispatchEvent(new CustomEvent("terminalresize", {detail: report}));
-	const {contentHeight, wrappedRowsAbove, documentTop} = report.standing!;
+	if (report.standing === null) {
+		return;
+	}
+	const {contentHeight, wrappedRowsAbove, documentTop} = report.standing;
 	const settling = session[kSettlingResize];
 
 	const redraw = (startRow: number) => {

--- a/src/internal/exchange.ts
+++ b/src/internal/exchange.ts
@@ -1025,8 +1025,11 @@ export class Exchange extends EventTarget {
 			ask: CURSOR_QUERY,
 			timeoutMs: 1000,
 			sequence: this[kDSRSequence]++,
+			// The 1-based row the command started on becomes the 0-based
+			// anchor.
 			read: ({row}) => {
-				anchorDetected(this, row);
+				this[kScreen].documentTop = row - 1;
+				this[kScreen].anchorScrollTop = 1 - row;
 				this[kHasDetectedAnchor] = true;
 				return row;
 			},
@@ -1292,7 +1295,9 @@ function requestDeferredProbeFrame(session: Exchange): void {
 		if (session[kDisposed] || widths.deferred.size === 0) {
 			return;
 		}
-		probesDeferred(session);
+		// Deferred probes go out with the next frame even if nothing changed.
+		session[kScreen].flushProbes();
+		requestRender(session[kWindow].document);
 	}, Exchange[kWidthDeferralWait]);
 }
 
@@ -1377,8 +1382,14 @@ function settleWidthProbe(
 
 	widths.settled.add(probe.cluster);
 	widths.drift += advance - probe.width;
+	// A cluster measured wider or narrower than the tables said, so every
+	// column after it on a painted row is off. The previous frame described
+	// a screen that was never drawn. Drop it and paint again from the
+	// corrected measurements.
 	if (recordClusterAdvance(probe.cluster, advance)) {
-		widthsCorrected(session);
+		session[kLayout].invalidateTextMeasurement();
+		session[kScreen].repaintAll();
+		requestRender(session[kWindow].document);
 	}
 }
 
@@ -1465,59 +1476,6 @@ function terminalResized(
 	syncMediaQueries(window.document);
 }
 
-/** Where the frame is after a resize, for the re-anchor. */
-function frameStanding(
-	session: Exchange,
-	cols: number,
-): {
-	contentHeight: number;
-	wrappedRowsAbove: number | null;
-	documentTop: number;
-} {
-	const layout = session[kLayout];
-	layout.performLayout();
-	return {
-		contentHeight: layout.documentPaintHeight(),
-		wrappedRowsAbove: session[kScreen].wrappedRowsAbovePark(cols),
-		documentTop: session[kScreen].documentTop,
-	};
-}
-
-/** The frame now starts at `startRow`. Repaint it from there. */
-function frameReplaced(session: Exchange, startRow: number): void {
-	const screen = session[kScreen];
-	screen.documentTop = startRow;
-	screen.anchorScrollTop = -startRow;
-	screen.replaced(startRow);
-	requestRender(session[kWindow].document);
-}
-
-/**
- * The 1-based terminal row the command started on becomes the 0-based anchor.
- */
-function anchorDetected(session: Exchange, row: number): void {
-	session[kScreen].documentTop = row - 1;
-	session[kScreen].anchorScrollTop = 1 - row;
-}
-
-/** Deferred width probes go out with the next frame even if nothing changed. */
-function probesDeferred(session: Exchange): void {
-	session[kScreen].flushProbes();
-	requestRender(session[kWindow].document);
-}
-
-/**
- * A cluster measured wider or narrower than the tables said, so every
- * column after it on a painted row is off. The previous frame described
- * a screen that was never drawn. Drop it and paint again from the
- * corrected measurements.
- */
-function widthsCorrected(session: Exchange): void {
-	session[kLayout].invalidateTextMeasurement();
-	session[kScreen].repaintAll();
-	requestRender(session[kWindow].document);
-}
-
 // The terminal has rewrapped the old frame with the text above it. The
 // cursor was parked on the frame's bottom row and stayed on its line
 // through the rewrap, and every painted row is a hard line, so the
@@ -1527,14 +1485,21 @@ function widthsCorrected(session: Exchange): void {
 function handleResize(session: Exchange): void {
 	const {cols: newWidth, rows: newHeight} = session[kTransport];
 	terminalResized(session, newWidth, newHeight);
-	const {contentHeight, wrappedRowsAbove, documentTop} = frameStanding(
-		session,
-		newWidth,
-	);
+	// Where the frame is after the resize, for the re-anchor.
+	const screen = session[kScreen];
+	const layout = session[kLayout];
+	layout.performLayout();
+	const contentHeight = layout.documentPaintHeight();
+	const wrappedRowsAbove = screen.wrappedRowsAbovePark(newWidth);
+	const documentTop = screen.documentTop;
 	const settling = session[kSettlingResize];
 
+	// The frame now starts at startRow. Repaint it from there.
 	const redraw = (startRow: number) => {
-		frameReplaced(session, startRow);
+		screen.documentTop = startRow;
+		screen.anchorScrollTop = -startRow;
+		screen.replaced(startRow);
+		requestRender(session[kWindow].document);
 
 		// The frame is placed by the screen reset. Cursor detection is
 		// suspended until it is written.

--- a/src/internal/input.ts
+++ b/src/internal/input.ts
@@ -14,6 +14,7 @@ import {
 	lightDismissRelease,
 	lockDataTransfer,
 	placeTextControlCaret,
+	requestRender,
 	setDocumentFocusVisible,
 	setHoveredElement,
 	setUASelection,
@@ -23,7 +24,6 @@ import {
 import type {WireKey, WireMouse, WirePaste} from "./exchange.ts";
 import type {Layout} from "./layout.ts";
 import type {Screen} from "./screen.ts";
-import {render, type TermDOM} from "./termdom.ts";
 
 // The keys a terminal names, with the legacy keyCode plenty of code
 // still reads. Also the list of names that are physical key identities.
@@ -226,7 +226,6 @@ function getSequentialFocusEntries(
 	return buildScope(roots, null);
 }
 
-const kTermDOM = Symbol("termDOM");
 const kLayout = Symbol("layout");
 const kCascade = Symbol("cascade");
 const kScreen = Symbol("screen");
@@ -298,7 +297,6 @@ export class Input {
 	static readonly [kDblclickIntervalMs] = 500;
 	declare [kDocument]: Document;
 	declare [kWindow]: Window;
-	declare [kTermDOM]: TermDOM;
 	declare [kLayout]: Layout;
 	declare [kCascade]: Cascade;
 	declare [kScreen]: Screen;
@@ -337,14 +335,13 @@ export class Input {
 	declare [kLastClickTime]: number;
 
 	constructor(
-		termDOM: TermDOM,
+		document: Document,
 		layout: Layout,
 		styles: Cascade,
 		screen: Screen,
 	) {
-		this[kDocument] = termDOM.document;
-		this[kWindow] = termDOM.document.defaultView as unknown as Window;
-		this[kTermDOM] = termDOM;
+		this[kDocument] = document;
+		this[kWindow] = document.defaultView as unknown as Window;
 		this[kLayout] = layout;
 		this[kCascade] = styles;
 		this[kScreen] = screen;
@@ -524,7 +521,7 @@ function deliverMouseReport(
 			quiet: base <= 2,
 		};
 		if (base > 2) {
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 			return;
 		}
 	}
@@ -553,7 +550,7 @@ function deliverMouseReport(
 			// scrollback, so the mouse is yielded to it. preventDefault on the
 			// wheel event opts out, as in a browser.
 			input[kMouseCaptureYielded] = true;
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 			if (input[kScrollChainTimer] !== null) {
 				clearTimeout(input[kScrollChainTimer]);
 			}
@@ -635,7 +632,7 @@ function deliverPaste(input: Input, text: string): void {
 			}),
 		);
 	}
-	void render(input[kTermDOM]);
+	requestRender(input[kDocument]);
 }
 
 // A keystroke also means the terminal has snapped back to the live
@@ -715,7 +712,6 @@ function scrollByWheel(
 		scroller.scrollTop += deltaY;
 		return false;
 	}
-	const termDOM = input[kTermDOM];
 	if (
 		deltaY < 0 &&
 		input[kScreen].scrollTop === 0 &&
@@ -724,7 +720,7 @@ function scrollByWheel(
 		return true;
 	}
 	input[kScreen].scrollTo(input[kScreen].scrollTop + deltaY);
-	void render(termDOM);
+	requestRender(input[kDocument]);
 	return false;
 }
 
@@ -734,7 +730,7 @@ function reclaimMouseCapture(input: Input): void {
 		input[kScrollChainTimer] = null;
 	}
 	input[kMouseCaptureYielded] = false;
-	void render(input[kTermDOM]);
+	requestRender(input[kDocument]);
 }
 
 function dragTo(
@@ -757,7 +753,7 @@ function dragTo(
 				Math.max(anchor, focus),
 				focus < anchor ? "backward" : "forward",
 			);
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 		}
 		return;
 	}
@@ -776,7 +772,7 @@ function dragTo(
 					focus.node,
 					focus.offset,
 				);
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 		}
 	}
 }
@@ -799,7 +795,7 @@ function dispatchPress(
 		input[kCascade].handleFocusChange(
 			input[kDocument].activeElement,
 		);
-		void render(input[kTermDOM]);
+		requestRender(input[kDocument]);
 	}
 	const notCanceled = dispatchAsUserAgent(
 		target,
@@ -813,10 +809,10 @@ function dispatchPress(
 	const active = input[kDocument].activeElement;
 	if (focusable && focusable !== active) {
 		(focusable as HTMLElement).focus();
-		void render(input[kTermDOM]);
+		requestRender(input[kDocument]);
 	} else if (!focusable && active && active !== input[kDocument].body) {
 		(active as HTMLElement).blur();
-		void render(input[kTermDOM]);
+		requestRender(input[kDocument]);
 	}
 
 	// Default action: a press in a text control places the caret and anchors a
@@ -834,7 +830,7 @@ function dispatchPress(
 		if (docSelection && !docSelection.isCollapsed) {
 			docSelection.removeAllRanges();
 		}
-		void render(input[kTermDOM]);
+		requestRender(input[kDocument]);
 	}
 
 	// Default action: collapse the document selection at the press and
@@ -858,7 +854,7 @@ function dispatchPress(
 			selection.removeAllRanges();
 		}
 		if (hadSelection) {
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 		}
 	}
 }
@@ -909,7 +905,7 @@ function dispatchRelease(
 				: null;
 		if (control) {
 			control.focus();
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 		}
 
 		// In addition to its own click. Reset so a third click starts a pair.
@@ -943,7 +939,7 @@ function dispatchKey(input: Input, stroke: WireKey): void {
 		input[kCascade].handleFocusChange(
 			input[kDocument].activeElement,
 		);
-		void render(input[kTermDOM]);
+		requestRender(input[kDocument]);
 	}
 
 	// A fullscreen element is usually not focusable, so keydown falls back
@@ -976,7 +972,7 @@ function dispatchKey(input: Input, stroke: WireKey): void {
 	// app.
 	if (keyName === "Escape") {
 		if (handleCloseRequest(input[kDocument])) {
-			void render(input[kTermDOM]);
+			requestRender(input[kDocument]);
 			return;
 		}
 	}
@@ -1003,7 +999,7 @@ function dispatchKey(input: Input, stroke: WireKey): void {
 						composed: true,
 					}),
 				);
-				void render(input[kTermDOM]);
+				requestRender(input[kDocument]);
 			}
 		}
 	}
@@ -1185,7 +1181,7 @@ function moveFocus(input: Input, reverse: boolean): void {
 	next.focus();
 	next.scrollIntoView({block: "nearest"});
 	// No mutation record describes a focus move.
-	void render(input[kTermDOM]);
+	requestRender(input[kDocument]);
 }
 
 // Null over a form control. Its value is not document text.

--- a/src/internal/painter.ts
+++ b/src/internal/painter.ts
@@ -245,6 +245,63 @@ export class Painter {
 		this[kTopLayer] = getTopLayer(document) as unknown as Set<Element>;
 	}
 
+	/**
+	 * The buffer rows a journalled element scroll covers, or null when the
+	 * terminal cannot shift them. DECSTBM margins are horizontal, so a scroll
+	 * shift is the region's full width or nothing. Content overlapping the
+	 * shift is dragged along and the diff repairs it.
+	 */
+	resolveScrollShift(
+		regionHeight: number,
+		record: {element: Element; delta: number} | null,
+	): {delta: number; top: number; end: number} | null {
+		const screen = this[kScreen];
+		const layout = this[kLayout];
+		if (
+			record === null ||
+			record.delta === 0 ||
+			// One scroll shift per frame. The document scroll's region already
+			// contains this box.
+			screen.journal.frameScroll !== 0 ||
+			// The rows the terminal would shift are not the rows the last
+			// frame painted.
+			layout.moved ||
+			!record.element.isConnected
+		) {
+			return null;
+		}
+		const rect = layout.getRect(record.element);
+		if (rect === null) {
+			return null;
+		}
+
+		// The scroll port is the padding box.
+		const box = getBoxModel(record.element);
+		const left = rect.left + (box.borderLeftWidth || 0);
+		const right = rect.left + rect.width - (box.borderRightWidth || 0);
+		if (left > 0 || right < screen.cols) {
+			return null;
+		}
+
+		// Layout rows are document rows. Buffer rows are the document
+		// scroll's. A fixed box is laid out in viewport rows and the paint
+		// cancels the document scroll for it.
+		const lift = layout.isInFixedSpace(record.element) ? 0 : screen.scrollTop;
+		const top = Math.max(
+			0,
+			Math.round(rect.top + (box.borderTopWidth || 0)) - lift,
+		);
+		const end = Math.min(
+			regionHeight,
+			Math.round(rect.top + rect.height - (box.borderBottomWidth || 0)) -
+			lift,
+		);
+		if (end - top <= Math.abs(record.delta)) {
+			return null;
+		}
+		return {delta: record.delta, top, end};
+	}
+
 	paint(ctx: CellContext): void {
 		this[kRenderedOutsideMarkers] = new WeakSet<Element>();
 		this[kScrolledRows] = 0;

--- a/src/internal/screen.ts
+++ b/src/internal/screen.ts
@@ -1754,10 +1754,9 @@ export class Screen {
 		rows: number,
 		cols: number,
 		colorDepth: ColorDepth = "rgb",
-		measurer: Exchange | null = null,
 	) {
 		this[kFlushProbes] = false;
-		this[kMeasurer] = measurer;
+		this[kMeasurer] = null;
 		this[kPrev] = null;
 		this[kSpare] = null;
 		this[kDiff] = null;
@@ -1778,6 +1777,11 @@ export class Screen {
 		this[kFrameScroll] = 0;
 		this[kDirty] = true;
 		this[kWriter] = new FrameWriter(colorDepth);
+	}
+
+	/** Width probes go out over the exchange, once there is one. */
+	set measurer(exchange: Exchange) {
+		this[kMeasurer] = exchange;
 	}
 
 	get rows(): number {

--- a/src/internal/screen.ts
+++ b/src/internal/screen.ts
@@ -891,7 +891,13 @@ function getGridLine(grid: CellGrid, row: number, writer: FrameWriter): string {
 	let previous = -1;
 	for (let col = 0; col <= lastCol; col++) {
 		const index = rowStart + col;
+		// An empty cell has no style. Written under the previous cell's
+		// background, a gap between two boxes would take the left one's color.
 		if (grid.cluster[index] === 0) {
+			if (previous !== -1) {
+				writer.resetStyle();
+				previous = -1;
+			}
 			writer.text(" ");
 			continue;
 		}

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -214,25 +214,55 @@ export class TermDOM {
 			}
 			closeTermDOM(this);
 		});
-		exchange.addEventListener("seal", () => sealTermDOM(this));
-
-		exchange.addEventListener("terminalresize", (event) => {
-			const report = (event as CustomEvent<ResizeReport>).detail;
-			terminalResized(this, report.cols, report.rows);
-			report.standing = frameStanding(this, report.cols);
-		});
-		exchange.addEventListener("replace", (event) => {
-			const {startRow} = (event as CustomEvent<{startRow: number}>).detail;
-			frameReplaced(this, startRow);
-		});
-		exchange.addEventListener("anchor", (event) => {
-			const {row} = (event as CustomEvent<{row: number}>).detail;
-			anchorDetected(this, row);
-		});
-		exchange.addEventListener("reorder", () => terminalReorders(this));
-		exchange.addEventListener("probes", () => probesDeferred(this));
-		exchange.addEventListener("widths", () => widthsCorrected(this));
-		exchange.addEventListener("terminalclose", () => closeTermDOM(this));
+		// Terminal events come from the exchange itself. A page can dispatch
+		// an event of the same name on the document, and it must not reach
+		// these.
+		const fromTerminal =
+			(handle: (event: Event) => void) =>
+				(event: Event): void => {
+					if (event.target === exchange) {
+						handle(event);
+					}
+				};
+		exchange.addEventListener("seal", fromTerminal(() => sealTermDOM(this)));
+		exchange.addEventListener(
+			"terminalresize",
+			fromTerminal((event) => {
+				const report = (event as CustomEvent<ResizeReport>).detail;
+				terminalResized(this, report.cols, report.rows);
+				report.standing = frameStanding(this, report.cols);
+			}),
+		);
+		exchange.addEventListener(
+			"replace",
+			fromTerminal((event) => {
+				const {startRow} = (event as CustomEvent<{startRow: number}>).detail;
+				frameReplaced(this, startRow);
+			}),
+		);
+		exchange.addEventListener(
+			"anchor",
+			fromTerminal((event) => {
+				const {row} = (event as CustomEvent<{row: number}>).detail;
+				anchorDetected(this, row);
+			}),
+		);
+		exchange.addEventListener(
+			"reorder",
+			fromTerminal(() => terminalReorders(this)),
+		);
+		exchange.addEventListener(
+			"probes",
+			fromTerminal(() => probesDeferred(this)),
+		);
+		exchange.addEventListener(
+			"widths",
+			fromTerminal(() => widthsCorrected(this)),
+		);
+		exchange.addEventListener(
+			"terminalclose",
+			fromTerminal(() => closeTermDOM(this)),
+		);
 	}
 
 	/**

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -8,6 +8,7 @@ import {
 } from "./dom.ts";
 import {
 	Exchange,
+	type ResizeReport,
 	type TerminalCloseInfo,
 	type TerminalSize,
 	type TerminalTransport,
@@ -129,7 +130,8 @@ export class TermDOM {
 		this[kCascade] = new Cascade(this.window, this[kLayout]);
 
 		// The screen measures widths over the exchange's probe channel.
-		this[kExchange] = new Exchange(this[kTransport], this);
+		this[kExchange] = new Exchange(this[kTransport], this.window);
+		const exchange = this[kExchange];
 		this[kScreen] = new Screen(
 			this[kTransport].rows,
 			this[kTransport].cols,
@@ -139,15 +141,15 @@ export class TermDOM {
 
 		DOM.attachDocument(
 			document,
-			this,
 			this[kLayout],
 			this[kCascade],
 			this[kExchange],
 			this[kScreen],
+			() => render(this),
 		);
 
 		this[kInput] = new Input(
-			this,
+			this.document,
 			this[kLayout],
 			this[kCascade],
 			this[kScreen],
@@ -164,7 +166,7 @@ export class TermDOM {
 		const onTextControlEditEvent = (event: Event): void => {
 			const target = event.target;
 			if (
-				target !== this.document.activeElement ||
+				target !== getFocusedElement(this) ||
 				!(
 					target instanceof DOM.HTMLInputElement ||
 					target instanceof DOM.HTMLTextAreaElement ||
@@ -180,15 +182,10 @@ export class TermDOM {
 			void render(this);
 		};
 
-		// Capture, so the event is seen however it bubbles.
-		this.document.addEventListener("input", onTextControlEditEvent, true);
-		this.document.addEventListener("select", onTextControlEditEvent, true);
-		this.document.addEventListener("change", onTextControlEditEvent, true);
-		this.document.addEventListener(
-			"selectionchange",
-			onTextControlEditEvent,
-			true,
-		);
+		exchange.addEventListener("input", onTextControlEditEvent);
+		exchange.addEventListener("select", onTextControlEditEvent);
+		exchange.addEventListener("change", onTextControlEditEvent);
+		exchange.addEventListener("selectionchange", onTextControlEditEvent);
 
 		// A details that closes took content away. Only opening reveals.
 		const onDisclosureToggle = (event: Event): void => {
@@ -204,7 +201,38 @@ export class TermDOM {
 
 		// A terminal page is one screen tall, and what a details opened is
 		// often below the fold.
-		this.document.addEventListener("toggle", onDisclosureToggle, true);
+		exchange.addEventListener("toggle", onDisclosureToggle);
+
+		// A canceled or untrusted beforeunload does not close.
+		exchange.addEventListener("beforeunload", (event) => {
+			if (
+				!event.isTrusted ||
+				event.defaultPrevented ||
+				(event as BeforeUnloadEvent).returnValue !== ""
+			) {
+				return;
+			}
+			closeTermDOM(this);
+		});
+		exchange.addEventListener("seal", () => sealTermDOM(this));
+
+		exchange.addEventListener("terminalresize", (event) => {
+			const report = (event as CustomEvent<ResizeReport>).detail;
+			terminalResized(this, report.cols, report.rows);
+			report.standing = frameStanding(this, report.cols);
+		});
+		exchange.addEventListener("replace", (event) => {
+			const {startRow} = (event as CustomEvent<{startRow: number}>).detail;
+			frameReplaced(this, startRow);
+		});
+		exchange.addEventListener("anchor", (event) => {
+			const {row} = (event as CustomEvent<{row: number}>).detail;
+			anchorDetected(this, row);
+		});
+		exchange.addEventListener("reorder", () => terminalReorders(this));
+		exchange.addEventListener("probes", () => probesDeferred(this));
+		exchange.addEventListener("widths", () => widthsCorrected(this));
+		exchange.addEventListener("terminalclose", () => closeTermDOM(this));
 	}
 
 	/**
@@ -233,6 +261,7 @@ export class TermDOM {
 		// Resolves when the first frame has been written. The negotiations'
 		// silence timeouts must not delay that.
 		this[kLifecycle] = "attaching";
+		DOM.setDocumentVisible(this.document, true);
 		let begun!: () => void;
 		this[kAttachBegun] = new Promise<void>((resolve) => {
 			begun = resolve;
@@ -312,6 +341,7 @@ export class TermDOM {
 
 		const wasAttached = isAttached(this);
 		this[kLifecycle] = "disposed";
+		DOM.setDocumentVisible(this.document, false);
 
 		// Frames painted in place, so nothing reached the scrollback. Write the
 		// document out now. Skip this if no frame was ever painted, because the
@@ -353,11 +383,20 @@ function isFullscreen(termDOM: TermDOM): boolean {
 	return termDOM.document.fullscreenElement !== null;
 }
 
-// What the document asks of its session, from dom.ts and input.ts: whether
-// there is a live one, the end of the document, the end of the session, and
-// a frame. render() is below, with the frame loop it drives.
+// activeElement retargets to the shadow host; this follows it down.
+function getFocusedElement(termDOM: TermDOM): Element | null {
+	let active = termDOM.document.activeElement;
+	for (
+		let inner = active && DOM.getShadowRoot(active)?.activeElement;
+		inner;
+		inner = DOM.getShadowRoot(inner)?.activeElement
+	) {
+		active = inner;
+	}
+	return active;
+}
 
-export function isAttached(termDOM: TermDOM): boolean {
+function isAttached(termDOM: TermDOM): boolean {
 	const lifecycle = termDOM[kLifecycle];
 	return lifecycle === "attaching" || lifecycle === "attached";
 }
@@ -366,7 +405,7 @@ export function isAttached(termDOM: TermDOM): boolean {
  * document.close(): flush the document into the scrollback and seal it.
  * The next mutation starts a fresh one below it.
  */
-export function sealTermDOM(termDOM: TermDOM): void {
+function sealTermDOM(termDOM: TermDOM): void {
 	if (isAttached(termDOM) && termDOM[kRenderCount] > 0) {
 		flushDocument(termDOM);
 		termDOM[kSealed] = true;
@@ -377,7 +416,7 @@ export function sealTermDOM(termDOM: TermDOM): void {
  * End the session. Called when the window closed and beforeunload
  * allowed it, or when the terminal went away.
  */
-export function closeTermDOM(termDOM: TermDOM): void {
+function closeTermDOM(termDOM: TermDOM): void {
 	// A terminal that went away has nothing to drain or close.
 	const live = isAttached(termDOM) && !termDOM[kExchange].transportClosed;
 	// Wait for attach to finish so the final output lands where the frame
@@ -398,12 +437,7 @@ export function closeTermDOM(termDOM: TermDOM): void {
 	})();
 }
 
-// What the terminal reports, from exchange.ts: its size, where the command
-// started, where the frame stands and lands around a resize, how it orders
-// text, what its glyphs measure, and, through closeTermDOM above, that it
-// went away. Nothing else calls these.
-
-export function terminalResized(
+function terminalResized(
 	termDOM: TermDOM,
 	width: number,
 	height: number,
@@ -423,7 +457,7 @@ export function terminalResized(
 }
 
 /** Record where the frame is after a resize, for the re-anchor. */
-export function frameStanding(
+function frameStanding(
 	termDOM: TermDOM,
 	cols: number,
 ): {
@@ -441,7 +475,7 @@ export function frameStanding(
 }
 
 /** The frame now starts at `startRow`. Repaint it from there. */
-export function frameReplaced(termDOM: TermDOM, startRow: number): void {
+function frameReplaced(termDOM: TermDOM, startRow: number): void {
 	const screen = termDOM[kScreen];
 	screen.documentTop = startRow;
 	screen.anchorScrollTop = -startRow;
@@ -452,17 +486,17 @@ export function frameReplaced(termDOM: TermDOM, startRow: number): void {
 /**
  * The 1-based terminal row the command started on becomes the 0-based anchor.
  */
-export function anchorDetected(termDOM: TermDOM, row: number): void {
+function anchorDetected(termDOM: TermDOM, row: number): void {
 	termDOM[kScreen].documentTop = row - 1;
 	termDOM[kScreen].anchorScrollTop = 1 - row;
 }
 
-export function terminalReorders(termDOM: TermDOM): void {
+function terminalReorders(termDOM: TermDOM): void {
 	termDOM[kLayout].adoptTerminalReordering();
 }
 
 /** Deferred width probes go out with the next frame even if nothing changed. */
-export function probesDeferred(termDOM: TermDOM): void {
+function probesDeferred(termDOM: TermDOM): void {
 	termDOM[kScreen].flushProbes();
 	void render(termDOM);
 }
@@ -473,7 +507,7 @@ export function probesDeferred(termDOM: TermDOM): void {
  * a screen that was never drawn. Drop it and paint again from the
  * corrected measurements.
  */
-export function widthsCorrected(termDOM: TermDOM): void {
+function widthsCorrected(termDOM: TermDOM): void {
 	termDOM[kLayout].invalidateTextMeasurement();
 	termDOM[kScreen].repaintAll();
 	void render(termDOM);
@@ -931,7 +965,7 @@ async function renderInteractive(
 	if (termDOM[kPendingCaretReveal]) {
 		const reveal = termDOM[kPendingCaretReveal];
 		termDOM[kPendingCaretReveal] = null;
-		if (reveal === termDOM.document.activeElement) {
+		if (reveal === getFocusedElement(termDOM)) {
 			scrollCaretIntoView(termDOM, reveal);
 		}
 	}

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -329,7 +329,6 @@ function isFullscreen(termDOM: TermDOM): boolean {
 	return termDOM.document.fullscreenElement !== null;
 }
 
-// activeElement retargets to the shadow host; this follows it down.
 function isAttached(termDOM: TermDOM): boolean {
 	const lifecycle = termDOM[kLifecycle];
 	return lifecycle === "attaching" || lifecycle === "attached";

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -8,7 +8,6 @@ import {
 } from "./dom.ts";
 import {
 	Exchange,
-	type ResizeReport,
 	type TerminalCloseInfo,
 	type TerminalSize,
 	type TerminalTransport,
@@ -129,15 +128,21 @@ export class TermDOM {
 		);
 		this[kCascade] = new Cascade(this.window, this[kLayout]);
 
-		// The screen measures widths over the exchange's probe channel.
-		this[kExchange] = new Exchange(this[kTransport], this.window);
-		const exchange = this[kExchange];
 		this[kScreen] = new Screen(
 			this[kTransport].rows,
 			this[kTransport].cols,
 			this[kTransport].colorDepth,
-			this[kExchange],
 		);
+		this[kExchange] = new Exchange(
+			this[kTransport],
+			this.window,
+			this[kLayout],
+			this[kCascade],
+			this[kScreen],
+		);
+		const exchange = this[kExchange];
+		// The screen measures widths over the exchange's probe channel.
+		this[kScreen].measurer = exchange;
 
 		DOM.attachDocument(
 			document,
@@ -214,55 +219,18 @@ export class TermDOM {
 			}
 			closeTermDOM(this);
 		});
-		// Terminal events come from the exchange itself. A page can dispatch
-		// an event of the same name on the document, and it must not reach
-		// these.
-		const fromTerminal =
-			(handle: (event: Event) => void) =>
-				(event: Event): void => {
-					if (event.target === exchange) {
-						handle(event);
-					}
-				};
-		exchange.addEventListener("seal", fromTerminal(() => sealTermDOM(this)));
-		exchange.addEventListener(
-			"terminalresize",
-			fromTerminal((event) => {
-				const report = (event as CustomEvent<ResizeReport>).detail;
-				terminalResized(this, report.cols, report.rows);
-				report.standing = frameStanding(this, report.cols);
-			}),
-		);
-		exchange.addEventListener(
-			"replace",
-			fromTerminal((event) => {
-				const {startRow} = (event as CustomEvent<{startRow: number}>).detail;
-				frameReplaced(this, startRow);
-			}),
-		);
-		exchange.addEventListener(
-			"anchor",
-			fromTerminal((event) => {
-				const {row} = (event as CustomEvent<{row: number}>).detail;
-				anchorDetected(this, row);
-			}),
-		);
-		exchange.addEventListener(
-			"reorder",
-			fromTerminal(() => terminalReorders(this)),
-		);
-		exchange.addEventListener(
-			"probes",
-			fromTerminal(() => probesDeferred(this)),
-		);
-		exchange.addEventListener(
-			"widths",
-			fromTerminal(() => widthsCorrected(this)),
-		);
-		exchange.addEventListener(
-			"terminalclose",
-			fromTerminal(() => closeTermDOM(this)),
-		);
+		// A page can dispatch an event of the same name on the document.
+		// Only the exchange's own reach these.
+		exchange.addEventListener("seal", (event) => {
+			if (event.target === exchange) {
+				sealTermDOM(this);
+			}
+		});
+		exchange.addEventListener("terminalclose", (event) => {
+			if (event.target === exchange) {
+				closeTermDOM(this);
+			}
+		});
 	}
 
 	/**
@@ -465,82 +433,6 @@ function closeTermDOM(termDOM: TermDOM): void {
 			termDOM[kTransport].close({status: 0});
 		}
 	})();
-}
-
-function terminalResized(
-	termDOM: TermDOM,
-	width: number,
-	height: number,
-): void {
-	const screen = termDOM[kScreen];
-	// A SIGWINCH with an unchanged size still redraws but fires no event.
-	const sizeChanged = width !== screen.cols || height !== screen.rows;
-	screen.resize(height, width);
-	termDOM[kLayout].resize(width, height);
-	// A size change can flip any @media result and every vw/vh value.
-	termDOM[kCascade].syncStylesheets();
-	if (sizeChanged) {
-		const window = termDOM.window;
-		DOM.dispatchAsUserAgent(window, new window.Event("resize"));
-	}
-	DOM.syncMediaQueries(termDOM.document);
-}
-
-/** Record where the frame is after a resize, for the re-anchor. */
-function frameStanding(
-	termDOM: TermDOM,
-	cols: number,
-): {
-	contentHeight: number;
-	wrappedRowsAbove: number | null;
-	documentTop: number;
-} {
-	const layout = termDOM[kLayout];
-	layout.performLayout();
-	return {
-		contentHeight: layout.documentPaintHeight(),
-		wrappedRowsAbove: termDOM[kScreen].wrappedRowsAbovePark(cols),
-		documentTop: termDOM[kScreen].documentTop,
-	};
-}
-
-/** The frame now starts at `startRow`. Repaint it from there. */
-function frameReplaced(termDOM: TermDOM, startRow: number): void {
-	const screen = termDOM[kScreen];
-	screen.documentTop = startRow;
-	screen.anchorScrollTop = -startRow;
-	screen.replaced(startRow);
-	void render(termDOM);
-}
-
-/**
- * The 1-based terminal row the command started on becomes the 0-based anchor.
- */
-function anchorDetected(termDOM: TermDOM, row: number): void {
-	termDOM[kScreen].documentTop = row - 1;
-	termDOM[kScreen].anchorScrollTop = 1 - row;
-}
-
-function terminalReorders(termDOM: TermDOM): void {
-	termDOM[kLayout].adoptTerminalReordering();
-}
-
-/** Deferred width probes go out with the next frame even if nothing changed. */
-function probesDeferred(termDOM: TermDOM): void {
-	termDOM[kScreen].flushProbes();
-	void render(termDOM);
-}
-
-/**
- * A cluster measured wider or narrower than the tables said, so every
- * column after it on a painted row is off. The previous frame described
- * a screen that was never drawn. Drop it and paint again from the
- * corrected measurements.
- */
-function widthsCorrected(termDOM: TermDOM): void {
-	termDOM[kLayout].invalidateTextMeasurement();
-	termDOM[kScreen].repaintAll();
-	void render(termDOM);
 }
 
 /**

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -1,4 +1,4 @@
-import {Cascade, getBoxModel} from "./cssom.ts";
+import {Cascade} from "./cssom.ts";
 import * as DOM from "./dom.ts";
 import {
 	createDocumentWindow,
@@ -43,7 +43,6 @@ const kInput = Symbol("input");
 const kAttachReady = Symbol("attachReady");
 const kMouseReportingEnabled = Symbol("mouseReportingEnabled");
 const kHoverReportingEnabled = Symbol("hoverReportingEnabled");
-const kPendingCaretReveal = Symbol("pendingCaretReveal");
 const kTransport = Symbol("transport");
 const kExchange = Symbol("exchange");
 const kStaticSibling = Symbol("staticSibling");
@@ -77,13 +76,6 @@ export class TermDOM {
 	declare [kLifecycle]: Lifecycle;
 	declare [kMouseReportingEnabled]: boolean;
 	declare [kHoverReportingEnabled]: boolean;
-	// The text control whose caret the next frame reveals. The last edit before
-	// the frame wins.
-	declare [kPendingCaretReveal]: HTMLInputElement |
-		HTMLTextAreaElement |
-		HTMLSelectElement |
-		null;
-
 	declare [kTransport]: TerminalTransport;
 	declare [kExchange]: Exchange;
 	// Resolves once the session is established and the first frame written.
@@ -94,7 +86,6 @@ export class TermDOM {
 	declare [kAttachBegun]: Promise<void>;
 	// The engine behind renderANSI and print, rebuilt when the width changes.
 	declare [kStaticSibling]: TermDOM | null;
-
 	constructor(options: TermDOMOptions = {}) {
 		this[kSealed] = false;
 
@@ -106,7 +97,6 @@ export class TermDOM {
 
 		this[kMouseReportingEnabled] = false;
 		this[kHoverReportingEnabled] = false;
-		this[kPendingCaretReveal] = null;
 
 		this[kAttachReady] = Promise.resolve();
 		this[kAttachBegun] = Promise.resolve();
@@ -165,48 +155,6 @@ export class TermDOM {
 			this[kCascade],
 			this[kScreen],
 		);
-
-		// Only the active text control. A select commit or an author's dispatch
-		// on an unfocused control must not move the document scroll.
-		const onTextControlEditEvent = (event: Event): void => {
-			const target = event.target;
-			if (
-				target !== getFocusedElement(this) ||
-				!(
-					target instanceof DOM.HTMLInputElement ||
-					target instanceof DOM.HTMLTextAreaElement ||
-					target instanceof DOM.HTMLSelectElement
-				)
-			) {
-				return;
-			}
-			queueCaretReveal(
-				this,
-				target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
-			);
-			void render(this);
-		};
-
-		exchange.addEventListener("input", onTextControlEditEvent);
-		exchange.addEventListener("select", onTextControlEditEvent);
-		exchange.addEventListener("change", onTextControlEditEvent);
-		exchange.addEventListener("selectionchange", onTextControlEditEvent);
-
-		// A details that closes took content away. Only opening reveals.
-		const onDisclosureToggle = (event: Event): void => {
-			const details = event.target as HTMLElement | null;
-			if (details === null || !("open" in details)) {
-				return;
-			}
-			if (!(details as HTMLDetailsElement).open) {
-				return;
-			}
-			details.scrollIntoView({block: "nearest"});
-		};
-
-		// A terminal page is one screen tall, and what a details opened is
-		// often below the fold.
-		exchange.addEventListener("toggle", onDisclosureToggle);
 
 		// A canceled or untrusted beforeunload does not close.
 		exchange.addEventListener("beforeunload", (event) => {
@@ -382,18 +330,6 @@ function isFullscreen(termDOM: TermDOM): boolean {
 }
 
 // activeElement retargets to the shadow host; this follows it down.
-function getFocusedElement(termDOM: TermDOM): Element | null {
-	let active = termDOM.document.activeElement;
-	for (
-		let inner = active && DOM.getShadowRoot(active)?.activeElement;
-		inner;
-		inner = DOM.getShadowRoot(inner)?.activeElement
-	) {
-		active = inner;
-	}
-	return active;
-}
-
 function isAttached(termDOM: TermDOM): boolean {
 	const lifecycle = termDOM[kLifecycle];
 	return lifecycle === "attaching" || lifecycle === "attached";
@@ -567,175 +503,6 @@ async function renderOnce(
 	await renderInteractive(termDOM);
 }
 
-function getDocumentFlowHeight(
-	termDOM: TermDOM,
-): number {
-	const rect =
-		termDOM[kLayout].getRect(termDOM.document.documentElement);
-	return rect ? Math.ceil(rect.height) : 0;
-}
-
-/**
- * The rows the document scroll shows. Fullscreen owns the screen from row zero,
- * and its element has left the flow, which then measures next to
- * nothing.
- */
-function getScrollingRegionHeight(
-	termDOM: TermDOM,
-): number {
-	return isFullscreen(termDOM)
-		? termDOM[kScreen].rows
-		: Math.min(
-			termDOM[kScreen].rows,
-			getDocumentFlowHeight(termDOM),
-		);
-}
-
-/**
- * The reveal happens on the frame the edit scheduled, so there is one
- * document scroll decision per frame instead of a synchronous layout flush per
- * keystroke.
- */
-function queueCaretReveal(
-	termDOM: TermDOM,
-	element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
-): void {
-	termDOM[kPendingCaretReveal] = element;
-	// A document scroll move and a caret move. No mutation record describes
-	// either.
-	termDOM[kScreen].invalidate();
-}
-
-/**
- * The caret as the painter derives it: the selection focus, measured
- * through the rendered text. Null when there is no record, text or box.
- */
-function getCaretRect(
-	termDOM: TermDOM,
-	element: Element,
-): {x: number; y: number} | null {
-	const focus = DOM.getSelectionFocus(element);
-	if (focus === null) {
-		return null;
-	}
-	const node = DOM.getTextControlValueText(element);
-	if (node === null) {
-		return null;
-	}
-	const range = element.ownerDocument.createRange();
-	range.setStart(node, Math.min(focus, node.data.length));
-	range.collapse(true);
-	const rects = termDOM[kLayout].getRangeRects(range);
-	if (rects.length === 0) {
-		return null;
-	}
-	return {x: Math.round(rects[0].x), y: Math.round(rects[0].y)};
-}
-
-/**
- * Keeps the caret inside the document scroll on edits only. Wheel-scrolling away
- * from a focused text control stays allowed.
- */
-function scrollCaretIntoView(
-	termDOM: TermDOM,
-	element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
-): void {
-	DOM.flushLayout(termDOM.document);
-	const rect = termDOM[kLayout].getRect(element);
-	if (!rect) {
-		return;
-	}
-	let caretY = Math.round(rect.top);
-	const caret = getCaretRect(termDOM, element);
-	if (caret !== null) {
-		caretY = caret.y;
-	}
-	// Widened to the text control's edge when the caret is on its first or last
-	// row, so the border shows instead of a cropped box.
-	const boxModel = getBoxModel(element);
-	let revealTop = caretY;
-	let revealBottom = caretY + 1;
-	if (caretY <= Math.round(rect.top) + (boxModel.borderTopWidth || 0)) {
-		revealTop = Math.round(rect.top);
-	}
-	if (
-		caretY >=
-		Math.round(rect.bottom) - (boxModel.borderBottomWidth || 0) - 1
-	) {
-		revealBottom = Math.round(rect.bottom);
-	}
-	const regionHeight = getScrollingRegionHeight(termDOM);
-	const top = termDOM[kScreen].scrollTop;
-	const delta =
-		revealTop < top
-			? revealTop - top
-			: revealBottom > top + regionHeight
-				? revealBottom - (top + regionHeight)
-				: 0;
-	if (delta) {
-		scrollDocument(termDOM, delta);
-	}
-}
-
-/**
- * The buffer rows the journalled element scroll covers, or null when the
- * terminal cannot shift them. DECSTBM margins are horizontal, so a scroll shift
- * is the region's full width or nothing. Content overlapping the shift is
- * dragged along and the diff repairs it.
- */
-function resolveScrollShift(
-	termDOM: TermDOM,
-	regionHeight: number,
-	record: {element: Element; delta: number} | null,
-): {delta: number; top: number; end: number} | null {
-	const journal = termDOM[kScreen].journal;
-	if (
-		record === null ||
-		record.delta === 0 ||
-		// One scroll shift per frame. The document scroll's region already
-		// contains this box.
-		journal.frameScroll !== 0 ||
-		// The rows the terminal would shift are not the rows the last frame
-		// painted.
-		termDOM[kLayout].moved ||
-		!record.element.isConnected
-	) {
-		return null;
-	}
-	const engine = termDOM[kLayout];
-	const rect = engine.getRect(record.element);
-	if (rect === null) {
-		return null;
-	}
-
-	// The scroll port is the padding box.
-	const box = getBoxModel(record.element);
-	const left = rect.left + (box.borderLeftWidth || 0);
-	const right = rect.left + rect.width - (box.borderRightWidth || 0);
-	if (left > 0 || right < termDOM[kScreen].cols) {
-		return null;
-	}
-
-	// Layout rows are document rows. Buffer rows are the document scroll's. A
-	// fixed box is laid out in viewport rows and the paint cancels the document
-	// scroll for it.
-	const lift = engine.isInFixedSpace(record.element)
-		? 0
-		: termDOM[kScreen].scrollTop;
-	const top = Math.max(
-		0,
-		Math.round(rect.top + (box.borderTopWidth || 0)) - lift,
-	);
-	const end = Math.min(
-		regionHeight,
-		Math.round(rect.top + rect.height - (box.borderBottomWidth || 0)) - lift,
-	);
-	if (end - top <= Math.abs(record.delta)) {
-		return null;
-	}
-	return {delta: record.delta, top, end};
-}
-
 /**
  * Run the observers against the layout just produced. A callback that
  * mutates schedules the next frame through the mutation observer.
@@ -882,15 +649,7 @@ async function renderInteractive(
 	termDOM[kLayout].performLayout();
 	DOM.clampScrollOffsets(termDOM.document);
 
-	// Skipped if focus has moved on. Revealing a text control the user left
-	// would yank the document scroll back.
-	if (termDOM[kPendingCaretReveal]) {
-		const reveal = termDOM[kPendingCaretReveal];
-		termDOM[kPendingCaretReveal] = null;
-		if (reveal === getFocusedElement(termDOM)) {
-			scrollCaretIntoView(termDOM, reveal);
-		}
-	}
+	DOM.revealPendingCaret(termDOM.document);
 
 	// Nothing this frame could paint differs from the screen, so skip the
 	// paint.
@@ -924,7 +683,7 @@ async function renderInteractive(
 		termDOM[kScreen].rows,
 	);
 
-	const top = fullscreen ? 0 : reserveRows(termDOM, regionHeight);
+	const top = fullscreen ? 0 : termDOM[kExchange].reserveRows(regionHeight);
 
 	if (!fullscreen) {
 		// Through scrollTo, so the journal's delta is what the screen is about
@@ -935,7 +694,7 @@ async function renderInteractive(
 
 	// The document scroll has nothing to move in fullscreen. A scroll box
 	// inside it still does, under DECSTBM margins.
-	const shift = resolveScrollShift(termDOM, regionHeight, journalled);
+	const shift = termDOM[kPainter].resolveScrollShift(regionHeight, journalled);
 	// Read after the clamp, which adds to the journal.
 	const clamped = termDOM[kScreen].journal;
 	const context = termDOM[kScreen].beginFrame({
@@ -962,55 +721,6 @@ async function renderInteractive(
 		!termDOM[kScreen].caretVisible,
 	);
 	afterRender(termDOM);
-}
-
-/**
- * How many rows the screen must scroll for `rows` to fit below the
- * anchor. The start moves up by that much.
- */
-function pushRowsUp(
-	termDOM: TermDOM,
-	rows: number,
-): number {
-	const overflow = termDOM[kScreen].documentTop +
-		rows -
-		termDOM[kScreen].rows;
-	if (overflow <= 0) {
-		return 0;
-	}
-	const push = Math.min(overflow, termDOM[kScreen].documentTop);
-	termDOM[kScreen].documentTop -= push;
-	return push;
-}
-
-function scrollDocument(
-	termDOM: TermDOM,
-	rows: number,
-): void {
-	termDOM[kScreen].scrollTo(termDOM[kScreen].scrollTop + rows);
-	// No mutation record describes a document scroll move.
-	void render(termDOM);
-}
-
-/**
- * Room below the anchor comes from scrolling earlier output into
- * the scrollback, never from painting over it. The scroll is IND (ESC D)
- * from the bottom row. A bare LF after an absolute CUP does not scroll
- * (tmux and xterm-headless both), and CSI n S scrolls without adding the
- * rows to xterm-headless's scrollback, which would make this untestable.
- * Returns the screen row the region starts at.
- */
-function reserveRows(termDOM: TermDOM, rows: number): number {
-	const push = pushRowsUp(termDOM, rows);
-	if (push > 0) {
-		void termDOM[kExchange].scrollUp(termDOM[kScreen].rows, push);
-		// The previous buffer is not shifted. Its rows are region-relative and
-		// the region top moved by exactly the scroll. A pending post-resize
-		// reset is screen-absolute and does shift.
-		termDOM[kScreen].scrolled(push);
-	}
-
-	return termDOM[kScreen].documentTop;
 }
 
 function staticRenderer(

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -169,9 +169,17 @@ export class TermDOM {
 		});
 		// A page can dispatch an event of the same name on the document.
 		// Only the exchange's own reach these.
+
+		// document.close(): flush the document into the scrollback and seal
+		// it. The next mutation starts a fresh one below it.
 		exchange.addEventListener("seal", (event) => {
-			if (event.target === exchange) {
-				sealTermDOM(this);
+			if (
+				event.target === exchange &&
+				isAttached(this) &&
+				this[kRenderCount] > 0
+			) {
+				flushDocument(this);
+				this[kSealed] = true;
 			}
 		});
 		exchange.addEventListener("terminalclose", (event) => {
@@ -201,8 +209,12 @@ export class TermDOM {
 			}
 			return this[kAttachReady];
 		}
+		// Re-derive everything that comes from the transport. Only before the
+		// first frame.
 		if (rebinding) {
-			rebindTransport(this, transport);
+			this[kTransport] = transport;
+			this[kScreen].rebind(transport.colorDepth);
+			this[kExchange].rebind(transport);
 		}
 		// Resolves when the first frame has been written. The negotiations'
 		// silence timeouts must not delay that.
@@ -335,17 +347,6 @@ function isAttached(termDOM: TermDOM): boolean {
 }
 
 /**
- * document.close(): flush the document into the scrollback and seal it.
- * The next mutation starts a fresh one below it.
- */
-function sealTermDOM(termDOM: TermDOM): void {
-	if (isAttached(termDOM) && termDOM[kRenderCount] > 0) {
-		flushDocument(termDOM);
-		termDOM[kSealed] = true;
-	}
-}
-
-/**
  * End the session. Called when the window closed and beforeunload
  * allowed it, or when the terminal went away.
  */
@@ -371,19 +372,6 @@ function closeTermDOM(termDOM: TermDOM): void {
 }
 
 /**
- * Re-derive everything that comes from the transport. Only before the first
- * frame.
- */
-function rebindTransport(
-	termDOM: TermDOM,
-	transport: TerminalTransport,
-): void {
-	termDOM[kTransport] = transport;
-	termDOM[kScreen].rebind(transport.colorDepth);
-	termDOM[kExchange].rebind(transport);
-}
-
-/**
  * The mouse is captured while the document owns the document scroll. When the
  * wheel has been yielded to the terminal, capture would take the user's
  * scrollback and selection for nothing.
@@ -406,15 +394,6 @@ function syncMouseReporting(
 }
 
 /** Whether anything in the document can observe pointer hover right now. */
-function isHoverObserved(
-	termDOM: TermDOM,
-): boolean {
-	return (
-		DOM.hoverListenerCount(termDOM.document) > 0 ||
-		termDOM[kCascade].hoverRulesExist()
-	);
-}
-
 /**
  * Motion reporting (1003) sends a report per cell the pointer crosses, so
  * it is on only while capture is on and something observes hover.
@@ -422,7 +401,10 @@ function isHoverObserved(
 function syncHoverReporting(
 	termDOM: TermDOM,
 ): void {
-	const wanted = termDOM[kMouseReportingEnabled] && isHoverObserved(termDOM);
+	const wanted =
+		termDOM[kMouseReportingEnabled] &&
+		(DOM.hoverListenerCount(termDOM.document) > 0 ||
+			termDOM[kCascade].hoverRulesExist());
 	if (wanted === termDOM[kHoverReportingEnabled]) {
 		return;
 	}

--- a/src/internal/termdom.ts
+++ b/src/internal/termdom.ts
@@ -722,9 +722,11 @@ async function renderInteractive(
 	afterRender(termDOM);
 }
 
-function staticRenderer(
+function renderStaticHTML(
 	termDOM: TermDOM,
-): TermDOM {
+	html: string,
+	lineEnding: "\n" | "\r\n",
+): string {
 	const cols = termDOM[kTransport].cols;
 	if (
 		termDOM[kStaticSibling] &&
@@ -748,15 +750,8 @@ function staticRenderer(
 			close() {},
 		},
 	});
-	return termDOM[kStaticSibling];
-}
 
-function renderStaticHTML(
-	termDOM: TermDOM,
-	html: string,
-	lineEnding: "\n" | "\r\n",
-): string {
-	const renderer = staticRenderer(termDOM);
+	const renderer = termDOM[kStaticSibling];
 	renderer.document.body.innerHTML = html;
 	return renderStatic(renderer, lineEnding);
 }

--- a/tests/attach.test.ts
+++ b/tests/attach.test.ts
@@ -73,6 +73,18 @@ test("requestFullscreen before attach() rejects and stays silent", async () => {
 	dom.dispose();
 });
 
+test("renderANSI leaves the gap between two backgrounds unpainted", () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const dom = new TermDOM({transport: terminal.transport});
+	const ansi = dom.renderANSI(
+		"<div style=\"display:flex;gap:1ch\">" +
+		"<span style=\"background-color:red\">a</span>" +
+		"<span style=\"background-color:blue\">b</span>" +
+		"</div>",
+	);
+	expect(ansi).toContain("a\x1b[0m \x1b[");
+});
+
 test("renderANSI transforms HTML at the transport's width, touching nothing", () => {
 	const terminal = new MockProcess({cols: 40, rows: 8});
 	const writes = countWrites(terminal);

--- a/tests/exchange-events.test.ts
+++ b/tests/exchange-events.test.ts
@@ -78,6 +78,23 @@ test("a change inside a shadow root reveals the control", async () => {
 	await dom.dispose();
 });
 
+test("a composed event dispatched inside a shadow root retargets to the host after dispatch", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document, window} = dom;
+	document.body.innerHTML = "<div id=host></div>";
+	const host = document.getElementById("host")!;
+	const root = host.attachShadow({mode: "closed"});
+	root.innerHTML = "<input>";
+	const input = root.querySelector("input")!;
+	await nextFrame(dom);
+
+	const event = new window.Event("shadowed", {bubbles: true, composed: true});
+	input.dispatchEvent(event);
+	expect(event.target).toBe(host);
+	await dom.dispose();
+});
+
 test("a page's own beforeunload closes nothing; the window's does", async () => {
 	const terminal = new MockProcess({cols: 40, rows: 8});
 	const watched = closeCountingTransport(terminal);

--- a/tests/exchange-events.test.ts
+++ b/tests/exchange-events.test.ts
@@ -12,6 +12,13 @@ function filler(rows: number): string {
 	return html;
 }
 
+async function until(condition: () => boolean): Promise<void> {
+	const deadline = Date.now() + 5000;
+	while (!condition() && Date.now() < deadline) {
+		await new Promise((r) => setTimeout(r, 10));
+	}
+}
+
 function closeCountingTransport(terminal: MockProcess): {
 	transport: any;
 	closes(): number;
@@ -84,7 +91,7 @@ test("a page's own beforeunload closes nothing; the window's does", async () => 
 	expect(watched.closes()).toBe(0);
 
 	dom.window.close();
-	await new Promise((r) => setTimeout(r, 60));
+	await until(() => watched.closes() === 1);
 	expect(watched.closes()).toBe(1);
 });
 
@@ -104,7 +111,7 @@ test("a page's terminalclose or seal reaches no session listener", async () => {
 	expect(dom.document.body.innerHTML).toBe("<div>open</div>");
 
 	dom.window.close();
-	await new Promise((r) => setTimeout(r, 60));
+	await until(() => watched.closes() === 1);
 	expect(watched.closes()).toBe(1);
 });
 

--- a/tests/exchange-events.test.ts
+++ b/tests/exchange-events.test.ts
@@ -88,6 +88,26 @@ test("a page's own beforeunload closes nothing; the window's does", async () => 
 	expect(watched.closes()).toBe(1);
 });
 
+test("a page's terminalclose or seal reaches no session listener", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	dom.document.body.innerHTML = "<div>open</div>";
+	await nextFrame(dom);
+
+	for (const type of ["terminalclose", "seal", "replace", "anchor"]) {
+		dom.document.dispatchEvent(new dom.window.Event(type));
+	}
+	await new Promise((r) => setTimeout(r, 60));
+	expect(watched.closes()).toBe(0);
+	expect(dom.document.body.innerHTML).toBe("<div>open</div>");
+
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 60));
+	expect(watched.closes()).toBe(1);
+});
+
 test("a document is visible from attach() to dispose()", async () => {
 	const terminal = new MockProcess({cols: 40, rows: 8});
 	const dom = new TermDOM({transport: terminal.transport});

--- a/tests/exchange-events.test.ts
+++ b/tests/exchange-events.test.ts
@@ -1,0 +1,118 @@
+import {expect, test} from "@b9g/libuild/test";
+
+import {createDocumentWindow} from "../src/internal/dom.ts";
+import {TermDOM} from "../src/internal/termdom.ts";
+import {MockProcess, nextFrame} from "./test-utils";
+
+function filler(rows: number): string {
+	let html = "";
+	for (let i = 0; i < rows; i++) {
+		html += `<div>filler ${i}</div>`;
+	}
+	return html;
+}
+
+function closeCountingTransport(terminal: MockProcess): {
+	transport: any;
+	closes(): number;
+} {
+	const base = terminal.transport;
+	let closes = 0;
+	return {
+		transport: {
+			...base,
+			cols: base.cols,
+			rows: base.rows,
+			close: () => {
+				closes++;
+			},
+		},
+		closes: () => closes,
+	};
+}
+
+test("a details opened inside a shadow root scrolls into view", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+	document.body.innerHTML = filler(20) + "<div id=host></div>";
+	const root = document.getElementById("host")!.attachShadow({mode: "open"});
+	root.innerHTML = "<details><summary>more</summary>revealed body</details>";
+	await nextFrame(dom);
+	expect(terminal.getVisibleText()).toContain("filler 0");
+	expect(terminal.getVisibleText()).not.toContain("revealed body");
+
+	root.querySelector("details")!.open = true;
+	await new Promise((r) => setTimeout(r, 20));
+	await nextFrame(dom);
+	expect(terminal.getVisibleText()).toContain("revealed body");
+	await dom.dispose();
+});
+
+test("a change inside a shadow root reveals the control", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document, window} = dom;
+	document.body.innerHTML = filler(20) + "<div id=host></div>";
+	const root = document.getElementById("host")!.attachShadow({mode: "open"});
+	root.innerHTML = "<select><option>alpha</option><option>beta</option></select>";
+	const select = root.querySelector("select")!;
+	await nextFrame(dom);
+	select.focus();
+	await nextFrame(dom);
+	window.scrollTo(0, 0);
+	await nextFrame(dom);
+	expect(terminal.getVisibleText()).toContain("filler 0");
+	expect(terminal.getVisibleText()).not.toContain("alpha");
+
+	select.dispatchEvent(new window.Event("change", {bubbles: true}));
+	await nextFrame(dom);
+	expect(terminal.getVisibleText()).toContain("alpha");
+	await dom.dispose();
+});
+
+test("a page's own beforeunload closes nothing; the window's does", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const watched = closeCountingTransport(terminal);
+	const dom = new TermDOM({transport: watched.transport});
+	dom.attach();
+	dom.document.body.innerHTML = "<div>open</div>";
+	await nextFrame(dom);
+
+	dom.window.dispatchEvent(new dom.window.Event("beforeunload"));
+	await new Promise((r) => setTimeout(r, 60));
+	expect(watched.closes()).toBe(0);
+
+	dom.window.close();
+	await new Promise((r) => setTimeout(r, 60));
+	expect(watched.closes()).toBe(1);
+});
+
+test("a document is visible from attach() to dispose()", async () => {
+	const terminal = new MockProcess({cols: 40, rows: 8});
+	const dom = new TermDOM({transport: terminal.transport});
+	const {document} = dom;
+	const states: string[] = [];
+	document.addEventListener("visibilitychange", () => {
+		states.push(document.visibilityState);
+	});
+	expect(document.hidden).toBe(true);
+	expect(document.visibilityState).toBe("hidden");
+
+	dom.attach();
+	expect(document.hidden).toBe(false);
+	expect(document.visibilityState).toBe("visible");
+	await nextFrame(dom);
+
+	await dom.dispose();
+	expect(document.hidden).toBe(true);
+	expect(states).toEqual(["visible", "hidden"]);
+});
+
+test("a headless document has no terminal to hide it", () => {
+	const window = createDocumentWindow(
+		"<!DOCTYPE html><html><head></head><body></body></html>",
+	);
+	expect(window.document.hidden).toBe(false);
+	expect(window.document.visibilityState).toBe("visible");
+});

--- a/tests/fixtures/ansi-output.ts
+++ b/tests/fixtures/ansi-output.ts
@@ -40,5 +40,5 @@ export const recordedOutput: Record<string, string> = {
 	"clipRect and viewport offset":
 		"\u001b[?2026h\u001b[3;1H\r\n\r\n\r\u001b[Kvisible row\r\n\u001b[2C\r\u001b[K\u001b[2C────────\r\n\u001b[2C\r\u001b[K\u001b[2Cso clipp\r\n\r\n\r\u001b[Kunclipped again\u001b[8;1H\u001b[?2026l",
 	"static render to a pipe":
-		"plain\u001b[0m\n\u001b[38;2;255;0;0;1mstyled\u001b[0m\n日本語 wide\u001b[0m\n\u001b[38;2;0;255;0m┌──────┐  \u001b[0m👍 tail\u001b[0m\n\u001b[38;2;0;255;0m└──────┘\u001b[0m\n|crlf\u001b[0m\r\nlines\u001b[0m\r\n",
+		"plain\u001b[0m\n\u001b[38;2;255;0;0;1mstyled\u001b[0m\n日本語 wide\u001b[0m\n\u001b[38;2;0;255;0m┌──────┐\u001b[0m  👍 tail\u001b[0m\n\u001b[38;2;0;255;0m└──────┘\u001b[0m\n|crlf\u001b[0m\r\nlines\u001b[0m\r\n",
 };

--- a/tests/width-measurement.test.ts
+++ b/tests/width-measurement.test.ts
@@ -132,7 +132,8 @@ function emit(
 	cells: Array<[number, string]>,
 	measurer: Exchange,
 ): string {
-	const screen = new Screen(rows, cols, "rgb", measurer);
+	const screen = new Screen(rows, cols, "rgb");
+	screen.measurer = measurer;
 	const context = screen.beginFrame({offset: 0});
 	for (const [index, cluster] of cells) {
 		context.drawText(cluster, index % cols, Math.floor(index / cols));

--- a/website/src/models/playground-examples.ts
+++ b/website/src/models/playground-examples.ts
@@ -32,6 +32,7 @@ const RUNNABLE = [
 	"fullscreen",
 	"fuzzy-finder",
 	"hacker-news",
+	"hover",
 	"lists",
 	"markdown",
 	"password",


### PR DESCRIPTION
`Exchange` extends `EventTarget`. After an event's propagation path completes, `dispatch` passes the event to the exchange's listeners regardless of `bubbles`, `composed`, or `stopPropagation()`, with the original target and related target set. The clearing of those the spec requires runs after. Default actions are registered on the exchange and check `defaultPrevented`, which is final at that point.

## Moved onto the exchange

- The caret reveal on `input`, `select`, `change`, and `selectionchange`, and the details reveal on `toggle`. Previously capture listeners on the document.
- Closing the session after an uncanceled, trusted `beforeunload`. `window.close()` only dispatches now.
- Sealing the document on `document.close()`, via an internal `seal` event.
- Terminal events dispatched by the exchange: `terminalresize`, `replace`, `anchor`, `reorder`, `probes`, `widths`, `terminalclose`. The `terminalresize` listener fills in the frame geometry on the event. `exchange.ts` and `input.ts` no longer import from `termdom.ts`; `termdom.ts` exports `TermDOM`, `render`, and `TermDOMOptions`.

## Visibility

`document.visibilityState` is `"visible"` between `attach()` and `dispose()` and `"hidden"` otherwise, with `visibilitychange` on each change. A document with no engine is always `"visible"`. The fullscreen and mouse-reporting checks use this instead of the lifecycle field.

## Bug fixes

A details inside a shadow root did not scroll into view when opened: `toggle` is not composed, so the document's capture listener never received it. A change on a control inside a shadow root did not reveal it: `document.activeElement` retargets to the host, so the equality check failed. Both have tests that fail on main.

## Review notes

- `resize` and `close` are prefixed with `terminal` because the document's `close` and `resize` events are passed to the exchange too. Without the prefix, closing a dialog closed the session.
- The spec clears `event.target` after dispatch for a shadow-tree target, so the listeners run before that clearing.
- `EventTarget` in dom.ts is now a value export so `Exchange` can extend it. `index.ts` does not re-export it.

Tests: 1,615 pass on Node and Bun, 36 of 36 examples verify, the drift ledger is exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Bw3yEu4cfkuDkaZ3RSy4D